### PR TITLE
Add `ENStatusPaused` to switch statement.

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -68,8 +68,6 @@ RCT_REMAP_METHOD(stop, stopWithResolver:(RCTPromiseResolveBlock)resolve rejecter
 RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   switch (self.enManager.exposureNotificationStatus) {
-    case ENStatusUnknown: resolve(@"unknown");
-      break;
     case ENStatusActive: resolve(@"active");
       break;
     case ENStatusDisabled: resolve(@"disabled");
@@ -77,6 +75,12 @@ RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolv
     case ENStatusBluetoothOff: resolve(@"bluetooth_off");
       break;
     case ENStatusRestricted: resolve(@"restricted");
+      break;
+    case ENStatusPaused: resolve(@"paused");
+      break;
+    case ENStatusUnknown:
+    default:
+      resolve(@"unknown");
       break;
   }
 }

--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -76,8 +76,7 @@ RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolv
       break;
     case ENStatusRestricted: resolve(@"restricted");
       break;
-    case ENStatusPaused: resolve(@"paused");
-      break;
+    case ENStatusPaused:
     case ENStatusUnknown:
     default:
       resolve(@"unknown");

--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -67,6 +67,7 @@ RCT_REMAP_METHOD(stop, stopWithResolver:(RCTPromiseResolveBlock)resolve rejecter
 
 RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
+  // TODO: return a more meaningful status for 'ENStatusPaused' when it's known how to pause the EN framework.
   switch (self.enManager.exposureNotificationStatus) {
     case ENStatusActive: resolve(@"active");
       break;


### PR DESCRIPTION
# Summary

Adding `ENStatusPaused` to switch statement.
Adding `default` case to switch statement, to ensure a value is always returned. Default value returned is `unknown`.
Closes #1049 

# Unresolved questions / Out of scope

I have been unable to test the `paused` status, since it is not known how to pause **Exposure Notification** on the phone.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
