### PR TITLE
Handle error code 10 on Android

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -22,6 +22,7 @@ import app.covidshield.utils.CovidShieldException.ApiNotEnabledException
 import app.covidshield.utils.CovidShieldException.InvalidActivityException
 import app.covidshield.utils.CovidShieldException.NoResolutionRequiredException
 import app.covidshield.utils.CovidShieldException.PermissionDeniedException
+import app.covidshield.utils.CovidShieldException.PlayServicesNotAvailableException
 import app.covidshield.utils.CovidShieldException.SendIntentException
 import app.covidshield.utils.CovidShieldException.SummaryTokenNotFoundException
 import app.covidshield.utils.CovidShieldException.UnknownException
@@ -72,7 +73,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     fun start(promise: Promise) {
         promise.launch(this) {
             if (!isPlayServicesAvailable()) {
-                throw Exception("PLAY_SERVICES_NOT_AVAILABLE")
+                throw PlayServicesNotAvailableException()
             }
             val status = getStatusInternal()
             if (status != Status.ACTIVE) {
@@ -87,7 +88,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     fun stop(promise: Promise) {
         promise.launch(this) {
             if (!isPlayServicesAvailable()) {
-                throw Exception("PLAY_SERVICES_NOT_AVAILABLE")
+                throw PlayServicesNotAvailableException()
             }
             stopInternal()
         }

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -110,7 +110,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun detectExposure(configuration: ReadableMap, diagnosisKeysURLs: ReadableArray, promise: Promise) {
         promise.launch(this) {
-            if (getStatusInternal() != Status.ACTIVE) {
+            if (getStatusInternal() == Status.DISABLED) {
                 throw ApiNotEnabledException()
             }
 
@@ -143,7 +143,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getPendingExposureSummary(promise: Promise) {
         promise.launch(this) {
-            if (getStatusInternal() != Status.ACTIVE) {
+            if (getStatusInternal() == Status.DISABLED) {
                 throw ApiNotEnabledException()
             }
 
@@ -174,7 +174,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getTemporaryExposureKeyHistory(promise: Promise) {
         promise.launch(this) {
-            if (getStatusInternal() != Status.ACTIVE) {
+            if (getStatusInternal() == Status.DISABLED) {
                 throw ApiNotEnabledException()
             }
 
@@ -186,7 +186,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getExposureInformation(summary: ReadableMap, promise: Promise) {
         promise.launch(this) {
-            if (getStatusInternal() != Status.ACTIVE) {
+            if (getStatusInternal() == Status.DISABLED) {
                 throw ApiNotEnabledException()
             }
 

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -18,12 +18,12 @@ import app.covidshield.models.Configuration
 import app.covidshield.models.ExposureKey
 import app.covidshield.receiver.ExposureNotificationBroadcastReceiver
 import app.covidshield.utils.ActivityResultHelper
-import app.covidshield.utils.CovidShieldException
 import app.covidshield.utils.CovidShieldException.ApiNotEnabledException
 import app.covidshield.utils.CovidShieldException.InvalidActivityException
 import app.covidshield.utils.CovidShieldException.NoResolutionRequiredException
 import app.covidshield.utils.CovidShieldException.PermissionDeniedException
 import app.covidshield.utils.CovidShieldException.SendIntentException
+import app.covidshield.utils.CovidShieldException.SummaryTokenNotFoundException
 import app.covidshield.utils.CovidShieldException.UnknownException
 import app.covidshield.utils.PendingTokenManager
 import com.facebook.react.bridge.Promise
@@ -191,7 +191,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
             }
 
             val token = summary.getString(SUMMARY_HIDDEN_KEY)
-                ?: throw CovidShieldException.SummaryTokenNotFoundException()
+                ?: throw SummaryTokenNotFoundException()
             val exposureInformationList = exposureNotificationClient.getExposureInformation(token).await()
             val informationList = exposureInformationList.map { it.toInformation() }.toWritableArray()
             promise.resolve(informationList)

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -18,6 +18,13 @@ import app.covidshield.models.Configuration
 import app.covidshield.models.ExposureKey
 import app.covidshield.receiver.ExposureNotificationBroadcastReceiver
 import app.covidshield.utils.ActivityResultHelper
+import app.covidshield.utils.CovidShieldException
+import app.covidshield.utils.CovidShieldException.ApiNotEnabledException
+import app.covidshield.utils.CovidShieldException.InvalidActivityException
+import app.covidshield.utils.CovidShieldException.NoResolutionRequiredException
+import app.covidshield.utils.CovidShieldException.PermissionDeniedException
+import app.covidshield.utils.CovidShieldException.SendIntentException
+import app.covidshield.utils.CovidShieldException.UnknownException
 import app.covidshield.utils.PendingTokenManager
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -103,6 +110,10 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun detectExposure(configuration: ReadableMap, diagnosisKeysURLs: ReadableArray, promise: Promise) {
         promise.launch(this) {
+            if (getStatusInternal() != Status.ACTIVE) {
+                throw ApiNotEnabledException()
+            }
+
             val exposureConfiguration = configuration.parse(Configuration::class.java).toExposureConfiguration()
             val files = diagnosisKeysURLs.parse(String::class.java).map { File(it) }
             val token = "${UUID.randomUUID()}-${Date().time}"
@@ -132,6 +143,10 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getPendingExposureSummary(promise: Promise) {
         promise.launch(this) {
+            if (getStatusInternal() != Status.ACTIVE) {
+                throw ApiNotEnabledException()
+            }
+
             val tokens = PendingTokenManager.instance.retrieve()
             PendingTokenManager.instance.clear()
 
@@ -159,6 +174,10 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getTemporaryExposureKeyHistory(promise: Promise) {
         promise.launch(this) {
+            if (getStatusInternal() != Status.ACTIVE) {
+                throw ApiNotEnabledException()
+            }
+
             val exposureKeys = getTemporaryExposureKeyHistoryInternal()
             promise.resolve(exposureKeys.toWritableArray())
         }
@@ -167,8 +186,12 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun getExposureInformation(summary: ReadableMap, promise: Promise) {
         promise.launch(this) {
+            if (getStatusInternal() != Status.ACTIVE) {
+                throw ApiNotEnabledException()
+            }
+
             val token = summary.getString(SUMMARY_HIDDEN_KEY)
-                ?: throw IllegalArgumentException("Invalid summary token")
+                ?: throw CovidShieldException.SummaryTokenNotFoundException()
             val exposureInformationList = exposureNotificationClient.getExposureInformation(token).await()
             val informationList = exposureInformationList.map { it.toInformation() }.toWritableArray()
             promise.resolve(informationList)
@@ -176,13 +199,13 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     }
 
     private suspend fun startInternal() {
-        val activity = currentActivity ?: throw IllegalStateException("Invalid activity")
+        val activity = currentActivity ?: throw InvalidActivityException()
         startResolutionCompleter?.await()
         try {
             exposureNotificationClient.start().await()
         } catch (exception: Exception) {
             if (exception !is ApiException) {
-                throw Exception("UNKNOWN_ERROR", exception)
+                throw UnknownException(exception)
             }
             if (exception.statusCode == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
                 startResolutionCompleter = CompletableDeferred()
@@ -195,15 +218,15 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
                     startResolutionCompleter = null
                     startInternal()
                 } catch (exception: IntentSender.SendIntentException) {
-                    startResolutionCompleter?.completeExceptionally(Exception("SEND_INTENT_EXCEPTION", exception))
+                    startResolutionCompleter?.completeExceptionally(SendIntentException(exception))
                 } catch (exception: Exception) {
-                    startResolutionCompleter?.completeExceptionally(Exception("PERMISSION_DENIED", exception))
+                    startResolutionCompleter?.completeExceptionally(PermissionDeniedException(exception))
                 } finally {
                     startResolutionCompleter = null
                 }
             } else {
                 log(exception.message)
-                throw Exception("NO_RESOLUTION_REQUIRED", exception)
+                throw NoResolutionRequiredException(exception)
             }
         }
     }
@@ -216,7 +239,7 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
             return tekKeys.map { it.toExposureKey() }
         } catch (exception: Exception) {
             if (exception !is ApiException) {
-                throw Exception("UNKNOWN_ERROR", exception)
+                throw UnknownException(exception)
             }
             if (exception.statusCode == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
                 getTekResolutionCompleter = CompletableDeferred()
@@ -229,17 +252,17 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
                     getTekResolutionCompleter = null
                     return getTemporaryExposureKeyHistoryInternal()
                 } catch (exception: IntentSender.SendIntentException) {
-                    getTekResolutionCompleter?.completeExceptionally(Exception("SEND_INTENT_EXCEPTION", exception))
+                    getTekResolutionCompleter?.completeExceptionally(SendIntentException(exception))
                 } catch (exception: Exception) {
-                    getTekResolutionCompleter?.completeExceptionally(Exception("PERMISSION_DENIED", exception))
+                    getTekResolutionCompleter?.completeExceptionally(PermissionDeniedException(exception))
                 } finally {
                     getTekResolutionCompleter = null
                 }
             } else {
-                throw Exception("NO_RESOLUTION_REQUIRED", exception)
+                throw NoResolutionRequiredException(exception)
             }
         }
-        throw Exception("UNKNOWN_ERROR")
+        throw UnknownException()
     }
 
     private suspend fun stopInternal() {

--- a/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
+++ b/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
@@ -1,0 +1,18 @@
+package app.covidshield.utils
+
+object CovidShieldException {
+
+    class UnknownException(cause: Throwable? = null) : Exception("UNKNOWN", cause)
+
+    class ApiNotEnabledException : Exception("API_NOT_ENABLED")
+
+    class SummaryTokenNotFoundException : IllegalArgumentException("SUMMARY_TOKEN_NOT_FOUND")
+
+    class InvalidActivityException : IllegalArgumentException("INVALID_ACTIVITY")
+
+    class SendIntentException(cause: Throwable) : Exception("SEND_INTENT_EXCEPTION", cause)
+
+    class PermissionDeniedException(cause: Throwable) : Exception("PERMISSION_DENIED", cause)
+
+    class NoResolutionRequiredException(cause: Throwable) : Exception("NO_RESOLUTION_REQUIRED", cause)
+}

--- a/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
+++ b/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
@@ -15,4 +15,6 @@ object CovidShieldException {
     class PermissionDeniedException(cause: Throwable) : Exception("PERMISSION_DENIED", cause)
 
     class NoResolutionRequiredException(cause: Throwable) : Exception("NO_RESOLUTION_REQUIRED", cause)
+
+    class PlayServicesNotAvailableException : Exception("PLAY_SERVICES_NOT_AVAILABLE")
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -15,11 +15,15 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: any
         }
         for (const diagnosisKeysURL of diagnosisKeysURLs) {
           (async (diagnosisKeysURL: string) => {
-            const summary = await exposureNotificationAPI.detectExposure(configuration, [diagnosisKeysURL]);
-            summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
-            // first detected exposure is enough
-            if (summary.matchedKeyCount > 0) {
-              resolve(summary);
+            try {
+              const summary = await exposureNotificationAPI.detectExposure(configuration, [diagnosisKeysURL]);
+              summary.lastExposureTimestamp = getLastExposureTimestamp(summary);
+              // first detected exposure is enough
+              if (summary.matchedKeyCount > 0) {
+                resolve(summary);
+              }
+            } catch (error) {
+              reject(error);
             }
           })(diagnosisKeysURL);
         }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -387,7 +387,7 @@ export class ExposureNotificationService {
   }
 
   private async processPendingExposureSummary() {
-    const summary = await this.exposureNotification.getPendingExposureSummary();
+    const summary = await this.exposureNotification.getPendingExposureSummary().catch(() => undefined);
     const exposureStatus = this.exposureStatus.get();
     if (exposureStatus.type === 'diagnosed' || !summary || summary.matchedKeyCount <= 0) {
       return;


### PR DESCRIPTION
This PR handles error code 10 on Android by checking EN permission when accessing EN methods. It also extracts all exception in the app into a utils for convenience.

Ref https://github.com/cds-snc/covid-shield-mobile/issues/593

## How to test?

Test in all cases: EN is OFF, Bluetooth is OFF, EN and Bluetooth are OFF.

Expected log
- `Error: performExposureStatusUpdate {"error": {"error": [Error: API_NOT_ENABLED], "message": "API_NOT_ENABLED"}}` is called after `performExposureStatusUpdate`. 
- `finalize` is called at the end with: `lastChecked.period` should be the same before and after updating. `last.Checked.timestamp` should be different.

```
[Thu Jul 23 2020 15:26:05.754]  LOG      App.appInit() {}
[Thu Jul 23 2020 15:26:06.883]  LOG      updateExposureStatusInBackground {"exposureStatus": {"type": "monitoring"}}
[Thu Jul 23 2020 15:26:06.895]  LOG      registerPeriodicTask {"result": true}
[Thu Jul 23 2020 15:26:07.170]  LOG      getExposureConfiguration {"exposureConfigurationUrl": "http://192.168.0.24:8001/exposure-configuration/CA.json"}
[Thu Jul 23 2020 15:26:07.169]  LOG      Using downloaded exposureConfiguration. {}
[Thu Jul 23 2020 15:26:07.183]  LOG      Saving exposure configuration to secure storage. {}
[Thu Jul 23 2020 15:26:07.191]  LOG      retrieveDiagnosisKeys {"period": 0, "url": "http://192.168.0.24:8001/retrieve/302/00000/f3068242ab71ef941656bd16e81856eb034819cf52af520899513dad50bb1c72"}
[Thu Jul 23 2020 15:26:07.229]  LOG      performExposureStatusUpdate {"exposureConfiguration": {"attenuationLevelValues": [0, 0, 2, 2, 2, 2, 2, 2], "attenuationWeight": 50, "daysSinceLastExposureLevelValues": [0, 1, 1, 1, 1, 1, 1, 1], "daysSinceLastExposureWeight": 50, "durationLevelValues": [0, 0, 0, 0, 5, 5, 5, 5], "durationWeight": 50, "minimumRiskScore": 1, "transmissionRiskLevelValues": [1, 1, 1, 1, 1, 1, 1, 1], "transmissionRiskWeight": 50}, "keysFileUrls": ["/data/user/0/ca.gc.hcsc.canada.stopcovid/app_c2acf5e3-43d0-4c49-b2d9-7f67dd53f4c2/keys.zip"], "lastCheckedPeriod": 18466}
[Thu Jul 23 2020 15:26:07.354]  LOG      Error: performExposureStatusUpdate {"error": {"error": [Error: API_NOT_ENABLED], "message": "API_NOT_ENABLED"}}
[Thu Jul 23 2020 15:26:07.477]  LOG      finalize {"currentExposureStatus": {"lastChecked": {"period": 0, "timestamp": 1595532368901}, "type": "monitoring"}, "previousExposureStatus": {"type": "monitoring"}}
[Thu Jul 23 2020 15:26:07.484]  LOG      updatedExposureStatusInBackground {"exposureStatus": {"lastChecked": {"period": 0, "timestamp": 1595532368901}, "type": "monitoring"}}

```

- If you already passed onboarding screen and enable EN framework:
  + Terminate the app.
  + Go to Settings, disable EN framework.
  + Open the app.
  + Observe js log.

- If you are still in onboarding screen:
  + In ExposureNotificationServiceProvider, call `updateExposureStatusInBackground` immediately. 
  + Open the app.
  + Observe js log.
  + Go through onboarding flow and DO NOT allow to turn on EN. 
  + At home screen, observe js log. 
  + Click `Enable COVID Alert`.
  + Allow to turn on EN.
  + Observe js log goes through as normal without `Error: performExposureStatusUpdate`. You might see it hangs at `performExposureStatusUpdate` because you don't have exposed TEKs or you are in exposed state.