### PR TITLE
Traceback duration logic

### DIFF
--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -100,8 +100,7 @@ export class BackendService implements BackendInterface {
   filterTEKs = (key: TemporaryExposureKey) => {
 
     /*
-      This function filters out TEKs that were generated outside the window
-      when the user was contagious.
+      This function filters out TEKs that were generated before the user was contagious.
 
       rollingStartIntervalNumber = A number describing when a key starts. It is equal to startTimeOfKeySinceEpochInSecs / (60 * 10).
 
@@ -109,13 +108,16 @@ export class BackendService implements BackendInterface {
 
       source: https://developers.google.com/android/reference/com/google/android/gms/nearby/exposurenotification/TemporaryExposureKey
     */
+    if (!SYMPTOM_ONSET_DATE) {
+      return true;
+    }
     const symptomOnsetHoursSinceEpoch = hoursSinceEpoch(SYMPTOM_ONSET_DATE);
     const contagiousStartHoursSinceEpoch = symptomOnsetHoursSinceEpoch - CONTAGIOUS_DAYS_BEFORE_SYMPTOM_ONSET * 24;
 
     const rollingEndIntervalNumber = key.rollingStartIntervalNumber + key.rollingPeriod;
     const rollingEndIntervalHoursSinceEpoch = rollingEndIntervalNumber / 6;
     if (rollingEndIntervalHoursSinceEpoch < contagiousStartHoursSinceEpoch) {
-      // the TEK is outside the contagious period
+      // the TEK is before the contagious period
       return false;
     }
     return true;

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -8,7 +8,7 @@ import {getRandomBytes, downloadDiagnosisKeysFile} from 'bridge/CovidShield';
 import {blobFetch} from 'shared/fetch';
 import {MCC_CODE} from 'env';
 import {captureMessage, captureException} from 'shared/log';
-import {getMillisSinceUTCEpoch} from 'shared/date-fns';
+import {getMillisSinceUTCEpoch, hoursSinceEpoch} from 'shared/date-fns';
 
 import {Observable} from '../../shared/Observable';
 import {Region, RegionContent} from '../../shared/Region';
@@ -22,6 +22,11 @@ const TRANSMISSION_RISK_LEVEL = 1;
 
 // See https://github.com/cds-snc/covid-shield-server/pull/176
 const LAST_14_DAYS_PERIOD = '00000';
+
+const CONTAGIOUS_DAYS_BEFORE_SYMPTOM_ONSET = 2;
+// this is a placeholder value to be replaced with one supplied
+// by the user.
+const SYMPTOM_ONSET_DATE = new Date(2020, 7, 1);
 
 export class BackendService implements BackendInterface {
   retrieveUrl: string;
@@ -93,9 +98,25 @@ export class BackendService implements BackendInterface {
   }
 
   async reportDiagnosisKeys(keyPair: SubmissionKeySet, _exposureKeys: TemporaryExposureKey[]) {
+    const symptomOnsetHoursSinceEpoch = hoursSinceEpoch(SYMPTOM_ONSET_DATE);
+    const contagiousStartHoursSinceEpoch = symptomOnsetHoursSinceEpoch - CONTAGIOUS_DAYS_BEFORE_SYMPTOM_ONSET * 24;
+
     // Ref https://github.com/CovidShield/mobile/issues/192
     const filteredExposureKeys = Object.values(
-      _exposureKeys.sort((first, second) => second.rollingStartIntervalNumber - first.rollingStartIntervalNumber),
+      _exposureKeys
+        .filter(key => {
+          // rollingStartIntervalNumber = A number describing when a key starts. It is equal to startTimeOfKeySinceEpochInSecs / (60 * 10).
+          // rollingPeriod = A number describing how long a key is valid. It is expressed in increments of 10 minutes (e.g. 144 for 24 hours).
+          // source: https://developers.google.com/android/reference/com/google/android/gms/nearby/exposurenotification/TemporaryExposureKey
+          const rollingEndIntervalNumber = key.rollingStartIntervalNumber + key.rollingPeriod;
+          const rollingEndIntervalHoursSinceEpoch = rollingEndIntervalNumber / 6;
+          if (rollingEndIntervalHoursSinceEpoch < contagiousStartHoursSinceEpoch) {
+            // the TEK is outside the contagious period
+            return false;
+          }
+          return true;
+        })
+        .sort((first, second) => second.rollingStartIntervalNumber - first.rollingStartIntervalNumber),
     );
     const exposureKeys = filteredExposureKeys.slice(0, MAX_UPLOAD_KEYS);
     captureMessage('reportDiagnosisKeys', {


### PR DESCRIPTION
# Summary | Résumé

I cherry-picked in the commits from #1047. I changed the logic to use the `contagiousDateInfo` object that will be passed in once #1088 is merged. The logic that determines when the user is contagious based on their test date needs looking at. I'm not sure how many days before the test date we are considering the person to be contagious (this has been set at 11 for now for no particular reason).

# Test instructions | Instructions pour tester la modification

It may be easier to test this after #1088 is in. To test this PR by itself, you could manually change the symptom onset date in the source code, do the TEK upload flow through the app, and check that only TEKs from the contagious period are uploaded to the server.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

There are a few TODOs that need resolving at some point.