### PR TITLE
Feature/exposure status secure storage

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -196,11 +196,13 @@ describe('ExposureNotificationService', () => {
   it('restores "diagnosed" status from storage', async () => {
     when(secureStorage.get)
       .calledWith(EXPOSURE_STATUS)
-      .mockResolvedValueOnce(
-        JSON.stringify({
-          type: 'diagnosed',
-          cycleStartsAt: new OriginalDate('2020-05-18T04:10:00+0000').toString(),
-        }),
+      .mockReturnValueOnce(
+        Promise.resolve(
+          JSON.stringify({
+            type: 'diagnosed',
+            cycleStartsAt: new OriginalDate('2020-05-18T04:10:00+0000').toString(),
+          }),
+        ),
       );
     dateSpy.mockImplementation((...args) =>
       args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-19T04:10:00+0000'),
@@ -227,6 +229,9 @@ describe('ExposureNotificationService', () => {
     });
 
     it('for positive', async () => {
+      when(secureStorage.get)
+        .calledWith(EXPOSURE_STATUS)
+        .mockReturnValueOnce(Promise.resolve(null));
       service.exposureStatus.append({
         submissionLastCompletedAt: new OriginalDate('2020-05-18T04:10:00+0000').getTime(),
       });
@@ -240,6 +245,9 @@ describe('ExposureNotificationService', () => {
     });
 
     it('for negative', async () => {
+      when(secureStorage.get)
+        .calledWith(EXPOSURE_STATUS)
+        .mockReturnValueOnce(Promise.resolve(null));
       service.exposureStatus.append({
         submissionLastCompletedAt: new OriginalDate('2020-05-19T04:10:00+0000').getTime(),
       });
@@ -255,6 +263,10 @@ describe('ExposureNotificationService', () => {
 
   it('needsSubmission status recalculates daily', async () => {
     let currentDateString = '2020-05-19T04:10:00+0000';
+
+    when(secureStorage.get)
+      .calledWith(EXPOSURE_STATUS)
+      .mockReturnValue(Promise.resolve(null));
 
     service.exposureStatus.append({
       type: 'diagnosed',
@@ -277,7 +289,7 @@ describe('ExposureNotificationService', () => {
     currentDateString = '2020-05-20T04:10:00+0000';
     when(secureStorage.get)
       .calledWith(SUBMISSION_AUTH_KEYS)
-      .mockResolvedValueOnce('{}');
+      .mockReturnValue(Promise.resolve('{}'));
     await service.fetchAndSubmitKeys();
 
     expect(secureStorage.set).toHaveBeenCalledWith(

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -185,7 +185,7 @@ describe('ExposureNotificationService', () => {
   });
 
   it('restores "diagnosed" status from storage', async () => {
-    when(storage.getItem)
+    when(storage.get)
       .calledWith(EXPOSURE_STATUS)
       .mockResolvedValueOnce(
         JSON.stringify({

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -193,7 +193,7 @@ export class ExposureNotificationService {
   }
 
   private async init() {
-    const exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
+    const exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS).catch(() => null)) || 'null');
     this.exposureStatus.append({...exposureStatus});
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -196,7 +196,12 @@ export class ExposureNotificationService {
   }
 
   private async init() {
-    const exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
+    let exposureStatus;
+    try {
+      exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
+    } catch (error) {
+      exposureStatus = 'null';
+    }
     this.exposureStatus.append({...exposureStatus});
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -8,6 +8,7 @@ import {addDays, periodSinceEpoch, minutesBetween, getCurrentDate, daysBetweenUT
 import {I18n} from 'locale';
 import {Observable, MapObservable} from 'shared/Observable';
 import {captureException, captureMessage} from 'shared/log';
+import {ACCESSIBLE} from 'react-native-secure-key-store';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 
@@ -106,8 +107,10 @@ export class ExposureNotificationService {
     this.backendInterface = backendInterface;
     this.storage = storage;
     this.secureStorage = secureStorage;
-    this.exposureStatus.observe(status => {
-      this.storage.setItem(EXPOSURE_STATUS, JSON.stringify(status));
+    this.exposureStatus.observe(async status => {
+      await this.secureStorage.set(EXPOSURE_STATUS, JSON.stringify(status), {
+        accessible: ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY,
+      });
     });
   }
 
@@ -193,7 +196,7 @@ export class ExposureNotificationService {
   }
 
   private async init() {
-    const exposureStatus = JSON.parse((await this.storage.getItem(EXPOSURE_STATUS)) || 'null');
+    const exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
     this.exposureStatus.append({...exposureStatus});
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -16,7 +16,7 @@ import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 import {ExposureConfigurationValidator, ExposureConfigurationValidationError} from './ExposureConfigurationValidator';
 
-const SUBMISSION_AUTH_KEYS = 'submissionAuthKey';
+export const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys_2';
 const EXPOSURE_CONFIGURATION = 'exposureConfiguration';
 
 export const EXPOSURE_STATUS = 'exposureStatus';
@@ -167,13 +167,9 @@ export class ExposureNotificationService {
   async startKeysSubmission(oneTimeCode: string): Promise<void> {
     const keys = await this.backendInterface.claimOneTimeCode(oneTimeCode);
     const serialized = JSON.stringify(keys);
-    try {
-      await this.secureStorage.set(SUBMISSION_AUTH_KEYS, serialized, {
-        accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
-      });
-    } catch (error) {
-      captureException('Error storing SUBMISSION_AUTH_KEYS.', error);
-    }
+    await this.secureStorage.set(SUBMISSION_AUTH_KEYS, serialized, {
+      accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+    });
     const cycleStartsAt = getCurrentDate();
     this.exposureStatus.append({
       type: 'diagnosed',
@@ -197,12 +193,7 @@ export class ExposureNotificationService {
   }
 
   private async init() {
-    let exposureStatus;
-    try {
-      exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
-    } catch (error) {
-      exposureStatus = 'null';
-    }
+    const exposureStatus = JSON.parse((await this.secureStorage.get(EXPOSURE_STATUS)) || 'null');
     this.exposureStatus.append({...exposureStatus});
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -16,7 +16,7 @@ import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 import {ExposureConfigurationValidator, ExposureConfigurationValidationError} from './ExposureConfigurationValidator';
 
-const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys';
+const SUBMISSION_AUTH_KEYS = 'submissionAuthKey';
 const EXPOSURE_CONFIGURATION = 'exposureConfiguration';
 
 export const EXPOSURE_STATUS = 'exposureStatus';
@@ -167,11 +167,12 @@ export class ExposureNotificationService {
   async startKeysSubmission(oneTimeCode: string): Promise<void> {
     const keys = await this.backendInterface.claimOneTimeCode(oneTimeCode);
     const serialized = JSON.stringify(keys);
-    console.log(serialized);
     try {
-      await this.secureStorage.set(SUBMISSION_AUTH_KEYS, serialized, {});
+      await this.secureStorage.set(SUBMISSION_AUTH_KEYS, serialized, {
+        accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+      });
     } catch (error) {
-      console.error(error);
+      captureException('Error storing SUBMISSION_AUTH_KEYS.', error);
     }
     const cycleStartsAt = getCurrentDate();
     this.exposureStatus.append({


### PR DESCRIPTION
Solves the problem of stopping data from being stored in the iOS `/Library` folder, by saving the data in the keychain instead of using React-Native Async storage. 

Setting the `accessible` property to `ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY` ensures that the data will remain on the phone, and not be backed up to iCloud.