### PR TITLE
Translates GitHub Templates to French

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,16 +8,32 @@ assignees: ""
 
 # Summary | Résumé
 
-> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing). Screenshots are greatly helpful here too. | Description du bogue en un paragraphe, incluant la raison pour laquelle il s’agit d’un problème (qu’est-ce que l’utilisateur n’est pas en mesure d’accomplir?). Les captures d’écran sont très utiles.
+> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing). Screenshots are greatly helpful here too.
+
+---
+
+> Description du bogue en un paragraphe, incluant la raison pour laquelle il s’agit d’un problème (qu’est-ce que l’utilisateur n’est pas en mesure d’accomplir?). Les captures d’écran sont très utiles.
 
 # Steps to reproduce | Étapes à reproduire
 
-> Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it. | Étapes consécutives (1., 2., 3., …) qui décrivent la façon de reproduire le bogue. Elles aideront les développeurs à voir ce que l’utilisateur a vu pour mieux corriger le bogue.
+> Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it.
+
+---
+
+> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de reproduire le bogue. Elles aideront les développeurs à voir ce que l’utilisateur a vu pour mieux corriger le bogue.
 
 # Environment | Environnement logiciel
 
-> What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant. | Type d’appareil sur lequel le bogue est survenu. Cela comprend le modèle de l’appareil, la version du système d’exploitation (sur iOS ou Android), et toute autre précision sur l’environnement logiciel qui peut être pertinente.
+> What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant.
+
+---
+
+> Type d’appareil sur lequel le bogue est survenu. Cela comprend le modèle de l’appareil, la version du système d’exploitation (sur iOS ou Android), et toute autre précision sur l’environnement logiciel qui peut être pertinente.
 
 # Unresolved questions / Out of scope | Questions non résolues ou hors sujet
 
-> Are there any related issues you consider out of scope for this issue that could be addressed in the future? | Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?
+> Are there any related issues you consider out of scope for this issue that could be addressed in the future?
+
+---
+
+> Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,23 +1,23 @@
 ---
-name: Bug
-about: Problems or flaws experienced in the app. Includes accessibility issues.
-title: Bug
+name: Bug | Bogue
+about: Problems or flaws experienced in the app. Includes accessibility issues. | Problèmes ou défaillances dans l’application. Peut comprendre les problèmes d’accessibilité.
+title: Bug | Bogue
 labels: bug, inbox
 assignees: ""
 ---
 
-# Summary
+# Summary | Résumé
 
-> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing). Screenshots are greatly helpful here too.
+> One paragraph explanation of the bug, including why it is a problem (i.e. what does it prevent a user from doing or accomplishing). Screenshots are greatly helpful here too. | Description du bogue en un paragraphe, incluant la raison pour laquelle il s’agit d’un problème (qu’est-ce que l’utilisateur n’est pas en mesure d’accomplir?). Les captures d’écran sont très utiles.
 
-# Steps to reproduce
+# Steps to reproduce | Étapes à reproduire
 
-> Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it.
+> Sequential steps (1., 2., 3., ...) that describe how to reproduce the bug. This will help a developer experience what the user experienced so that they can debug it. | Étapes consécutives (1., 2., 3., …) qui décrivent la façon de reproduire le bogue. Elles aideront les développeurs à voir ce que l’utilisateur a vu pour mieux corriger le bogue.
 
-# Environment
+# Environment | Environnement logiciel
 
-> What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant.
+> What kind of device was the bug experienced with. This would include device, version of the operating system (i.e. iOS or Android), and any other environmental details that might be relevant. | Type d’appareil sur lequel le bogue est survenu. Cela comprend le modèle de l’appareil, la version du système d’exploitation (sur iOS ou Android), et toute autre précision sur l’environnement logiciel qui peut être pertinente.
 
-# Unresolved questions / Out of scope
+# Unresolved questions / Out of scope | Questions non résolues ou hors sujet
 
-> Are there any related issues you consider out of scope for this issue that could be addressed in the future?
+> Are there any related issues you consider out of scope for this issue that could be addressed in the future? | Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,23 +1,35 @@
 ---
-name: Feature request
-about: Request a new feature, propose changes to an existing feature, or make a suggestion.
-title: Request new feature
+name: Feature request | Demande liée aux fonctionnalités
+about: Request a new feature, propose changes to an existing feature, or make a suggestion. | Demander une nouvelle fonctionnalité, proposer des modifications à une fonctionnalité existante ou faire une suggestion.
+title: Request new feature | Demander une nouvelle fonctionnalité
 labels: enhancement, inbox
 assignees: ""
 ---
 
-# Summary
+# Summary | Résumé
 
-> One paragraph explanation of the change. Ideally, this includes a statement in the following format: "As a (kind of user or stakeholder), I want (what feature) because (it does helps the user achieve or do what)."
+> One paragraph explanation of the change. Ideally, this includes a statement in the following format: "As a (kind of user or stakeholder), I want (what feature) because (it does helps the user achieve or do what)." An example for having a dark mode might look like: "As a user, I want a dark mode so that the app doesn't hurt my eyes."
 
-> An example for having a dark mode might look like: "As a user, I want a dark mode so that the app doesn't hurt my eyes."
+---
 
