### PR TITLE
Add ENAPIVersion and ENDeveloperRegion properties for iOS 14 compatibility

### DIFF
--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -59,9 +59,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-  <key>ENDeveloperRegion</key>
-  <string>CA</string>
-  <key>ENAPIVersion</key>
-  <number>1</number>
+	<key>ENDeveloperRegion</key>
+	<string>CA</string>
+	<key>ENAPIVersion</key>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -59,5 +59,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+  <key>ENDeveloperRegion</key>
+  <string>CA</string>
+  <key>ENAPIVersion</key>
+  <number>1</number>
 </dict>
 </plist>


### PR DESCRIPTION
# Summary

This should fix iOS 14 compatibility. These new properties have been added and are required on iOS 14.

Related issues: #1001 #981 

Relevant documentation: https://developer.apple.com/documentation/exposurenotification

# Test instructions

We'll need to test this on an iPhone with iOS 14 Beta installed. Currently these devices are displaying an error on the Exposure Notification Settings screen.

# Help requested

Need somebody with iOS 14 installed to test.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
