### PR TITLE
Package bump - react-native-safe-area-context

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-native-markdown-display": "^6.1.0",
     "react-native-permissions": "^2.1.4",
     "react-native-reanimated": "^1.8.0",
-    "react-native-safe-area-context": "^3.1.1",
+    "react-native-safe-area-context": "^3.1.6",
     "react-native-screens": "^2.7.0",
     "react-native-secure-key-store": "^2.0.7",
     "react-native-snap-carousel": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7592,10 +7592,10 @@ react-native-reanimated@^1.8.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.1.tgz#9b04d1154766e6c1132030aca8f4b0336f561ccd"
-  integrity sha512-Iqb41OT5+QxFn0tpTbbHgz8+3VU/F9OH2fTeeoU7oZCzojOXQbC6sp6mN7BlsAoTKhngWoJLMcSosL58uRaLWQ==
+react-native-safe-area-context@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.6.tgz#4be329c71f33cac8ac56ddb2fe7a42ac509397ea"
+  integrity sha512-sAlVejR1cE3WhlYcMhHPB9E32bDyOUxs4Ew2kc4ZReztzlHh1wK1wmiJpvBWXsdFer2bbfQwfq+ZWkHJYQKZvA==
 
 react-native-screens@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
Bumps react-native-safe-area-context

The update is in [v3.1.5](https://github.com/th3rdwave/react-native-safe-area-context/releases/tag/v3.1.5) 

ANR report from Play Console
```
- waiting on <0x0274eaf1> (a java.util.concurrent.atomic.AtomicBoolean)
  at java.lang.Object.wait (Object.java:422)
  at com.th3rdwave.safeareacontext.SafeAreaView.waitForReactLayout (SafeAreaView.java:83)
- locked <0x0274eaf1> (a java.util.concurrent.atomic.AtomicBoolean)
  at com.th3rdwave.safeareacontext.SafeAreaView.updateInsets (SafeAreaView.java:54)
  at com.th3rdwave.safeareacontext.SafeAreaView.maybeUpdateInsets (SafeAreaView.java:113)
  at com.th3rdwave.safeareacontext.SafeAreaView.onAttachedToWindow (SafeAreaView.java:137)
```

**Details here:** 
https://github.com/cds-snc/covid-alert-app/pull/992#issuecomment-676576325


@smcmurtry not sure if you can re-create that error consistently on your older device but maybe you could try testing this. 