### PR TITLE
Adds a KeyboardAvoidingView to automatically adjust padding/height when keyboard covers content

### DIFF
--- a/src/screens/datasharing/DataSharing.tsx
+++ b/src/screens/datasharing/DataSharing.tsx
@@ -1,8 +1,8 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, useEffect} from 'react';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Toolbar} from 'components';
-import {StyleSheet, Alert, ScrollView} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {StyleSheet, Alert, ScrollView, Keyboard} from 'react-native';
+import {SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 import {useI18n} from 'locale';
 import {useExposureStatus} from 'services/ExposureNotificationService';
 
@@ -22,6 +22,20 @@ export const DataSharingScreen = () => {
   // if keySubmissionStatus is None we need the 1-time code, otherwise we should go right to consent
   const [isVerified, setIsVerified] = useState(exposureStatus.type === 'diagnosed');
   const [isConfirmedStep1, setIsConfirmedStep1] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const keyboardWillShowSubcription = Keyboard.addListener('keyboardWillShow', keyboardWillUpdate);
+    const keyboardWillHideSubscription = Keyboard.addListener('keyboardWillHide', keyboardWillUpdate);
+    const keyboardWillChangeFrameSubscription = Keyboard.addListener('keyboardWillChangeFrame', keyboardWillUpdate);
+
+    return () => {
+      keyboardWillShowSubcription.remove();
+      keyboardWillHideSubscription.remove();
+      keyboardWillChangeFrameSubscription.remove();
+    };
+  });
+
   const onErrorForm = () => {
     Alert.alert(i18n.translate('DataUpload.FormView.ErrorTitle'), i18n.translate('DataUpload.FormView.ErrorBody'), [
       {text: i18n.translate('DataUpload.FormView.ErrorAction')},
@@ -35,6 +49,10 @@ export const DataSharingScreen = () => {
       i18n.translate('DataUpload.ConsentView.ErrorBody'),
       [{text: i18n.translate('DataUpload.FormView.ErrorAction')}],
     );
+  };
+
+  const keyboardWillUpdate = (event) => {
+    setKeyboardHeight(event.endCoordinates.height);
   };
 
   const handleVerify = useCallback(async () => {
@@ -55,6 +73,16 @@ export const DataSharingScreen = () => {
     }
   };
 
+  // We will calculate the contentInset for the scroll view taking into account
+  // the safeAreaInsets provided to us. Scroll views automatically take into account
+  // (see: `automaticallyAdjustContentInsets`) the "safe" areas so we have to be
+  // sure to match their values.
+  const safeAreaInsets = useSafeAreaInsets();
+  const scrollInsets = keyboardHeight > 0 ? {
+    top: -safeAreaInsets.top,
+    bottom: keyboardHeight - safeAreaInsets.top - safeAreaInsets.bottom * 2
+  } : undefined;
+
   return (
     <Box backgroundColor="overlayBackground" flex={1}>
       <SafeAreaView style={styles.flex}>
@@ -65,7 +93,7 @@ export const DataSharingScreen = () => {
           navLabel={i18n.translate('DataUpload.Cancel')}
           onIconClicked={close}
         />
-        <ScrollView style={styles.flex} keyboardShouldPersistTaps="handled">
+        <ScrollView style={styles.flex} keyboardShouldPersistTaps="handled" contentInset={scrollInsets}>
           {getContent()}
         </ScrollView>
       </SafeAreaView>

--- a/src/screens/datasharing/DataSharing.tsx
+++ b/src/screens/datasharing/DataSharing.tsx
@@ -51,7 +51,7 @@ export const DataSharingScreen = () => {
     );
   };
 
-  const keyboardWillUpdate = (event) => {
+  const keyboardWillUpdate = (event: any) => {
     setKeyboardHeight(event.endCoordinates.height);
   };
 
@@ -78,10 +78,13 @@ export const DataSharingScreen = () => {
   // (see: `automaticallyAdjustContentInsets`) the "safe" areas so we have to be
   // sure to match their values.
   const safeAreaInsets = useSafeAreaInsets();
-  const scrollInsets = keyboardHeight > 0 ? {
-    top: -safeAreaInsets.top,
-    bottom: keyboardHeight - safeAreaInsets.top - safeAreaInsets.bottom * 2
-  } : undefined;
+  const scrollInsets =
+    keyboardHeight > 0
+      ? {
+          top: -safeAreaInsets.top,
+          bottom: keyboardHeight - safeAreaInsets.top - safeAreaInsets.bottom * 2,
+        }
+      : undefined;
 
   return (
     <Box backgroundColor="overlayBackground" flex={1}>


### PR DESCRIPTION
# What
Enables the user to scroll when the system keyboard covers content on the screen. In this app, it only manifests when a user is entering codes.

# Why? How?
When entering a one-time key in landscape mode, the submit button was obscurred. The user can still press "done" on the native keyboard and it will progress, however the rest of the content is obscurred. This is non-standard behaviour.

This is implemented by using keyboard events, rather than using the `KeyboardAvoidingView`. The react-native KeyboardAvoidingView will create a new view, place all of its content within it, and put a massive `paddingBottom` on it to ensure that the content fits above the keyboard. This uses system provided properties to help manage the keyboard.

This is _fine_ but this means that the content that is scrolled beneath the keyboard is not visible. Additionally, the `KeyboardAvoidingView` causes rendering issues when used within this modal setup.

**Before (static image)**
<img width="679" alt="Screen Shot 2020-07-22 at 12 50 07 PM" src="https://user-images.githubusercontent.com/128299/88204832-e0716d00-cc19-11ea-8f33-07f21dacc3aa.png">

** (gif)**
![keyboard](https://user-images.githubusercontent.com/128299/88204968-1878b000-cc1a-11ea-96af-7daadb753e6f.gif)

# Testing
This was tested on device (iOS, iOS 13.5) and in a simulator.
Tested on an Android emulator (Pixel, Android 10+)

Note:
- It's important to try this in both portrait, landscape, and rotating back and forth between the two modes. The original approach using the `KeyboardAvoidingView` caused render errors (screen would go white on device)

