### PR TITLE
react-native-safe-area-context package update

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -243,7 +243,7 @@ PODS:
     - React
   - react-native-netinfo (5.9.5):
     - React
-  - react-native-safe-area-context (3.0.2):
+  - react-native-safe-area-context (3.1.1):
     - React
   - react-native-splash-screen (3.2.0):
     - React
@@ -545,7 +545,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
   react-native-config: 313a1306066289211579b9655eb81d9a565462d0
   react-native-netinfo: a53b00d949b6456913aaf507d9dba90c4008c611
-  react-native-safe-area-context: b11a34881faac509cad5578726c98161ad4d275c
+  react-native-safe-area-context: 344b969c45af3d8464d36e8dea264942992ef033
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-native-markdown-display": "^6.1.0",
     "react-native-permissions": "^2.1.4",
     "react-native-reanimated": "^1.8.0",
-    "react-native-safe-area-context": "^3.0.2",
+    "react-native-safe-area-context": "^3.1.1",
     "react-native-screens": "^2.7.0",
     "react-native-secure-key-store": "^2.0.7",
     "react-native-snap-carousel": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7231,10 +7231,10 @@ react-native-reanimated@^1.8.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.2.tgz#95dd7e56bc89bcc4f3f7bb5fada30c98420328b2"
-  integrity sha512-x3yVMsxwe9GyvIkv0Q5jy2CWYN7VO0/CJTFGG5kSiMo8FFTQJbWtuWGANFqxDzEH5NEV7/SfK+qTgAh931KyUw==
+react-native-safe-area-context@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.1.tgz#9b04d1154766e6c1132030aca8f4b0336f561ccd"
+  integrity sha512-Iqb41OT5+QxFn0tpTbbHgz8+3VU/F9OH2fTeeoU7oZCzojOXQbC6sp6mN7BlsAoTKhngWoJLMcSosL58uRaLWQ==
 
 react-native-screens@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
```diff
-"react-native-safe-area-context": "^3.0.2",
+"react-native-safe-area-context": "^3.1.1"
```

Ref: https://github.com/th3rdwave/react-native-safe-area-context/commit/883bc241b08ba67aa532429d9b9dc19dfd2854a1

Bumping version based on the crashes we're seeing

**Crash reports**
```
Input dispatching timed out (Waiting to send non-key event because the touched window has not finished processing certain input events that were delivered to it over 500.0ms ago. Wait queue length: 2. Wait queue head age: 6283.4ms.), VisibleToUser
```

```
"main" prio=5 tid=1 TimedWaiting
  | group="main" sCount=1 dsCount=0 obj=0x7586de38 self=0xa7784400
  | sysTid=21166 nice=-4 cgrp=default sched=0/0 handle=0xaa498534
  | state=S schedstat=( 1029221983 48633020 871 ) utm=83 stm=19 core=4 HZ=100
  | stack=0xbe2dd000-0xbe2df000 stackSize=8MB
  | held mutexes=
  at java.lang.Object.wait! (Native method)
- waiting on <0x08c1a22b> (a java.util.concurrent.atomic.AtomicBoolean)
  at java.lang.Object.wait (Object.java:407)
  at com.th3rdwave.safeareacontext.SafeAreaView.waitForReactLayout (SafeAreaView.java:83)
- locked <0x08c1a22b> (a java.util.concurrent.atomic.AtomicBoolean)
  at com.th3rdwave.safeareacontext.SafeAreaView.updateInsets (SafeAreaView.java:54)
  at com.th3rdwave.safeareacontext.SafeAreaView.maybeUpdateInsets (SafeAreaView.java:113)
  at com.th3rdwave.safeareacontext.SafeAreaView.onAttachedToWindow (SafeAreaView.java:137)
```


