### PR TITLE
Add an e2e test for one time code entry

### DIFF
--- a/e2e/oneTimeCode.e2e.js
+++ b/e2e/oneTimeCode.e2e.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-undef */
+import {onboard} from './shared';
+
+describe('Test one time code flow', () => {
+  it('can get to the one time code screen', async () => {
+    await onboard();
+    await element(by.id('tapPromptCollapsed')).tap();
+    await device.takeScreenshot('BottomSheet');
+    await element(by.text('Enter your one-time key')).tap();
+    await device.takeScreenshot('OTC-Step1');
+    await element(by.text('Next')).tap();
+    await device.takeScreenshot('OTC-Step2');
+    await element(by.id('textInput')).tap();
+    await device.takeScreenshot('OTC-Step2-focussed');
+    await element(by.id('textInput')).typeText('ABC123ABCD');
+    await element(by.text('Submit')).tap();
+    await device.takeScreenshot('OTC-Step2-error');
+    await expect(element(by.text('Try again later'))).toBeVisible();
+  });
+});

--- a/e2e/province.e2e.js
+++ b/e2e/province.e2e.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef */
-import {setDemoMode} from './shared';
+import {onboard} from './shared';
 
 const changeRegion = async region => {
   // should be called from the home screen
@@ -20,20 +20,9 @@ const changeScreen = async screenName => {
   await element(by.id(screenName)).swipe('right');
 };
 
-const NUM_ONBOARDING_SCREENS = 6;
 describe('Test province flow', () => {
-  it('pass through onboarding flow', async () => {
-    await device.launchApp({permissions: {notifications: 'YES'}});
-    await expect(element(by.id('enButton'))).toBeVisible();
-    await element(by.id('enButton')).tap();
-    setDemoMode();
-    for (let i = 1; i <= NUM_ONBOARDING_SCREENS; i++) {
-      await expect(element(by.id('onboardingNextButton'))).toBeVisible();
-      await element(by.id('onboardingNextButton')).tap();
-    }
-  });
-
   it('lands on the right home screen', async () => {
+    await onboard();
     // eslint-disable-next-line jest/no-if
     if (device.getPlatform() === 'android') {
       await expect(element(by.id('exposureNotificationsDisabled'))).toBeVisible();

--- a/e2e/shared.js
+++ b/e2e/shared.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-undef */
 const execSync = require('child_process').execSync;
 
+const NUM_ONBOARDING_SCREENS = 6;
+
 export const setDemoMode = () => {
   if (device.getPlatform() === 'ios') {
     execSync(
@@ -19,5 +21,16 @@ export const setDemoMode = () => {
     execSync('adb shell am broadcast -a com.android.systemui.demo -e command notifications -e visible false');
     // Show full battery but not in charging state
     execSync('adb shell am broadcast -a com.android.systemui.demo -e command battery -e plugged false -e level 100');
+  }
+};
+
+export const onboard = async () => {
+  await device.launchApp({permissions: {notifications: 'YES'}});
+  await expect(element(by.id('enButton'))).toBeVisible();
+  await element(by.id('enButton')).tap();
+  setDemoMode();
+  for (let i = 1; i <= NUM_ONBOARDING_SCREENS; i++) {
+    await expect(element(by.id('onboardingNextButton'))).toBeVisible();
+    await element(by.id('onboardingNextButton')).tap();
   }
 };

--- a/src/components/CodeInput.tsx
+++ b/src/components/CodeInput.tsx
@@ -47,6 +47,7 @@ export const CodeInput = ({value, onChange, accessibilityLabel}: CodeInputProps)
             autoCapitalize="characters"
             fontFamily="Menlo"
             letterSpacing={5}
+            testID="textInput"
           />
         </Box>
       </Box>


### PR DESCRIPTION
- move the "quick" version of onboarding to shared.js so it can be used in other tests
- go as far as possible (without mocking) into the OTC flow, taking screenshots along the way
