### PR TITLE
Pass the 'attenuationDurationThresholds' into ENExposureConfiguration for iOS.

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -136,6 +136,10 @@ RCT_REMAP_METHOD(detectExposure, detectExposureWithConfiguration:(NSDictionary *
     configuration.minimumRiskScore = [configDict[@"minimumRiskScore"] intValue];
   }
   
+  if (configDict[@"attenuationDurationThresholds"]) {
+    configuration.attenuationDurationThresholds = mapIntValues(configDict[@"attenuationDurationThresholds"]);
+  }
+  
   if (configDict[@"attenuationLevelValues"]) {
     configuration.attenuationLevelValues = mapIntValues(configDict[@"attenuationLevelValues"]);
   }


### PR DESCRIPTION
# Summary

The 'attenuationDurationThresholds' property was not being passed from the server config into the ENExposureConfiguration. This means the framework would have been using the default values. This would have affected

# Test instructions


# Help requested

> Things that you (the submitter) want reviewers to pay very close attention to when they review this.

# Unresolved questions / Out of scope

> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both official languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
