### PR TITLE
readme: Adds buttons and links for apps at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 ![Lint + Typscript](https://github.com/cds-snc/covid-alert-app/workflows/CI/badge.svg)
 
+*Available for iOS and Android:*
+
+<a href="https://apps.apple.com/ca/app/id1520284227"><img src="https://www.canada.ca/content/dam/phac-aspc/images/services/diseases-maladies/coronavirus-disease-covid-19/covid-alert/app-store-eng.png" alt="Download on the App Store"></a>
+<a href="https://play.google.com/store/apps/details?id=ca.gc.hcsc.canada.stopcovid"><img src="https://www.canada.ca/content/dam/phac-aspc/images/services/diseases-maladies/coronavirus-disease-covid-19/covid-alert/google-play-eng.png" alt="Get it on Google Play"></a>
+
+*Pour iOS et Android:*
+
+<a href="https://apps.apple.com/ca/app/id1520284227?l=fr"><img src="https://www.canada.ca/content/dam/phac-aspc/images/services/diseases-maladies/coronavirus-disease-covid-19/covid-alert/app-store-fra.png" alt="Télécharger dans l'App Store"></a>
+<a href="https://play.google.com/store/apps/details?id=ca.gc.hcsc.canada.stopcovid&hl=fr"><img src="https://www.canada.ca/content/dam/phac-aspc/images/services/diseases-maladies/coronavirus-disease-covid-19/covid-alert/google-play-fra.png" alt="Disponible sur Google Play"></a>
+
 Adapted from <https://github.com/CovidShield/mobile> ([upstream](https://github.com/cds-snc/covid-alert-app/blob/master/FORK.md))
 
 This repository implements a React Native _client application_ for Apple/Google's [Exposure


### PR DESCRIPTION
# Summary

I added buttons for the apps at the top of the README: 
* iOS and Android
* English and French

The images used are from [canada.ca](https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert.html).

Compare: #976.

# Test instructions

n/a

# Help requested

n/a

# Unresolved questions / Out of scope

n/a

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both official languages?
- [ ] Does this introduce any security concerns?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
