### PR TITLE
use in-ecosystem URL for reachability, instead of leaking info to Google

### DIFF
--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -1,5 +1,6 @@
 import {Platform} from 'react-native';
 import Config from 'react-native-config';
+import NetInfo from '@react-native-community/netinfo';
 
 export const APP_ID = Platform.select({
   android: Config.APP_ID_ANDROID,
@@ -21,3 +22,11 @@ export const MCC_CODE = parseInt(Config.MCC_CODE, 10) || 302;
 export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 
 export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;
+
+NetInfo.configure({
+  reachabilityUrl: 'https://retrieval.covid-notification.alpha.canada.ca/exposure-configuration/present',
+  reachabilityTest: async (response) => response.status === 204,
+  reachabilityLongTimeout: 60 * 1000, // 60s
+  reachabilityShortTimeout: 5 * 1000, // 5s
+  reachabilityRequestTimeout: 15 * 1000, // 15s
+});

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -26,7 +26,7 @@ export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;
 NetInfo.configure({
   reachabilityUrl: 'https://retrieval.covid-notification.alpha.canada.ca/exposure-configuration/present',
   reachabilityTest: async response => response.status === 204,
-  reachabilityLongTimeout: 60 * 1000, // 60s
-  reachabilityShortTimeout: 5 * 1000, // 5s
-  reachabilityRequestTimeout: 15 * 1000, // 15s
+  reachabilityLongTimeout: 60 * 1000,
+  reachabilityShortTimeout: 5 * 1000,
+  reachabilityRequestTimeout: 15 * 1000,
 });

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -25,7 +25,7 @@ export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;
 
 NetInfo.configure({
   reachabilityUrl: 'https://retrieval.covid-notification.alpha.canada.ca/exposure-configuration/present',
-  reachabilityTest: async (response) => response.status === 204,
+  reachabilityTest: async response => response.status === 204,
   reachabilityLongTimeout: 60 * 1000, // 60s
   reachabilityShortTimeout: 5 * 1000, // 5s
   reachabilityRequestTimeout: 15 * 1000, // 15s


### PR DESCRIPTION
# Summary

The app leaks IP addresses to Google. This fixes it. Explanation in [issue](https://github.com/cds-snc/covid-alert-app/issues/1003).

# Test instructions

You'll need [this PR](https://github.com/cds-snc/covid-alert-server/pull/241) deployed before this can really be tested. Once ready, analyze traffic to be sure that no data is flowing to Google, and instead is staying local on `canada.ca`

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
