### PR TITLE
Fix iOS build warnings.

### DIFF
--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -30,7 +30,7 @@ static void InitializeFlipper(UIApplication *application) {
 }
 #endif
 
-static void patchBGTaskSubmission();
+static void patchBGTaskSubmission(void);
 
 @implementation AppDelegate
 


### PR DESCRIPTION
# Summary

Removing iOS build warnings. Treating all warnings as errors, addressing each warning individually.

- **Fixing function declaration.** `void` was not added to the function declaration, so the function could have been called with a property.