### PR TITLE
Issue/bluetooth off behaviour

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -129,10 +129,6 @@ const CollapsedContent = (bottomSheetBehavior: BottomSheetBehavior) => {
   const [notificationStatus, turnNotificationsOn] = useNotificationPermissionStatus();
   const showNotificationWarning = notificationStatus !== 'granted';
 
-  // if (systemStatus === SystemStatus.Unknown) {
-  //   return null;
-  // }
-
   return (
     <CollapsedOverlayView
       status={systemStatus}
@@ -151,9 +147,6 @@ const ExpandedContent = (bottomSheetBehavior: BottomSheetBehavior) => {
     Linking.openSettings();
   }, []);
   const turnNotificationsOnFn = notificationStatus === 'blocked' ? toSettings : turnNotificationsOn;
-  // if (systemStatus === SystemStatus.Unknown) {
-  //   return null;
-  // }
 
   return (
     <OverlayView

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -89,25 +89,20 @@ const Content = ({setBackgroundColor, isBottomSheetExpanded}: ContentProps) => {
   switch (systemStatus) {
     case SystemStatus.Undefined:
       return null;
-    case SystemStatus.BluetoothOff:
-      return <BluetoothDisabledView />;
     case SystemStatus.Disabled:
     case SystemStatus.Restricted:
       return <ExposureNotificationsDisabledView isBottomSheetExpanded={isBottomSheetExpanded} />;
     case SystemStatus.PlayServicesNotAvailable:
       return <FrameworkUnavailableView isBottomSheetExpanded={isBottomSheetExpanded} />;
-    case SystemStatus.LocationOff:
-      return <LocationOffView isBottomSheetExpanded={isBottomSheetExpanded} />;
-  }
-
-  if (!network.isConnected) {
-    return <NetworkDisabledView />;
   }
 
   switch (exposureStatus.type) {
     case ExposureStatusType.Exposed:
       return <ExposureView isBottomSheetExpanded={isBottomSheetExpanded} />;
     case ExposureStatusType.Diagnosed:
+      if (!network.isConnected) {
+        return <NetworkDisabledView />;
+      }
       return exposureStatus.needsSubmission ? (
         <DiagnosedShareView isBottomSheetExpanded={isBottomSheetExpanded} />
       ) : (
@@ -115,7 +110,14 @@ const Content = ({setBackgroundColor, isBottomSheetExpanded}: ContentProps) => {
       );
     case ExposureStatusType.Monitoring:
     default:
+      if (!network.isConnected) {
+        return <NetworkDisabledView />;
+      }
       switch (systemStatus) {
+        case SystemStatus.BluetoothOff:
+          return <BluetoothDisabledView />;
+        case SystemStatus.LocationOff:
+          return <LocationOffView isBottomSheetExpanded={isBottomSheetExpanded} />;
         case SystemStatus.Active:
           return getNoExposureView(regionCase);
         default:


### PR DESCRIPTION
# Summary | Résumé

Trello: https://trello.com/c/gGBbwjW2/321-%F0%9F%8E%A8-assess-bluetooth-is-off-behaviour-against-expected-results
Github: https://github.com/cds-snc/covid-alert-app/issues/1073

Adjusting the displayed content as described in Issue #1073. 

Closes #1073 

# Test instructions | Instructions pour tester la modification

1. Launch App
2. Enter One Time Key, but **DO NOT UPLOAD KEYS**, Hit Cancel after entering One Time Key.
3. Send app to background.
4. Turn off Bluetooth.
5. Return to app.
6. The app should prompt the user to upload their keys, but still at the bottom indicate that there is a problem with COVID Alert.

7. Similar steps to enter "Exposed" state, turn Bluetooth off, and return to app.

8. In "Monitoring" state, when Bluetooth is off, the error should be the content on the main part of the screen.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

As discussed with @amazingphilippe, there is some design debt that remains from this issue

I believe the messaging for when the networking is off, and the user is in "Diagnosed" state should reflect that the action is to upload keys, not to perform exposure checks.