### PR TITLE
Change icon for "all set, unsupported region" screen, add icon for "monitoring, no region set" screen

### DIFF
--- a/src/screens/home/components/AllSetView.tsx
+++ b/src/screens/home/components/AllSetView.tsx
@@ -15,11 +15,11 @@ export const AllSetView = ({
 }) => {
   const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
   return (
-    <BaseHomeView iconName="thumbs-up">
+    <>
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">
         {titleText}
       </Text>
       <TextMultiline text={bodyText} marginBottom="m" />
-    </BaseHomeView>
+    </>
   );
 };

--- a/src/screens/home/components/AllSetView.tsx
+++ b/src/screens/home/components/AllSetView.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {Text, TextMultiline} from 'components';
 import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 
-import {BaseHomeView} from './BaseHomeView';
-
 export const AllSetView = ({
   isBottomSheetExpanded,
   titleText,

--- a/src/screens/home/views/NoExposureCoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureCoveredRegionView.tsx
@@ -15,11 +15,13 @@ export const NoExposureCoveredRegionView = ({isBottomSheetExpanded}: {isBottomSh
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (
-      <AllSetView
-        isBottomSheetExpanded={isBottomSheetExpanded}
-        titleText={i18n.translate('Home.NoExposureDetected.AllSetTitle')}
-        bodyText={i18n.translate('Home.NoExposureDetected.RegionCovered.AllSetBody')}
-      />
+      <BaseHomeView iconName="thumbs-up">
+        <AllSetView
+          isBottomSheetExpanded={isBottomSheetExpanded}
+          titleText={i18n.translate('Home.NoExposureDetected.AllSetTitle')}
+          bodyText={i18n.translate('Home.NoExposureDetected.RegionCovered.AllSetBody')}
+        />
+      </BaseHomeView>
     );
   }
   return (

--- a/src/screens/home/views/NoExposureNoRegionView.tsx
+++ b/src/screens/home/views/NoExposureNoRegionView.tsx
@@ -16,11 +16,13 @@ export const NoExposureNoRegionView = ({isBottomSheetExpanded}: {isBottomSheetEx
 
   if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
     return (
-      <AllSetView
-        isBottomSheetExpanded={isBottomSheetExpanded}
-        titleText={i18n.translate('Home.NoExposureDetected.AllSetTitle')}
-        bodyText={i18n.translate('Home.NoExposureDetected.NoRegion.AllSetBody')}
-      />
+      <BaseHomeView iconName="thumbs-up">
+        <AllSetView
+          isBottomSheetExpanded={isBottomSheetExpanded}
+          titleText={i18n.translate('Home.NoExposureDetected.AllSetTitle')}
+          bodyText={i18n.translate('Home.NoExposureDetected.NoRegion.AllSetBody')}
+        />
+      </BaseHomeView>
     );
   }
 

--- a/src/screens/home/views/NoExposureNoRegionView.tsx
+++ b/src/screens/home/views/NoExposureNoRegionView.tsx
@@ -28,7 +28,7 @@ export const NoExposureNoRegionView = ({isBottomSheetExpanded}: {isBottomSheetEx
 
   return (
     // note you can add an icon i.e. <BaseHomeView iconName="icon-offline>
-    <BaseHomeView>
+    <BaseHomeView iconName="thumbs-up">
       <Text focusRef={autoFocusRef} variant="bodyTitle" color="bodyText" marginBottom="m" accessibilityRole="header">
         {i18n.translate('Home.NoExposureDetected.NoRegion.Title')}
       </Text>

--- a/src/screens/home/views/NoExposureUncoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureUncoveredRegionView.tsx
@@ -13,15 +13,17 @@ export const NoExposureUncoveredRegionView = ({isBottomSheetExpanded}: {isBottom
   const {onboardedDatetime, skipAllSet} = useStorage();
   const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
-  if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
-    return (
-      <AllSetView
-        isBottomSheetExpanded
-        titleText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.Title')}
-        bodyText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.AllSetBody')}
-      />
-    );
-  }
+  // if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
+  //   return (
+  //     <BaseHomeView iconName="hand-no-province-yet">
+  //       <AllSetView
+  //         isBottomSheetExpanded
+  //         titleText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.Title')}
+  //         bodyText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.AllSetBody')}
+  //       />
+  //     </BaseHomeView>
+  //   );
+  // }
   return (
     // note you can add an icon i.e. <BaseHomeView iconName="icon-offline>
     <BaseHomeView iconName="hand-no-province-yet">

--- a/src/screens/home/views/NoExposureUncoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureUncoveredRegionView.tsx
@@ -13,17 +13,17 @@ export const NoExposureUncoveredRegionView = ({isBottomSheetExpanded}: {isBottom
   const {onboardedDatetime, skipAllSet} = useStorage();
   const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
-  // if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
-  //   return (
-  //     <BaseHomeView iconName="hand-no-province-yet">
-  //       <AllSetView
-  //         isBottomSheetExpanded
-  //         titleText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.Title')}
-  //         bodyText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.AllSetBody')}
-  //       />
-  //     </BaseHomeView>
-  //   );
-  // }
+  if (!skipAllSet && onboardedDatetime && hoursFromNow(onboardedDatetime) < 24) {
+    return (
+      <BaseHomeView iconName="hand-no-province-yet">
+        <AllSetView
+          isBottomSheetExpanded
+          titleText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.Title')}
+          bodyText={i18n.translate('Home.NoExposureDetected.RegionNotCovered.AllSetBody')}
+        />
+      </BaseHomeView>
+    );
+  }
   return (
     // note you can add an icon i.e. <BaseHomeView iconName="icon-offline>
     <BaseHomeView iconName="hand-no-province-yet">


### PR DESCRIPTION
I moved the `BaseHomeView` from the "all set" component to the monitoring screens, to make it easier to set what icon shows up on the "all set" screens.

Changes:
- "All set" screen for unsupported regions now has a wristwatch icon (previously had thumbs up):
<img width="338" alt="Screen Shot 2020-07-28 at 3 18 26 PM" src="https://user-images.githubusercontent.com/5498428/88723242-c0dcb780-d0e5-11ea-997c-87fd325e1081.png">

- "Monitoring" screen for "region not selected" now has a thumbs up (previously had no icon):
<img width="335" alt="Screen Shot 2020-07-28 at 3 19 26 PM" src="https://user-images.githubusercontent.com/5498428/88723253-c508d500-d0e5-11ea-8c64-537465dd7a4b.png">
