### PR TITLE
Issue and Pull Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,7 +8,7 @@ assignees: ""
 
 # Summary
 
-> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing).
+> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing). Screenshots are greatly helpful here too.
 
 # Steps to reproduce
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,18 +6,18 @@ labels: bug, inbox
 assignees: ""
 ---
 
-## Summary
+# Summary
 
 > One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing).
 
-## Steps to reproduce
+# Steps to reproduce
 
 > Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it.
 
-## Environment
+# Environment
 
 > What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant.
 
-## Unresolved questions
+# Unresolved questions
 
 > Are there any related issues you consider out of scope for this issue that could be addressed in the future?

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,6 +18,6 @@ assignees: ""
 
 > What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant.
 
-# Unresolved questions
+# Unresolved questions / Out of scope
 
 > Are there any related issues you consider out of scope for this issue that could be addressed in the future?

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,23 @@
+---
+name: Bug
+about: Problems or flaws experienced in the app. Includes accessibility issues.
+title: Bug
+labels: bug, inbox
+assignees: ""
+---
+
+## Summary
+
+> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing).
+
+## Steps to reproduce
+
+> Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it.
+
+## Environment
+
+> What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant.
+
+## Unresolved questions
+
+> Are there any related issues you consider out of scope for this issue that could be addressed in the future?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request a new feature, propose changes to an existing feature, or make a suggestion.
+title: Request new feature
+labels: enhancement, inbox
+assignees: ""
+---
+
+## Summary
+
+> One paragraph explanation of the change. Ideally, this includes a statement in the following format: "As a (kind of user or stakeholder), I want (what feature) because (it does helps the user achieve or do what)."
+
+> An example for having a dark mode might look like: "As a user, I want a dark mode so that the app doesn't hurt my eyes."
+
+## Design detail
+
+> Explain the design in enough detail for somebody familiar with the application to understand. This should get into specifics and corner-cases, and include examples of how the service is used. Any new terminology should be defined here. It is greatly appreciated if you have any design images or mockups that would be help clarify your idea.
+
+> Following the example of a dark mode feature request, you might describe that text is light, backgrounds are dark, and images have sufficient contrast with the dark backgrounds.
+
+## Unresolved questions
+
+> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -18,6 +18,6 @@ assignees: ""
 
 > Following the example of a dark mode feature request, you might describe that text is light, backgrounds are dark, and images have sufficient contrast with the dark backgrounds.
 
-# Unresolved questions
+# Unresolved questions / Out of scope
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,18 +6,18 @@ labels: enhancement, inbox
 assignees: ""
 ---
 
-## Summary
+# Summary
 
 > One paragraph explanation of the change. Ideally, this includes a statement in the following format: "As a (kind of user or stakeholder), I want (what feature) because (it does helps the user achieve or do what)."
 
 > An example for having a dark mode might look like: "As a user, I want a dark mode so that the app doesn't hurt my eyes."
 
-## Design detail
+# Design detail
 
 > Explain the design in enough detail for somebody familiar with the application to understand. This should get into specifics and corner-cases, and include examples of how the service is used. Any new terminology should be defined here. It is greatly appreciated if you have any design images or mockups that would be help clarify your idea.
 
 > Following the example of a dark mode feature request, you might describe that text is light, backgrounds are dark, and images have sufficient contrast with the dark backgrounds.
 
-## Unresolved questions
+# Unresolved questions
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,22 @@
 # Unresolved questions
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?
+
+# Reviewer checklist
+
+This is a suggested checklist of questions reviewers might ask during their review:
+
+- [ ] Does this meet a user need?
+- [ ] Is it accessible?
+- [ ] Is it translated between both offical languages?
+- [ ] Is the code maintainable?
+- [ ] Have you tested it?
+- [ ] Are there automated tests?
+- [ ] Does this cause automated test coverage to drop?
+- [ ] Does this break existing functionality?
+- [ ] Should this be split into smaller PRs to decrease change risk?
+- [ ] Does this change the privacy policy?
+- [ ] Does this introduce any security concerns?
+- [ ] Does this significantly alter performance?
+- [ ] What is the risk level of using added dependencies?
+- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 > Things that you (the submitter) want reviewers to pay very close attention to when they review this.
 
-# Unresolved questions
+# Unresolved questions / Out of scope
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Summary
+
+> 1-3 sentence description of the changed you're proposing, including a link to a GitHub Issue # or Trello card if applicable.
+
+# Test instructions
+
+> Sequential steps (1., 2., 3., ...) that describe how to test this change. This will help a developer test things out without too much detective work. Also, include any environmental setup steps that aren't in the normal README steps and/or any time-based elements that this requires.
+
+# Help requested
+
+> Things that you (the submitter) want reviewers to pay very close attention to when they review this.
+
+# Unresolved questions
+
+> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?


### PR DESCRIPTION
# Summary

Includes default templates for bugs, feature requests, and pull requests. The hope is that this will make it easier for both internal and external contributors to participate in development, make it easier to organize issues/PRs in GitHub. These were adapted from Report a Cybercrime and CPP Disability projects.

Other references:

- [Trello](https://trello.com/c/biRp9Chd)

# Test instructions

Unfortunately, this can't be tested until merged, but is low impact to do so.

For issues:

1. Go to this repo
1. Go to the Issues tab
1. Click New issue
1. See the available templates
1. Choose one
1. File a new issue
1. The appropriate labels should be added

For a PR:

1. Go to this repo
1. Create a branch with a change
1. Go to the Pull requests tab
1. Click New pull request
1. See boilerplate text

# Help requested

Would appreciate a reviewer to see if the text is clear and helpful in the templates.

# Unresolved questions

If these templates are acceptable, I'll merge and then get them translated into French.
