### PR TITLE
Issue/875/integer type mismatch

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -201,42 +201,5 @@ RCT_REMAP_METHOD(detectExposure, detectExposureWithConfiguration:(NSDictionary *
   }];
 }
 
-RCT_REMAP_METHOD(getExposureInformation,getExposureInformationForSummary:(NSDictionary *)summaryDict withUserExplanation: (NSString *)userExplanation withResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
-{
-  if (summaryDict[@"_summaryIdx"] == nil) {
-    reject(@"", @"Missing _summaryIdx", [NSError errorWithDomain:@"" code:0 userInfo:@{}]);
-    return;
-  }
-  NSInteger summaryIdx = [summaryDict[@"_summaryIdx"] unsignedIntValue];
-  if (summaryIdx >= self.reportedSummaries.count) {
-    reject(@"", @"Invalid _summaryIdx", [NSError errorWithDomain:@"" code:0 userInfo:@{}]);
-    return;
-  }
-  if (ENManager.authorizationStatus != ENAuthorizationStatusAuthorized) {
-    reject(@"API_NOT_ENABLED", [NSString stringWithFormat:@"Exposure Notification not authorized: %ld", ENManager.authorizationStatus], nil);
-    return;
-  }
-  ENExposureDetectionSummary *summary = self.reportedSummaries[summaryIdx];
-  [self.enManager getExposureInfoFromSummary:summary
-                             userExplanation:userExplanation
-                           completionHandler:^(NSArray<ENExposureInfo *> * _Nullable exposures, NSError * _Nullable error) {
-    if (error) {
-       reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription ,error);
-    } else {
-      NSMutableArray *arr = [NSMutableArray new];
-      for (ENExposureInfo *info in exposures) {
-        [arr addObject:@{
-          @"attenuationDurations": info.attenuationDurations,
-          @"attenuationValue": @(info.attenuationValue),
-          @"dateMillisSinceEpoch": @([info.date timeIntervalSince1970]),
-          @"durationMinutes": @(info.duration),
-          @"totalRiskScore": @(info.totalRiskScore),
-          @"transmissionRiskLevel": @(info.transmissionRiskLevel)
-        }];
-      }
-      resolve(arr);
-    }
-
-  }];
-}
 @end
+  

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -70,10 +70,6 @@ export interface ExposureNotification {
   getTemporaryExposureKeyHistory(): Promise<TemporaryExposureKey[]>;
 
   detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary>;
-  getExposureInformation(
-    summary: ExposureSummary,
-    userExplanation: string /* used only by iOS */,
-  ): Promise<ExposureInformation[]>;
-
+  getExposureInformation(summary: ExposureSummary): Promise<ExposureInformation[]> /* used only by Android */;
   getPendingExposureSummary(): Promise<ExposureSummary | undefined> /* used only by Android */;
 }


### PR DESCRIPTION
# Summary | Résumé
A type mismatch was noticed, but upon further inspection of the code, it was noticed that the entire function was never called, and furthermore, the call to `[ENManager getExposureInfoFromSummary:userExplanation:completionHandler:]` has been deprecated. It is not likely that the function will ever be used or needed, so it has been removed.

# Test instructions | Instructions pour tester la modification
1. Run the app.
2. Exposure Checks should still complete successfully.

Closes #875 

