### PR TITLE
Use .env for region.json

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,4 @@ HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MCC_CODE=302
 TEST_MODE=false
 MOCK_SERVER=false
-REGION_JSON_URL=
+REGION_JSON_URL=http://example.com/region.json # optional value for development mode

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ SUBMIT_URL=https://submission.covidshield.app
 RETRIEVE_URL=https://retrieval.covidshield.app
 HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MCC_CODE=302
-
 TEST_MODE=false
 MOCK_SERVER=false
+REGION_JSON_URL=

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -23,6 +23,8 @@ export const TEST_MODE = Config.TEST_MODE === 'true' || false;
 
 export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;
 
+export const REGION_JSON_URL = Config.REGION_JSON_URL;
+
 /**
  * Set reachability check url to empty to prevent
  * unnecessary background network activity

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -6,7 +6,7 @@ import {ExposureConfiguration, TemporaryExposureKey} from 'bridge/ExposureNotifi
 import nacl from 'tweetnacl';
 import {getRandomBytes, downloadDiagnosisKeysFile} from 'bridge/CovidShield';
 import {blobFetch} from 'shared/fetch';
-import {MCC_CODE} from 'env';
+import {MCC_CODE, REGION_JSON_URL} from 'env';
 import {captureMessage, captureException} from 'shared/log';
 import {getMillisSinceUTCEpoch} from 'shared/date-fns';
 import AsyncStorage from '@react-native-community/async-storage';
@@ -53,7 +53,13 @@ export class BackendService implements BackendInterface {
 
   async getRegionContent(): Promise<RegionContentResponse> {
     const headers: any = {};
-    const regionContentUrl = `${this.retrieveUrl}/exposure-configuration/region.json`;
+
+    let regionContentUrl = `${this.retrieveUrl}/exposure-configuration/region.json`;
+
+    if (REGION_JSON_URL && REGION_JSON_URL !== '') {
+      regionContentUrl = REGION_JSON_URL;
+    }
+
     const eTagStorageKey = `etag-${regionContentUrl}`;
     const storedRegionContent = await AsyncStorage.getItem(regionContentUrl);
     const storedEtagForUrl = await AsyncStorage.getItem(eTagStorageKey);

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -53,8 +53,7 @@ export class BackendService implements BackendInterface {
 
   async getRegionContent(): Promise<RegionContentResponse> {
     const headers: any = {};
-    const regionPath = 'exposure-configuration/region.json';
-    const regionContentUrl = `${this.retrieveUrl}/${regionPath}`;
+    const regionContentUrl = `${this.retrieveUrl}/exposure-configuration/region.json`;
     const eTagStorageKey = `etag-${regionContentUrl}`;
     const storedRegionContent = await AsyncStorage.getItem(regionContentUrl);
     const storedEtagForUrl = await AsyncStorage.getItem(eTagStorageKey);

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -54,11 +54,9 @@ export class BackendService implements BackendInterface {
   async getRegionContent(): Promise<RegionContentResponse> {
     const headers: any = {};
 
-    let regionContentUrl = `${this.retrieveUrl}/exposure-configuration/region.json`;
-
-    if (REGION_JSON_URL && REGION_JSON_URL !== '') {
-      regionContentUrl = REGION_JSON_URL;
-    }
+    const regionContentUrl = REGION_JSON_URL
+      ? REGION_JSON_URL
+      : `${this.retrieveUrl}/exposure-configuration/region.json`;
 
     const eTagStorageKey = `etag-${regionContentUrl}`;
     const storedRegionContent = await AsyncStorage.getItem(regionContentUrl);


### PR DESCRIPTION
This PR adds a new .env variable to `REGION_JSON_URL`

If set this URL will be used to fetch the region.json file

```
REGION_JSON_URL=https://raw.githubusercontent.com/cds-snc/covid-alert-app/feature/region-json-env/src/locale/translations/region.json
```

This will allow us to use a custom region.json for demos etc... i.e. when new provinces onboard. 