### PR TITLE
Replace prime marks with proper apostrophe marks

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -1,7 +1,7 @@
 {
   "Home": {
     "NoExposureDetected": {
-      "AllSetTitle": "You're all set",
+      "AllSetTitle": "You’re all set",
       "RegionCovered": {
         "Title": "No exposure detected",
         "Body": "You have not been near anyone who reported a COVID-19 diagnosis through this app.",
@@ -124,7 +124,7 @@
     },
     "NotificationCardStatus": "Notifications are off",
     "NotificationCardStatusOff": "OFF",
-    "NotificationCardBody": "You will not receive notifications if you've been near anyone who has reported a COVID-19 diagnosis. Finding out potential exposures right away is essential to slowing the spread of COVID-19.",
+    "NotificationCardBody": "You will not receive notifications if you’ve been near anyone who has reported a COVID-19 diagnosis. Finding out potential exposures right away is essential to slowing the spread of COVID-19.",
     "NotificationCardAction": "Turn on notifications",
     "ExposureNotificationCardStatus": "Exposure notifications are ",
     "ExposureNotificationCardBody": "COVID Alert cannot notify you as soon as it learns of a possible exposure. Finding out right away is essential to slowing the spread of COVID-19.",
@@ -174,7 +174,7 @@
     "step-3": "If someone with the app is diagnosed with COVID-19, they can choose to upload the random codes their phone sent. The codes go into a central server.\n\nThe server only gets the codes. It does not get any information about the person.",
     "step-4Title": "Looking for exposures",
     "step-4AltText": "A hand-drawn illustration of a mobile phone uploading a numeric code to a cloud.",
-    "step-4": "Every day, whenever it has an Internet connection, your phone will get a list of the random codes from people who reported a diagnosis.\n\nIf it finds codes that match, the app notifies you that you've been exposed and explains what to do next.",
+    "step-4": "Every day, whenever it has an Internet connection, your phone will get a list of the random codes from people who reported a diagnosis.\n\nIf it finds codes that match, the app notifies you that you’ve been exposed and explains what to do next.",
     "ActionBack": "Back",
     "ActionNext": "Next",
     "ActionEnd": "Done",
@@ -216,7 +216,7 @@
       "Body2": "It has **no way of knowing**:",
       "Bullet1": "Your location.",
       "Bullet2": "Your name or address.",
-      "Bullet3": "Your phone's contacts.",
+      "Bullet3": "Your phone’s contacts.",
       "Bullet4": "Your health information.",
       "Bullet5": "The health information of anyone you’re near."
     },
@@ -249,7 +249,7 @@
   },
   "ThankYou": {
     "Title": "Thank you for helping",
-    "Body": "Exposure notifications are on. You will receive a message if COVID Alert detects that you've been near someone who has reported a COVID-19 diagnosis.",
+    "Body": "Exposure notifications are on. You will receive a message if COVID Alert detects that you’ve been near someone who has reported a COVID-19 diagnosis.",
     "Dismiss": "Dismiss"
   },
   "DataUpload": {
@@ -320,7 +320,7 @@
     "ExposedMessageTitle": "You’ve been exposed",
     "ExposedMessageBody": "You’ve had close contact with someone who reported a COVID-19 diagnosis through the app. Learn more about what to do next.",
     "OffMessageTitle": "COVID Alert is off",
-    "OffMessageBody": "Turn on COVID Alert to get notified if you've been near someone who has reported a COVID-19 diagnosis.",
+    "OffMessageBody": "Turn on COVID Alert to get notified if you’ve been near someone who has reported a COVID-19 diagnosis.",
     "DailyUploadNotificationTitle": "Upload new random codes",
     "DailyUploadNotificationBody": "Help slow the spread of COVID-19 and upload your new random codes."
   },

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -12,7 +12,7 @@
   },
   "DataUpload": {
     "Cancel": "Annuler",
-    "InfoSmall": "Vos identifiants aléatoires ne seront pas partagés, à moins que vous donniez votre permission à l'étape suivante.",
+    "InfoSmall": "Vos identifiants aléatoires ne seront pas partagés, à moins que vous donniez votre permission à l’étape suivante.",
     "ShareToast": "Identifiants aléatoires partagés avec succès",
     "Step1": {
       "Title": "Aviser les autres personnes d’une exposition potentielle",
@@ -297,7 +297,7 @@
     },
     "EnterCodeCardTitle": "Vous avez la COVID-19?",
     "EnterCodeCardTitleDiagnosed": "Vous contribuez à freiner la COVID",
-    "ExposureNotificationCardAction": "Activez les notifications d'exposition",
+    "ExposureNotificationCardAction": "Activez les notifications d’exposition",
     "ExposureNotificationCardBody": "Alerte COVID ne peut pas vous aviser de la découverte d’une exposition potentielle. Le fait d’être notifié rapidement est essentiel pour ralentir la propagation de la COVID-19.",
     "ExposureNotificationCardStatus": "Les notifications d’exposition à la COVID-19 sont ",
     "NotificationCardAction": "Activer les notifications",
@@ -398,8 +398,8 @@
   "Sharing": {
     "Close": "Fermer",
     "InstagramImageUrl": "https://user-images.githubusercontent.com/5274722/84658989-b9ba6b00-aee4-11ea-84d4-d840527467b4.png",
-    "Message": "Joignez-vous à moi pour aider à ralentir la transmission de la COVID-19. Téléchargez l'application Alerte COVID : https://covidshield.app",
-    "More": "Plus d'applications",
+    "Message": "Joignez-vous à moi pour aider à ralentir la transmission de la COVID-19. Téléchargez l’application Alerte COVID : https://covidshield.app",
+    "More": "Plus d’applications",
     "Platform-instagram": "Partager avec Instagram",
     "Platform-messages": "Partager avec Messages",
     "SubTitle": "Chaque personne utilisant Alerte COVID aide à ralentir la transmission de la COVID-19. Partager cette application ne partage aucune donnée privée.",
@@ -408,7 +408,7 @@
   "ThankYou": {
     "Body": "Les notifications d’exposition sont activées. Si Alerte COVID détecte que vous avez possiblement été exposé(e) à la COVID-19, vous recevrez une notification.",
     "Dismiss": "OK",
-    "Title": "Merci d'aider"
+    "Title": "Merci d’aider"
   },
   "Tutorial": {
     "ActionBack": "Précédent",


### PR DESCRIPTION
# Summary

A few words in the English and French localizations use prime marks instead of apostrophes (e.g. `you're` instead of `you‘re`). This minor PR makes the copy consistently use apostrophes.

# Test instructions

These are just copy changes, so the normal build process should pull in the updated copy.

# Help requested

I don't actually know the purpose of `src/locale/translations/index.js`, so I didn’t update that file. I assumed it is generated during the build process, but if that’s not the case, it will need to be updated as well since it contains the same errors as `en.json` and `fr.json`.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
