### PR TITLE
Remove special chars in CodeInput

### DIFF
--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -10,7 +10,14 @@ export interface CodeInputProps {
 }
 
 export const CodeInput = ({value, onChange, accessibilityLabel}: CodeInputProps) => {
-  const onChangeTrimmed = useCallback(text => onChange(text.trim()), [onChange]);
+  const onChangeTrimmed = useCallback(
+    text => {
+      // Remove any character that is not alphanumeric (or a space)
+      const modifiedText = text.replace(/[^a-zA-Z0-9\s]*/g, '');
+      onChange(modifiedText.trim());
+    },
+    [onChange],
+  );
   const [isFocus, setIsFocus] = useState(false);
   const onFocus = useCallback(() => setIsFocus(true), []);
   const onBlur = useCallback(() => setIsFocus(false), []);


### PR DESCRIPTION
Fixes #839 
Replaces any special characters as user types/copy and pastes text into the CodeInput

In TalkBack on Android, it will announce the deletion as the user types a special char (e.g. if they type a dollar sign it will say 'dollar sign deleted')