### PR TITLE
check bad configuration with missing: minimumRiskScore

### DIFF
--- a/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
@@ -3,7 +3,7 @@ import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 
 describe('ExposureConfigurationValidator', () => {
-  it('validates the default config', async () => {
+  it('validates the default config', () => {
     const result = new ExposureConfigurationValidator().validateExposureConfiguration(
       exposureConfigurationDefault,
       exposureConfigurationSchema,
@@ -12,7 +12,7 @@ describe('ExposureConfigurationValidator', () => {
     expect(result.errors).toHaveLength(0);
   });
 
-  it('check bad configuration with missing: minimumRiskScore', async () => {
+  it('check bad configuration with missing: minimumRiskScore', () => {
     const exposureConfig1: any = {
       attenuationLevelValues: [0, 0, 2, 2, 2, 2, 2, 2],
       attenuationWeight: 50,
@@ -24,13 +24,11 @@ describe('ExposureConfigurationValidator', () => {
       transmissionRiskWeight: 50,
     };
 
-    let validatorError;
-    try {
+    function validateMissingMinimumRiskScore() {
       new ExposureConfigurationValidator().validateExposureConfiguration(exposureConfig1, exposureConfigurationSchema);
-    } catch (error) {
-      validatorError = error;
     }
-    expect(validatorError).toStrictEqual(
+
+    expect(validateMissingMinimumRiskScore).toThrow(
       new ExposureConfigurationValidationError(
         'Invalid Exposure Configuration JSON. instance requires property "minimumRiskScore"',
       ),

--- a/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureConfigurationValidator.spec.ts
@@ -1,4 +1,4 @@
-import {ExposureConfigurationValidator} from './ExposureConfigurationValidator';
+import {ExposureConfigurationValidationError, ExposureConfigurationValidator} from './ExposureConfigurationValidator';
 import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 
@@ -10,5 +10,30 @@ describe('ExposureConfigurationValidator', () => {
     );
 
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('check bad configuration with missing: minimumRiskScore', async () => {
+    const exposureConfig1: any = {
+      attenuationLevelValues: [0, 0, 2, 2, 2, 2, 2, 2],
+      attenuationWeight: 50,
+      daysSinceLastExposureLevelValues: [0, 1, 1, 1, 1, 1, 1, 1],
+      daysSinceLastExposureWeight: 50,
+      durationLevelValues: [0, 0, 0, 0, 5, 5, 5, 5],
+      durationWeight: 50,
+      transmissionRiskLevelValues: [1, 1, 1, 1, 1, 1, 1, 1],
+      transmissionRiskWeight: 50,
+    };
+
+    let validatorError;
+    try {
+      new ExposureConfigurationValidator().validateExposureConfiguration(exposureConfig1, exposureConfigurationSchema);
+    } catch (error) {
+      validatorError = error;
+    }
+    expect(validatorError).toStrictEqual(
+      new ExposureConfigurationValidationError(
+        'Invalid Exposure Configuration JSON. instance requires property "minimumRiskScore"',
+      ),
+    );
   });
 });


### PR DESCRIPTION
Adding a jest test to verify when a bad exposureConfiguration has been passed into the exposureConfigurationValidator.

This test is a success when the correct error is thrown.