### PR TITLE
Add initialNumToRender to Carousel

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -89,6 +89,7 @@ export const OnboardingScreen = () => {
             onSnapToItem={onSnapToItem}
             importantForAccessibility="no"
             accessible={false}
+            initialNumToRender={1}
           />
         </View>
         <Box flexDirection="row" borderTopWidth={2} borderTopColor="gray5">


### PR DESCRIPTION
# Summary

This PR sets `initialNumToRender` prop of the onboarding Carousel to `1`. This change will improve the performance and the feel of the transition from the language selection screen to onboarding by initially loading the first page and load the reset of the pages after the transition.

Before/after demo:


![covid](https://user-images.githubusercontent.com/5301577/89741712-95e95080-da61-11ea-8184-3aabf6f84a3f.gif)


# Test instructions

- Clear Data
- Go through the onboarding flow
- The transition from _language selection_ to _onboarding carousel_ should be smoother and everything else stay be the same.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [x] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
