### PR TITLE
Patch `async-storage` with `NSURLIsExcludedFromBackupKey`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fastlane:android:local": "bundle exec fastlane android local"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.9.0",
+    "@react-native-community/async-storage": "1.9.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
     "@react-native-community/push-notification-ios": "^1.3.0",

--- a/patches/@react-native-community+async-storage+1.9.0.patch
+++ b/patches/@react-native-community+async-storage+1.9.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
-index 2d72ac7..1a0531e 100644
+index 2d72ac7..2937091 100644
 --- a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
 +++ b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
 @@ -414,14 +414,38 @@ - (NSDictionary *)_ensureSetup
@@ -45,27 +45,32 @@ index 2d72ac7..1a0531e 100644
    return errorOut;
  }
  
-@@ -481,6 +505,26 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
+@@ -480,7 +504,30 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
+     _manifest[key] = value;
      return nil;
    }
-   [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
-+
+-  [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
++    
 +  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
-+  if (!error){
-+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+    BOOL success = [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
-+    if (!success) {
-+      if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {
-+        NSError *removeFileError;
-+        BOOL removeFileSuccess = [[NSFileManager defaultManager] removeItemAtPath:filePath error:&removeFileError];
-+        if (!removeFileSuccess) {
-+          return RCTMakeError(@"Error removing file at path.", removeFileError, nil);
-+        } else {
-+          return RCTMakeError(@"Unable to exclude file from backup.", error, nil);
-+        }
++  BOOL success;
++  success = [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
++  if (!success) {
++    return RCTMakeError(@"Failed to write file.", error, nil);
++  }
++  
++  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++  success = [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++  if (!success) {
++    if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {
++      NSError *removeFileError;
++      BOOL removeFileSuccess = [[NSFileManager defaultManager] removeItemAtPath:filePath error:&removeFileError];
++      if (!removeFileSuccess) {
++        return RCTMakeError(@"Error removing file at path.", removeFileError, nil);
 +      } else {
-+          return RCTMakeError(@"Unable to delete file.", nil, nil);
++        return RCTMakeError(@"Unable to exclude file from backup.", error, nil);
 +      }
++    } else {
++      return RCTMakeError(@"Unable to delete file.", nil, nil);
 +    }
 +  }
 +

--- a/patches/@react-native-community+async-storage+1.9.0.patch
+++ b/patches/@react-native-community+async-storage+1.9.0.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
+index 2d72ac7..c4de715 100644
+--- a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
++++ b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
+@@ -417,6 +417,14 @@ - (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+   NSError *error;
+   NSString *serialized = RCTJSONStringify(_manifest, &error);
+   [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
++    
++  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
++  if (!error){
++    NSString *filePath = RCTCreateStorageDirectoryPath(RCTGetManifestFilePath());
++    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++  }
++    
+   NSDictionary *errorOut;
+   if (error) {
+     errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);
+@@ -481,6 +489,13 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
+     return nil;
+   }
+   [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
++
++  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
++  if (!error){
++    NSURL *fileURL = [NSURL URLWithString:filePath];
++    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++  }
++
+   [RCTGetCache() setObject:value forKey:key cost:value.length];
+   if (error) {
+     errorOut = RCTMakeError(@"Failed to write value.", error, @{@"key": key});

--- a/patches/@react-native-community+async-storage+1.9.0.patch
+++ b/patches/@react-native-community+async-storage+1.9.0.patch
@@ -1,23 +1,25 @@
 diff --git a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
-index 2d72ac7..c4de715 100644
+index 2d72ac7..bf72515 100644
 --- a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
 +++ b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
-@@ -417,6 +417,14 @@ - (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+@@ -417,10 +417,16 @@ - (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
    NSError *error;
    NSString *serialized = RCTJSONStringify(_manifest, &error);
    [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
 +    
-+  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
-+  if (!error){
-+    NSString *filePath = RCTCreateStorageDirectoryPath(RCTGetManifestFilePath());
-+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
-+  }
-+    
    NSDictionary *errorOut;
    if (error) {
      errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);
-@@ -481,6 +489,13 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
+     RCTAppendError(errorOut, errors);
++  } else {
++    // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
++    NSString *filePath = RCTCreateStorageDirectoryPath(RCTGetManifestFilePath());
++    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
+   }
+   return errorOut;
+ }
+@@ -481,6 +487,13 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
      return nil;
    }
    [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];

--- a/patches/@react-native-community+async-storage+1.9.0.patch
+++ b/patches/@react-native-community+async-storage+1.9.0.patch
@@ -1,33 +1,72 @@
 diff --git a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
-index 2d72ac7..bf72515 100644
+index 2d72ac7..1a0531e 100644
 --- a/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
 +++ b/node_modules/@react-native-community/async-storage/ios/RNCAsyncStorage.m
-@@ -417,10 +417,16 @@ - (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+@@ -414,14 +414,38 @@ - (NSDictionary *)_ensureSetup
+ 
+ - (NSDictionary *)_writeManifest:(NSMutableArray<NSDictionary *> **)errors
+ {
++  NSDictionary *errorOut;
    NSError *error;
-   NSString *serialized = RCTJSONStringify(_manifest, &error);
-   [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
++  BOOL success;
 +    
-   NSDictionary *errorOut;
+   NSString *serialized = RCTJSONStringify(_manifest, &error);
+-  [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
+-  NSDictionary *errorOut;
    if (error) {
-     errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);
-     RCTAppendError(errorOut, errors);
-+  } else {
-+    // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
-+    NSString *filePath = RCTCreateStorageDirectoryPath(RCTGetManifestFilePath());
-+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-+    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
+-    errorOut = RCTMakeError(@"Failed to write manifest file.", error, nil);
+-    RCTAppendError(errorOut, errors);
++    return RCTMakeError(@"Unable to parse manifest file.", error, nil);
++  }
++  
++  success = [serialized writeToFile:RCTCreateStorageDirectoryPath(RCTGetManifestFilePath()) atomically:YES encoding:NSUTF8StringEncoding error:&error];
++  if (!success) {
++    return RCTMakeError(@"Failed to write manifest file.", error, nil);
++  }
++
++  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
++  NSString *filePath = RCTCreateStorageDirectoryPath(RCTGetManifestFilePath());
++  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++  success = [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++  if (!success) {
++    if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {
++      NSError *removeFileError;
++      BOOL removeFileSuccess = [[NSFileManager defaultManager] removeItemAtPath:filePath error:&removeFileError];
++      if (!removeFileSuccess) {
++        return RCTMakeError(@"Error removing file at path.", removeFileError, nil);
++      } else {
++        return RCTMakeError(@"Unable to exclude file from backup.", error, nil);
++      }
++    } else {
++        return RCTMakeError(@"Unable to delete file.", nil, nil);
++    }
    }
++    
    return errorOut;
  }
-@@ -481,6 +487,13 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
+ 
+@@ -481,6 +505,26 @@ - (NSDictionary *)_writeEntry:(NSArray<NSString *> *)entry changedManifest:(BOOL
      return nil;
    }
    [value writeToFile:filePath atomically:YES encoding:NSUTF8StringEncoding error:&error];
 +
 +  // Added by COVID Alert: Ensure all files are excluded from iCloud Backup.
 +  if (!error){
-+    NSURL *fileURL = [NSURL URLWithString:filePath];
-+    [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
++    BOOL success = [fileURL setResourceValue:[NSNumber numberWithBool: YES] forKey: NSURLIsExcludedFromBackupKey error: &error];
++    if (!success) {
++      if ([[NSFileManager defaultManager] isDeletableFileAtPath:filePath]) {
++        NSError *removeFileError;
++        BOOL removeFileSuccess = [[NSFileManager defaultManager] removeItemAtPath:filePath error:&removeFileError];
++        if (!removeFileSuccess) {
++          return RCTMakeError(@"Error removing file at path.", removeFileError, nil);
++        } else {
++          return RCTMakeError(@"Unable to exclude file from backup.", error, nil);
++        }
++      } else {
++          return RCTMakeError(@"Unable to delete file.", nil, nil);
++      }
++    }
 +  }
 +
    [RCTGetCache() setObject:value forKey:key cost:value.length];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,7 +1043,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@react-native-community/async-storage@^1.9.0":
+"@react-native-community/async-storage@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.9.0.tgz#af26a8879bd2987970fbbe81a9623851d29a56f1"
   integrity sha512-TlGMr02JcmY4huH1P7Mt7p6wJecosPpW+09+CwCFLn875IhpRqU2XiVA+BQppZOYfQdHUfUzIKyCBeXOlCEbEg==


### PR DESCRIPTION
## What

All files stored with `async-storage` were being stored in iCloud backups by default.

## Solution
Mark each file with the `NSURLIsExcludedFromBackupKey`. The easiest way to implement this was to patch-package the `async-storage` repo.

## Note
Affects iOS only.