### PR TITLE
Change react-native package for better secure storage.

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,8 +3,6 @@ include ':react-native-localize'
 project(':react-native-localize').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-localize/android')
 include ':react-native-system-setting'
 project(':react-native-system-setting').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-system-setting/android')
-include ':react-native-sensitive-info'
-project(':react-native-sensitive-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sensitive-info/android')
 include ':react-native-config'
 project(':react-native-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config/android')
 include ':react-native-splash-screen'

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -89,8 +89,6 @@ target 'CovidShield' do
 
   pod 'react-native-config', :path => '../node_modules/react-native-config'
 
-  pod 'react-native-sensitive-info', :path => '../node_modules/react-native-sensitive-info'
-
   pod 'RCTSystemSetting', :path => '../node_modules/react-native-system-setting'
 
   pod 'RNLocalize', :path => '../node_modules/react-native-localize'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -326,6 +326,8 @@ PODS:
     - React
   - RNScreens (2.7.0):
     - React
+  - RNSecureKeyStore (1.0.0):
+    - React
   - RNSVG (12.1.0):
     - React
   - RNZipArchive (5.0.2):
@@ -404,6 +406,7 @@ DEPENDENCIES:
   - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNSecureKeyStore (from `../node_modules/react-native-secure-key-store/ios`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNZipArchive (from `../node_modules/react-native-zip-archive`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -507,6 +510,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNSecureKeyStore:
+    :path: "../node_modules/react-native-secure-key-store/ios"
   RNSVG:
     :path: "../node_modules/react-native-svg"
   RNZipArchive:
@@ -567,6 +572,7 @@ SPEC CHECKSUMS:
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8
   RNReanimated: 955cf4068714003d2f1a6e2bae3fb1118f359aff
   RNScreens: cf198f915f8a2bf163de94ca9f5bfc8d326c3706
+  RNSecureKeyStore: f1ad870e53806453039f650720d2845c678d89c8
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   RNZipArchive: ab51bc004a31657f34010254a9182014c6a81217
   SSZipArchive: fa16b8cc4cdeceb698e5e5d9f67e9558532fbf23

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -245,8 +245,6 @@ PODS:
     - React
   - react-native-safe-area-context (3.0.2):
     - React
-  - react-native-sensitive-info (5.5.5):
-    - React
   - react-native-splash-screen (3.2.0):
     - React
   - React-RCTActionSheet (0.62.2):
@@ -384,7 +382,6 @@ DEPENDENCIES:
   - react-native-config (from `../node_modules/react-native-config`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
-  - react-native-sensitive-info (from `../node_modules/react-native-sensitive-info`)
   - react-native-splash-screen (from `../node_modules/react-native-splash-screen`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -468,8 +465,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
-  react-native-sensitive-info:
-    :path: "../node_modules/react-native-sensitive-info"
   react-native-splash-screen:
     :path: "../node_modules/react-native-splash-screen"
   React-RCTActionSheet:
@@ -551,7 +546,6 @@ SPEC CHECKSUMS:
   react-native-config: 313a1306066289211579b9655eb81d9a565462d0
   react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
   react-native-safe-area-context: b11a34881faac509cad5578726c98161ad4d275c
-  react-native-sensitive-info: 4629b223484a08225c3eb088ff3f91b03097b5e5
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
@@ -579,6 +573,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 0c65bc53d3b3fc855c000ffe8e723d581980164f
+PODFILE CHECKSUM: d43b08bc42409fd8009cd422b62cfbab0aeb820d
 
 COCOAPODS: 1.7.5

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "react-native-safe-area-context": "^3.0.2",
     "react-native-screens": "^2.7.0",
     "react-native-secure-key-store": "^2.0.7",
-    "react-native-sensitive-info": "^5.5.5",
     "react-native-snap-carousel": "^3.9.0",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-native-reanimated": "^1.8.0",
     "react-native-safe-area-context": "^3.0.2",
     "react-native-screens": "^2.7.0",
+    "react-native-secure-key-store": "^2.0.7",
     "react-native-sensitive-info": "^5.5.5",
     "react-native-snap-carousel": "^3.9.0",
     "react-native-splash-screen": "^3.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 import 'react-native-gesture-handler';
 
 import AsyncStorage from '@react-native-community/async-storage';
-import SecureStorage from 'react-native-sensitive-info';
+import RNSecureKeyStore from 'react-native-secure-key-store';
 import ExposureNotification from 'bridge/ExposureNotification';
 import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL} from 'env';
 import {AppRegistry, YellowBox} from 'react-native';
@@ -28,7 +28,7 @@ BackgroundScheduler.registerAndroidHeadlessPeriodicTask(async () => {
     backendService,
     i18n,
     AsyncStorage,
-    SecureStorage,
+    RNSecureKeyStore,
     ExposureNotification,
   );
   await exposureNotificationService.updateExposureStatusInBackground();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -23,8 +23,8 @@ const storage: any = {
   setItem: jest.fn().mockResolvedValueOnce(undefined),
 };
 const secureStorage: any = {
-  getItem: jest.fn().mockResolvedValue(null),
-  setItem: jest.fn().mockResolvedValueOnce(undefined),
+  get: jest.fn().mockResolvedValue(null),
+  set: jest.fn().mockResolvedValueOnce(undefined),
 };
 const bridge: any = {
   detectExposure: jest.fn().mockResolvedValue({matchedKeyCount: 0}),
@@ -266,7 +266,7 @@ describe('ExposureNotificationService', () => {
     );
 
     currentDateString = '2020-05-20T04:10:00+0000';
-    when(secureStorage.getItem)
+    when(secureStorage.get)
       .calledWith('submissionAuthKeys')
       .mockResolvedValueOnce('{}');
     await service.fetchAndSubmitKeys();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -178,7 +178,6 @@ export class ExposureNotificationService {
       cycleStartsAt: cycleStartsAt.getTime(),
       cycleEndsAt: addDays(cycleStartsAt, EXPOSURE_NOTIFICATION_CYCLE).getTime(),
     });
-    console.log('hey');
   }
 
   async fetchAndSubmitKeys(): Promise<void> {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -16,13 +16,7 @@ import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 import {ExposureConfigurationValidator, ExposureConfigurationValidationError} from './ExposureConfigurationValidator';
 
 const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys';
-const EXPOSURE_CONFIGURATION = 'exposure-configuration';
-
-const SECURE_OPTIONS = {
-  sharedPreferencesName: 'covidShieldSharedPreferences',
-  keychainService: 'covidShieldKeychain',
-};
-const SECURE_OPTIONS_FOR_CONFIGURATION = {...SECURE_OPTIONS, kSecAttrAccessible: 'kSecAttrAccessibleAlways'};
+const EXPOSURE_CONFIGURATION = 'exposureConfiguration';
 
 export const EXPOSURE_STATUS = 'exposureStatus';
 
@@ -70,13 +64,12 @@ export interface PersistencyProvider {
 }
 
 export interface SecurePersistencyProvider {
-  setItem(key: string, value: string, options: SecureStorageOptions): Promise<null>;
-  getItem(key: string, options: SecureStorageOptions): Promise<string | null>;
+  set(key: string, value: string, options: SecureStorageOptions): Promise<null>;
+  get(key: string): Promise<string | null>;
 }
 
 export interface SecureStorageOptions {
-  keychainService?: string;
-  sharedPreferencesName?: string;
+  accessible?: string;
 }
 
 export class ExposureNotificationService {
@@ -172,7 +165,12 @@ export class ExposureNotificationService {
   async startKeysSubmission(oneTimeCode: string): Promise<void> {
     const keys = await this.backendInterface.claimOneTimeCode(oneTimeCode);
     const serialized = JSON.stringify(keys);
-    await this.secureStorage.setItem(SUBMISSION_AUTH_KEYS, serialized, SECURE_OPTIONS);
+    console.log(serialized);
+    try {
+      await this.secureStorage.set(SUBMISSION_AUTH_KEYS, serialized, {});
+    } catch (error) {
+      console.error(error);
+    }
     const cycleStartsAt = getCurrentDate();
     this.exposureStatus.append({
       type: 'diagnosed',
@@ -180,10 +178,11 @@ export class ExposureNotificationService {
       cycleStartsAt: cycleStartsAt.getTime(),
       cycleEndsAt: addDays(cycleStartsAt, EXPOSURE_NOTIFICATION_CYCLE).getTime(),
     });
+    console.log('hey');
   }
 
   async fetchAndSubmitKeys(): Promise<void> {
-    const submissionKeysStr = await this.secureStorage.getItem(SUBMISSION_AUTH_KEYS, SECURE_OPTIONS);
+    const submissionKeysStr = await this.secureStorage.get(SUBMISSION_AUTH_KEYS);
     if (!submissionKeysStr) {
       throw new Error('No Upload keys found, did you forget to claim one-time code?');
     }
@@ -207,10 +206,7 @@ export class ExposureNotificationService {
   private async getAlternateExposureConfiguration(): Promise<ExposureConfiguration> {
     try {
       captureMessage('Getting exposure configuration from secure storage.');
-      const exposureConfigurationStr = await this.secureStorage.getItem(
-        EXPOSURE_CONFIGURATION,
-        SECURE_OPTIONS_FOR_CONFIGURATION,
-      );
+      const exposureConfigurationStr = await this.storage.getItem(EXPOSURE_CONFIGURATION);
       if (exposureConfigurationStr) {
         return JSON.parse(exposureConfigurationStr);
       } else {
@@ -290,7 +286,7 @@ export class ExposureNotificationService {
       );
       captureMessage('Using downloaded exposureConfiguration.');
       const serialized = JSON.stringify(exposureConfiguration);
-      await this.secureStorage.setItem(EXPOSURE_CONFIGURATION, serialized, SECURE_OPTIONS_FOR_CONFIGURATION);
+      await this.storage.setItem(EXPOSURE_CONFIGURATION, serialized);
       captureMessage('Saving exposure configuration to secure storage.');
     } catch (error) {
       if (error instanceof SyntaxError) {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 import {useI18nRef} from 'locale';
 import ExposureNotification, {Status as SystemStatus} from 'bridge/ExposureNotification';
 import {AppState, AppStateStatus} from 'react-native';
-import SecureStorage from 'react-native-sensitive-info';
+import RNSecureKeyStore from 'react-native-secure-key-store';
 import SystemSetting from 'react-native-system-setting';
 
 import {BackendInterface} from '../BackendService';
@@ -42,7 +42,7 @@ export const ExposureNotificationServiceProvider = ({
         backendInterface,
         i18n,
         storage || AsyncStorage,
-        secureStorage || SecureStorage,
+        secureStorage || RNSecureKeyStore,
         exposureNotification || ExposureNotification,
       ),
     [backendInterface, exposureNotification, i18n, secureStorage, storage],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7246,11 +7246,6 @@ react-native-secure-key-store@^2.0.7:
   resolved "https://registry.yarnpkg.com/react-native-secure-key-store/-/react-native-secure-key-store-2.0.7.tgz#70b24afae0f75fd90e46aabd8fc9ce6484727850"
   integrity sha512-1hIuFcgWPVqS1Q3843ysHfN5cx/YFE0U1ab6p5Adfch0Yikyglcs3FZWHXxo7qsHvFai71Z7Wyv3SuWCuBG6AQ==
 
-react-native-sensitive-info@^5.5.5:
-  version "5.5.5"
-  resolved "https://registry.yarnpkg.com/react-native-sensitive-info/-/react-native-sensitive-info-5.5.5.tgz#0559aaff6bd59b6a14d92035c032b46bd007b55f"
-  integrity sha512-ShRqvHTZnY4VYNEF+5pCBUu/2wslojY445FdA9nuH9nkVqOQRXxIGYqTRYXJ42mDLTt+KnW5hcvuAjpVVokafQ==
-
 react-native-snap-carousel@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/react-native-snap-carousel/-/react-native-snap-carousel-3.9.0.tgz#017793ca3f5e901ccd5a3117d79bb18ec08928a3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7241,6 +7241,11 @@ react-native-screens@^2.7.0:
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.7.0.tgz#2d3cf3c39a665e9ca1c774264fccdb90e7944047"
   integrity sha512-n/23IBOkrTKCfuUd6tFeRkn3lB2QZ3cmvoubRscR0JU/Zl4/ZyKmwnFmUv1/Fr+2GH/H8UTX59kEKDYYg3dMgA==
 
+react-native-secure-key-store@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-native-secure-key-store/-/react-native-secure-key-store-2.0.7.tgz#70b24afae0f75fd90e46aabd8fc9ce6484727850"
+  integrity sha512-1hIuFcgWPVqS1Q3843ysHfN5cx/YFE0U1ab6p5Adfch0Yikyglcs3FZWHXxo7qsHvFai71Z7Wyv3SuWCuBG6AQ==
+
 react-native-sensitive-info@^5.5.5:
   version "5.5.5"
   resolved "https://registry.yarnpkg.com/react-native-sensitive-info/-/react-native-sensitive-info-5.5.5.tgz#0559aaff6bd59b6a14d92035c032b46bd007b55f"


### PR DESCRIPTION
The previous package for storing secure data `react-native-sensitive-info` did not store the data for Android in the keychain.

Replacing that package with `react-native-secure-key-store` allows for both iOS and Android data to be stored in the keychain.

Along with changing the package, I changed the way the **Exposure Configuration** is being stored. It is no longer being stored in the secure storage, but rather just in the AsyncStorage. The exposure configuration is not sensitive data, as it's the same file downloaded from the server for every person.