### PR TITLE
Add `noStore` cacheControl to the diagnosisKeysFile download.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
@@ -38,7 +39,9 @@ class CovidShieldModule(context: ReactApplicationContext) : ReactContextBaseJava
     @ReactMethod
     fun downloadDiagnosisKeysFile(url: String, promise: Promise) {
         promise.launch(this) {
-            val request = Request.Builder().url(url).build()
+            val request = Request.Builder()
+                    .cacheControl(CacheControl.Builder().noStore().build())
+                    .url(url).build()
             okHttpClient.newCall(request).execute().use { response ->
                 if (response.code() != 200) {
                     throw IOException()

--- a/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/CovidShieldModule.kt
@@ -40,8 +40,8 @@ class CovidShieldModule(context: ReactApplicationContext) : ReactContextBaseJava
     fun downloadDiagnosisKeysFile(url: String, promise: Promise) {
         promise.launch(this) {
             val request = Request.Builder()
-                    .cacheControl(CacheControl.Builder().noStore().build())
-                    .url(url).build()
+                .cacheControl(CacheControl.Builder().noStore().build())
+                .url(url).build()
             okHttpClient.newCall(request).execute().use { response ->
                 if (response.code() != 200) {
                     throw IOException()


### PR DESCRIPTION
For added level of security, prevent requests for the diagnosisKeysFile from being cached.