### PR TITLE
Apply `attenuationDurationThresholds` only to iOS 13.6+.

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -136,8 +136,11 @@ RCT_REMAP_METHOD(detectExposure, detectExposureWithConfiguration:(NSDictionary *
     configuration.minimumRiskScore = [configDict[@"minimumRiskScore"] intValue];
   }
   
-  if (configDict[@"attenuationDurationThresholds"]) {
-    configuration.attenuationDurationThresholds = mapIntValues(configDict[@"attenuationDurationThresholds"]);
+  // `attenuationDurationThresholds` are only a part of the configuration in iOS 13.6+.
+  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 13.6) {
+    if (configDict[@"attenuationDurationThresholds"]) {
+      configuration.attenuationDurationThresholds = mapIntValues(configDict[@"attenuationDurationThresholds"]);
+    }
   }
   
   if (configDict[@"attenuationLevelValues"]) {


### PR DESCRIPTION
# Summary

The `attenuationDurationThresholds` was introduced to the framework in 13.6+ and as a result needs to to be excluded.

# Test instructions

Running the app on iOS 13.5 - 13.5.2 should not result in a runtime error when trying to set the `attenuationDurationThresholds`.

# Help requested

> Things that you (the submitter) want reviewers to pay very close attention to when they review this.

# Unresolved questions / Out of scope

> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
