### PR TITLE
Add `attenuationDurationThresholds` to iOS < 13.6 via metadata.

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -136,10 +136,11 @@ RCT_REMAP_METHOD(detectExposure, detectExposureWithConfiguration:(NSDictionary *
     configuration.minimumRiskScore = [configDict[@"minimumRiskScore"] intValue];
   }
   
-  // `attenuationDurationThresholds` are only a part of the configuration in iOS 13.6+.
-  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 13.6) {
-    if (configDict[@"attenuationDurationThresholds"]) {
+  if (configDict[@"attenuationDurationThresholds"]) {
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 13.6) {
       configuration.attenuationDurationThresholds = mapIntValues(configDict[@"attenuationDurationThresholds"]);
+    } else {
+      configuration.metadata = @{@"attenuationDurationThresholds": mapIntValues(configDict[@"attenuationDurationThresholds"])};
     }
   }
   


### PR DESCRIPTION
# Summary

iOS changed the way that `attenuationDurationThresholds` was added to ENExposureConfiguration. In iOS 13.5.x, it was added via the "metadata" property.

# Test instructions

Run this on iOS 13.5.x and 13.6 to ensure it doesn't crash. 

# Help requested

> Things that you (the submitter) want reviewers to pay very close attention to when they review this.

# Unresolved questions / Out of scope

> Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [x] Have you tested it?
   I have tested this on iOS 13.5.1

- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
