### PR TITLE
Force NSURLSession to not cache anything.

### DIFF
--- a/ios/CovidShield/CovidShield.m
+++ b/ios/CovidShield/CovidShield.m
@@ -27,7 +27,7 @@ RCT_REMAP_METHOD(getRandomBytes, randomBytesWithSize:(NSUInteger)size withResolv
 
 RCT_REMAP_METHOD(downloadDiagnosisKeysFile, downloadDiagnosisKeysFileWithURL:(NSString *)url WithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
   NSURL *taskURL = [RCTConvert NSURL:url];
   [[session downloadTaskWithURL:taskURL
               completionHandler:^(NSURL * _Nullable location, NSURLResponse * _Nullable response, NSError * _Nullable error) {


### PR DESCRIPTION
For added level of security, prevent requests for the diagnosisKeysFile from being cached.