-# Design detail
+> Description de la modification en un paragraphe. Idéalement, elle devrait comprendre un énoncé dans le format suivant : « En tant que [type d’utilisateur ou d’intervenant], je veux [telle fonctionnalité] parce que [cela permettra à l’utilisateur de faire ou d’accomplir telle chose]. » Voici à quoi pourrait ressembler un exemple pour un mode sombre : « En tant qu’utilisateur, je veux un mode sombre pour que l’application ne me fasse pas mal aux yeux. »
+
+# Design detail | Précisions au sujet de la conception
 
 > Explain the design in enough detail for somebody familiar with the application to understand. This should get into specifics and corner-cases, and include examples of how the service is used. Any new terminology should be defined here. It is greatly appreciated if you have any design images or mockups that would be help clarify your idea.
 
 > Following the example of a dark mode feature request, you might describe that text is light, backgrounds are dark, and images have sufficient contrast with the dark backgrounds.
 
-# Unresolved questions / Out of scope
+---
+
+> Expliquez la conception avec suffisamment de détails pour qu’une personne familière avec l’application puisse comprendre. Vous devriez entrer dans les détails et aborder les cas sortant du fonctionnement normal des paramètres (les « corner cases »), et fournir des exemples d’utilisation du service. Toute nouvelle terminologie doit être définie. Toute image ou maquette conceptuelle pouvant aider à clarifier votre idée sera très appréciée.
+
+> Pour reprendre l’exemple de la demande d’un mode sombre, vous pourriez avancer que le texte est pâle, que l’arrière-plan est foncé et que les images ont un contraste suffisant par rapport aux arrière-plans foncés.
+
+# Unresolved questions / Out of scope | Questions non résolues ou hors sujet
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?
+
+---
+
+> Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,34 +1,52 @@
-# Summary
+# Summary | Résumé
 
 > 1-3 sentence description of the changed you're proposing, including a link to a GitHub Issue # or Trello card if applicable.
 
-# Test instructions
+---
+
+> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le problème (« issue ») GitHub ou la fiche Trello, le cas échéant.
+
+# Test instructions | Instructions pour tester la modification
 
 > Sequential steps (1., 2., 3., ...) that describe how to test this change. This will help a developer test things out without too much detective work. Also, include any environmental setup steps that aren't in the normal README steps and/or any time-based elements that this requires.
 
-# Help requested
+---
+
+> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la modification. Elles aideront les développeurs à faire des tests sans avoir à jouer au détective. Veuillez aussi inclure toutes les étapes de configuration de l’environnement qui ne font pas partie des étapes normales dans le fichier README et tout élément temporel requis.
+
+# Help requested | Aide requise
 
 > Things that you (the submitter) want reviewers to pay very close attention to when they review this.
 
-# Unresolved questions / Out of scope
+---
+
+> Éléments auxquels vous (le demandeur) souhaitez que les réviseurs prêtent attention lorsqu’ils examineront votre demande.
+
+# Unresolved questions / Out of scope | Questions non résolues ou hors sujet
 
 > Are there any related issues or tangent features you consider out of scope for this issue that could be addressed in the future?
 
-# Reviewer checklist
+---
 
-This is a suggested checklist of questions reviewers might ask during their review:
+> Y a-t-il des questions connexes que vous considérez hors sujet et qui pourraient être abordées plus tard?
 
-- [ ] Does this meet a user need?
-- [ ] Is it accessible?
-- [ ] Is it translated between both offical languages?
-- [ ] Is the code maintainable?
-- [ ] Have you tested it?
-- [ ] Are there automated tests?
-- [ ] Does this cause automated test coverage to drop?
-- [ ] Does this break existing functionality?
-- [ ] Should this be split into smaller PRs to decrease change risk?
-- [ ] Does this change the privacy policy?
-- [ ] Does this introduce any security concerns?
-- [ ] Does this significantly alter performance?
-- [ ] What is the risk level of using added dependencies?
-- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
+# Reviewer checklist | Liste de vérification du réviseur
+
+This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :
+
+
+- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
+- [ ] Is it accessible? | Est-ce que c’est accessible?
+- [ ] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
+- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
+- [ ] Have you tested it? | L’avez-vous testé?
+- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
+- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
+- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
+- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
+- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
+- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
+- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
+- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
+- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?
+


### PR DESCRIPTION
# Summary

Translates GitHub templates to French.

# Test instructions

Doesn't touch the application, but does modify templates in GitHub. Can't test until merge, but even if broken, doesn't stop the team from moving forward.

# Help requested

How does this look?

# Unresolved questions / Out of scope

No, but will re-use this template as a default for CDS repos going forward.

# Reviewer checklist

This is a suggested checklist of questions reviewers might ask during their review:

- [ ] Does this meet a user need?
- [ ] Is it accessible?
- [ ] Is it translated between both offical languages?
- [ ] Is the code maintainable?
- [ ] Have you tested it?
- [ ] Are there automated tests?
- [ ] Does this cause automated test coverage to drop?
- [ ] Does this break existing functionality?
- [ ] Should this be split into smaller PRs to decrease change risk?
- [ ] Does this change the privacy policy?
- [ ] Does this introduce any security concerns?
- [ ] Does this significantly alter performance?
- [ ] What is the risk level of using added dependencies?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.)
