### PR TITLE
Remove text about location permissions

### DIFF
--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -42,19 +42,6 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
           onPress={onPress}
         />
       </Box>
-      {Platform.OS === 'android' ? (
-        <Box marginBottom="xl">
-          <Text marginBottom="m" variant="bodySubTitle">
-            {i18n.translate('Home.EnDisabled.AndroidTitle2')}
-          </Text>
-          <Text marginBottom="m">{i18n.translate('Home.EnDisabled.AndroidBody1')}</Text>
-          <Text marginBottom="xl">
-            <Text>{i18n.translate('Home.EnDisabled.AndroidBody2a')}</Text>
-            <Text fontWeight="bold">{i18n.translate('Home.EnDisabled.AndroidBody2b')}</Text>
-            <Text>{i18n.translate('Home.EnDisabled.AndroidBody2c')}</Text>
-          </Text>
-        </Box>
-      ) : null}
     </BaseHomeView>
   );
 };


### PR DESCRIPTION
Remove Android only text that explains to user a perculiar situation with the location permissions, which is no longer true.

The application does NOT request the `ACCESS_COARSE_LOCATION` permission anymore.

This is in line with the API documentation: https://developers.google.com/android/exposure-notifications/exposure-notifications-api

Hence the block no longer applies.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
