### PR TITLE
Test Menu and Logging

### DIFF
--- a/src/bridge/CovidShield.ts
+++ b/src/bridge/CovidShield.ts
@@ -14,10 +14,6 @@ export interface CovidShieldBridge {
 
 export const downloadDiagnosisKeysFile = CovidShieldBridgeBare.downloadDiagnosisKeysFile;
 
-export const getRandomString = async (size: number) => {
-  return CovidShieldBridgeBare.getRandomBytes(size);
-};
-
 export const getRandomBytes = async (size: number) => {
   const base64encoded = await CovidShieldBridgeBare.getRandomBytes(size);
   return Buffer.from(base64encoded, 'base64');

--- a/src/bridge/CovidShield.ts
+++ b/src/bridge/CovidShield.ts
@@ -1,6 +1,6 @@
-import { Buffer } from 'buffer';
+import {Buffer} from 'buffer';
 
-import { NativeModules } from 'react-native';
+import {NativeModules} from 'react-native';
 
 const CovidShieldBridgeBare = NativeModules.CovidShield as {
   downloadDiagnosisKeysFile(url: string): Promise<string>;

--- a/src/bridge/CovidShield.ts
+++ b/src/bridge/CovidShield.ts
@@ -1,6 +1,6 @@
-import {Buffer} from 'buffer';
+import { Buffer } from 'buffer';
 
-import {NativeModules} from 'react-native';
+import { NativeModules } from 'react-native';
 
 const CovidShieldBridgeBare = NativeModules.CovidShield as {
   downloadDiagnosisKeysFile(url: string): Promise<string>;
@@ -13,6 +13,10 @@ export interface CovidShieldBridge {
 }
 
 export const downloadDiagnosisKeysFile = CovidShieldBridgeBare.downloadDiagnosisKeysFile;
+
+export const getRandomString = async (size: number) => {
+  return CovidShieldBridgeBare.getRandomBytes(size);
+};
 
 export const getRandomBytes = async (size: number) => {
   const base64encoded = await CovidShieldBridgeBare.getRandomBytes(size);

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,21 +1,43 @@
-export const captureMessage = async (message: string, params: {[key in string]: any} = {}) => {
-  // force return for production
-  return;
+import AsyncStorage from '@react-native-community/async-storage';
+import { getRandomString } from 'bridge/CovidShield';
 
-  const finalMessage = message;
-  const finalParams = params;
+let sentryEnabled = false;
 
-  if (!__DEV__) {
-    return;
-  }
-  console.log(finalMessage, finalParams); // eslint-disable-line no-console
+const UUID_KEY = 'UUID_KEY';
+
+const cachedUUID = AsyncStorage.getItem(UUID_KEY)
+  .then(uuid => uuid || getRandomString(8))
+  .then(uuid => {
+    AsyncStorage.setItem(UUID_KEY, uuid);
+    return uuid;
+  })
+  .catch(() => null);
+
+let currentUUID = '';
+
+export const setLogUUID = (uuid: string) => {
+  currentUUID = uuid;
+  AsyncStorage.setItem(UUID_KEY, uuid);
 };
 
-export const captureException = async (message: string, error: any, params: {[key in string]: any} = {}) => {
-  // force return for production
-  return;
+export const getLogUUID = async () => {
+  return currentUUID || (await cachedUUID) || 'unset';
+};
 
-  const finalMessage = `Error: ${message}`;
+export const captureMessage = async (message: string, params: { [key in string]: any } = {}) => {
+  const uuid = await getLogUUID();
+  const finalMessage = `[${uuid}] ${message}`.replace(/\n/g, '');
+  const finalParams = params;
+
+  if (__DEV__) {
+    console.log(finalMessage, finalParams); // eslint-disable-line no-console
+  }
+};
+
+export const captureException = async (message: string, error: any, params: { [key in string]: any } = {}) => {
+  const uuid = await getLogUUID();
+  const finalMessage = `[${uuid}] Error: ${message}`.replace(/\n/g, '');
+
   const finalParams = {
     ...params,
     error: {
@@ -23,8 +45,8 @@ export const captureException = async (message: string, error: any, params: {[ke
       error,
     },
   };
-  if (!__DEV__) {
-    return;
+
+  if (__DEV__) {
+    console.log(finalMessage, finalParams); // eslint-disable-line no-console
   }
-  console.log(finalMessage, finalParams); // eslint-disable-line no-console
 };

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -27,12 +27,16 @@ export const getLogUUID = async () => {
   return currentUUID || (await cachedUUID) || 'unset';
 };
 
+const isTest = () => {
+  return process.env.JEST_WORKER_ID !== undefined;
+};
+
 export const captureMessage = async (message: string, params: {[key in string]: any} = {}) => {
   const uuid = await getLogUUID();
   const finalMessage = `[${uuid}] ${message}`.replace(/\n/g, '');
   const finalParams = params;
 
-  if (__DEV__) {
+  if (__DEV__ && !isTest()) {
     console.log(finalMessage, finalParams); // eslint-disable-line no-console
   }
 };
@@ -49,7 +53,7 @@ export const captureException = async (message: string, error: any, params: {[ke
     },
   };
 
-  if (__DEV__) {
+  if (__DEV__ && !isTest()) {
     console.log(finalMessage, finalParams); // eslint-disable-line no-console
   }
 };

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,7 +1,12 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import {getRandomString} from 'bridge/CovidShield';
 
 const UUID_KEY = 'UUID_KEY';
+
+const getRandomString = (size: number) => {
+  const chars = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'];
+
+  return [...Array(size)].map(_ => chars[(Math.random() * chars.length) | 0]).join('');
+};
 
 const cachedUUID = AsyncStorage.getItem(UUID_KEY)
   .then(uuid => uuid || getRandomString(8))

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,7 +1,5 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import { getRandomString } from 'bridge/CovidShield';
-
-let sentryEnabled = false;
+import {getRandomString} from 'bridge/CovidShield';
 
 const UUID_KEY = 'UUID_KEY';
 
@@ -24,7 +22,7 @@ export const getLogUUID = async () => {
   return currentUUID || (await cachedUUID) || 'unset';
 };
 
-export const captureMessage = async (message: string, params: { [key in string]: any } = {}) => {
+export const captureMessage = async (message: string, params: {[key in string]: any} = {}) => {
   const uuid = await getLogUUID();
   const finalMessage = `[${uuid}] ${message}`.replace(/\n/g, '');
   const finalParams = params;
@@ -34,7 +32,7 @@ export const captureMessage = async (message: string, params: { [key in string]:
   }
 };
 
-export const captureException = async (message: string, error: any, params: { [key in string]: any } = {}) => {
+export const captureException = async (message: string, error: any, params: {[key in string]: any} = {}) => {
   const uuid = await getLogUUID();
   const finalMessage = `[${uuid}] Error: ${message}`.replace(/\n/g, '');
 

--- a/src/testMode/DemoMode.tsx
+++ b/src/testMode/DemoMode.tsx
@@ -1,32 +1,32 @@
-import React, { useCallback, useMemo, useState, useEffect } from 'react';
-import { TextInput, StyleSheet } from 'react-native';
-import { createDrawerNavigator, DrawerContentScrollView } from '@react-navigation/drawer';
-import { createStackNavigator } from '@react-navigation/stack';
-import { useI18n } from 'locale';
+import React, {useCallback, useMemo, useState, useEffect} from 'react';
+import {TextInput, StyleSheet} from 'react-native';
+import {createDrawerNavigator, DrawerContentScrollView} from '@react-navigation/drawer';
+import {createStackNavigator} from '@react-navigation/stack';
+import {useI18n} from 'locale';
 import PushNotification from 'bridge/PushNotification';
-import { Box, Button, LanguageToggle, Text } from 'components';
-import { useStorage } from 'services/StorageService';
+import {Box, Button, LanguageToggle, Text} from 'components';
+import {useStorage} from 'services/StorageService';
 import {
   useExposureNotificationService,
   useExposureStatus,
   useReportDiagnosis,
 } from 'services/ExposureNotificationService';
-import { APP_VERSION_NAME, APP_VERSION_CODE } from 'env';
-import { setLogUUID, getLogUUID, captureMessage } from 'shared/log';
+import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
+import {setLogUUID, getLogUUID, captureMessage} from 'shared/log';
 
-import { RadioButton } from './components/RadioButtons';
-import { MockProvider } from './MockProvider';
-import { Item } from './views/Item';
-import { Section } from './views/Section';
+import {RadioButton} from './components/RadioButtons';
+import {MockProvider} from './MockProvider';
+import {Item} from './views/Item';
+import {Section} from './views/Section';
 
 const Drawer = createDrawerNavigator();
 
 const ScreenRadioSelector = () => {
-  const { forceScreen, setForceScreen } = useStorage();
+  const {forceScreen, setForceScreen} = useStorage();
   const screenData = [
-    { displayName: 'None', value: 'None' },
-    { displayName: 'Exposed', value: 'ExposureView' },
-    { displayName: 'Diagnosed Share Data', value: 'DiagnosedShareView' },
+    {displayName: 'None', value: 'None'},
+    {displayName: 'Exposed', value: 'ExposureView'},
+    {displayName: 'Diagnosed Share Data', value: 'DiagnosedShareView'},
   ];
   return (
     <Box
@@ -52,10 +52,10 @@ const ScreenRadioSelector = () => {
 };
 
 const SkipAllSetRadioSelector = () => {
-  const { skipAllSet, setSkipAllSet } = useStorage();
+  const {skipAllSet, setSkipAllSet} = useStorage();
   const screenData = [
-    { displayName: 'False', value: 'false' },
-    { displayName: 'True', value: 'true' },
+    {displayName: 'False', value: 'false'},
+    {displayName: 'True', value: 'true'},
   ];
 
   return (
@@ -86,7 +86,7 @@ const SkipAllSetRadioSelector = () => {
 const DrawerContent = () => {
   const i18n = useI18n();
 
-  const { reset } = useStorage();
+  const {reset} = useStorage();
 
   const onShowSampleNotification = useCallback(() => {
     PushNotification.presentLocalNotification({
@@ -98,7 +98,7 @@ const DrawerContent = () => {
   const exposureNotificationService = useExposureNotificationService();
   const [, updateExposureStatus] = useExposureStatus();
 
-  const { fetchAndSubmitKeys } = useReportDiagnosis();
+  const {fetchAndSubmitKeys} = useReportDiagnosis();
 
   const [UUID, setUUID] = useState('');
   const onApplyUUID = useCallback(() => {
@@ -154,7 +154,7 @@ const DrawerContent = () => {
             onPress={async () => {
               captureMessage('Forcing refresh...');
               exposureNotificationService.exposureStatusUpdatePromise = null;
-              exposureNotificationService.exposureStatus.set({ type: 'monitoring' });
+              exposureNotificationService.exposureStatus.set({type: 'monitoring'});
               updateExposureStatus();
             }}
           />
@@ -179,7 +179,7 @@ export interface DemoModeProps {
   children?: React.ReactElement;
 }
 
-export const DemoMode = ({ children }: DemoModeProps) => {
+export const DemoMode = ({children}: DemoModeProps) => {
   const drawerContent = useCallback(() => <DrawerContent />, []);
   const Component = useMemo(() => {
     const Component = () => {
@@ -198,7 +198,7 @@ export const DemoMode = ({ children }: DemoModeProps) => {
 
   return (
     <MockProvider>
-      <DemoStack.Navigator screenOptions={{ headerShown: false }} initialRouteName="Demo">
+      <DemoStack.Navigator screenOptions={{headerShown: false}} initialRouteName="Demo">
         <DemoStack.Screen name="Demo" component={Screen} />
       </DemoStack.Navigator>
     </MockProvider>


### PR DESCRIPTION
# Summary

Split these changes out from the previous Sentry PR. Adds UUID and Version information to the Test Menu, and sets up basic console logging with UUID reference when working in DEV mode. Future PR will add the ability to send these logs somewhere.

# Test instructions

Run in emulator or on device in Debug mode with Test Menu enabled. You should see the UUID field/property on the Test Menu, and you should see the version information at the bottom. 

You should also see console logs in Xcode prefixed with the UUID set in the TestMenu. This will be more useful later on.
