### PR TITLE
Add `attenuationDurationThresholds` to iOS < 13.6 via metadata.

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -136,10 +136,11 @@ RCT_REMAP_METHOD(detectExposure, detectExposureWithConfiguration:(NSDictionary *
     configuration.minimumRiskScore = [configDict[@"minimumRiskScore"] intValue];
   }
   
-  // `attenuationDurationThresholds` are only a part of the configuration in iOS 13.6+.
-  if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 13.6) {
-    if (configDict[@"attenuationDurationThresholds"]) {
+  if (configDict[@"attenuationDurationThresholds"]) {
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 13.6) {
       configuration.attenuationDurationThresholds = mapIntValues(configDict[@"attenuationDurationThresholds"]);
+    } else {
+      configuration.metadata = @{@"attenuationDurationThresholds": mapIntValues(configDict[@"attenuationDurationThresholds"])};
     }
   }
   


### PR DESCRIPTION
# Summary

Pulls in attenuationDurationThresholds change to support iOS < 13.6 #1017 