### PR TITLE
iOS 13.7 Share Exposure Information Toggle

### DIFF
--- a/ios/CovidShield/ExposureNotification.m
+++ b/ios/CovidShield/ExposureNotification.m
@@ -68,6 +68,12 @@ RCT_REMAP_METHOD(stop, stopWithResolver:(RCTPromiseResolveBlock)resolve rejecter
 RCT_REMAP_METHOD(getStatus, getStatusWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   // TODO: return a more meaningful status for 'ENStatusPaused' when it's known how to pause the EN framework.
+
+  // Checking the authorizationStatus will check the "Share Exposure Information" toggle in 13.7+
+  if (ENManager.authorizationStatus != ENAuthorizationStatusAuthorized) {
+    resolve (@"disabled");
+    return;
+  }
   switch (self.enManager.exposureNotificationStatus) {
     case ENStatusActive: resolve(@"active");
       break;


### PR DESCRIPTION
# Summary | Résumé

With the release of iOS 13.7, there is a new toggle switch in the **Exposure Notification Settings**. When toggling to off the app is not reflecting that EN is not working properly. The new check for **authorizationStatus** will show the user that EN isn't fully working.

Trello: https://trello.com/c/DgnXZ7Mz/480-ios-1370-share-exposure-information-toggle-issue

# Test instructions | Instructions pour tester la modification

- launch the app and verify everything is working properly
- minimize the app
- go into Settings --> Exposure Notification --> Active Region --> Active Region (again) --> _scroll down_ **Share Exposure Information** to **_off_** 
- bring the app to the foreground
- the app should show that **COVID Alert is off**.
- Reverse the steps to turn it back on.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

- Should the messaging for that screen change to show the user more specifically what is **off **?
- The button to **Enable COVID Alert** does not link directly to the screen to toggle **Share Exposure Information**.