### PR TITLE
Revising NB-specific content

### DIFF
--- a/src/locale/regional.spec.tsx
+++ b/src/locale/regional.spec.tsx
@@ -5,18 +5,10 @@ const regionalI18n = createRegionalI18n('en', REGION_CONTENT);
 const activeRegions = regionalI18n.activeRegions;
 
 describe('if region is active', () => {
-  it('has the last paragraph text for ExposureView', async () => {
-    activeRegions.forEach((region: string) => {
-      expect(regionalI18n.translate(`RegionContent.ExposureView.Active.${region}.Body`)).not.toStrictEqual('');
-    });
-  });
-
   it('has all the required NoCode Content', async () => {
     activeRegions.forEach((region: string) => {
       expect(regionalI18n.translate(`RegionContent.NoCode.Active.${region}.Title`)).not.toStrictEqual('');
       expect(regionalI18n.translate(`RegionContent.NoCode.Active.${region}.Body`)).not.toStrictEqual('');
-      expect(regionalI18n.translate(`RegionContent.NoCode.Active.${region}.CTA`)).not.toStrictEqual('');
-      expect(regionalI18n.translate(`RegionContent.NoCode.Active.${region}.Link`)).not.toStrictEqual('');
     });
   });
 });

--- a/src/locale/translations/region.json
+++ b/src/locale/translations/region.json
@@ -1,5 +1,5 @@
 {
-  "Active": ["ON", "NL"],
+  "Active": ["ON", "NL", "NB"],
   "en": {
     "RegionContent": {
       "DiagnosedView": {
@@ -47,7 +47,7 @@
           },
           "NB": {
             "Title": "Get a one-time key",
-            "Body": "If you test positive for COVID-19, public health gives you a one-time key over the phone when you get your positive test result.\n\nYou will only get one key, and it expires in 24 hours or after you submit it.",
+            "Body": "If you test positive for COVID-19, public health gives you a one-time key over the phone when you get your positive test result.\n\nYou will get one key, and it expires in 24 hours or after you submit it.",
             "CTA": "",
             "Link": ""
           }

--- a/src/locale/translations/region.json
+++ b/src/locale/translations/region.json
@@ -48,8 +48,8 @@
           "NB": {
             "Title": "Get a one-time key",
             "Body": "If you test positive for COVID-19, public health gives you a one-time key over the phone when you get your positive test result.\n\nYou will only get one key, and it expires in 24 hours or after you submit it.",
-            "CTA": "Help",
-            "Link": "https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert/help.html#4"
+            "CTA": "",
+            "Link": ""
           }
         }
       },
@@ -66,9 +66,9 @@
             "URL": "https://www.gov.nl.ca/covid-19/exposed/"
           },
           "NB": {
-            "Body": "You’re at risk of being infected.",
-            "CTA": "Find out what to do next",
-            "URL": "https://www2.gnb.ca/content/gnb/en/departments/ocmoh/cdc/content/respiratory_diseases/coronavirus/coronavirusexposure.html#/app/symptom-checker/guides/399/what-to-do"
+            "Body": "",
+            "CTA": "Find out if you need to get tested",
+            "URL": "https://www2.gnb.ca/content/gnb/en/corporate/promo/covid-19/covid_alert.html"
           }
         },
         "Inactive": {
@@ -180,8 +180,8 @@
           "NB": {
             "Title": "Obtenir une clé à usage unique",
             "Body": "Quand vous recevez un résultat de test positif pour la COVID-19, la Santé publique vous fournit aussi une clé à usage unique.\n\nVous recevrez une seule clé, et elle expirera au bout de 24 heures.",
-            "CTA": "Aide",
-            "Link": "https://www.canada.ca/fr/sante-publique/services/maladies/maladie-coronavirus-covid-19/alerte-covid/aide.html#4"
+            "CTA": "",
+            "Link": ""
           }
         }
       },
@@ -198,9 +198,9 @@
             "URL": "https://www.gov.nl.ca/covid-19/expose/"
           },
           "NB": {
-            "Body": "Vous êtes à risque d’être infecté.",
-            "CTA": "Lisez les étapes à suivre",
-            "URL": "https://www2.gnb.ca/content/gnb/fr/ministeres/bmhc/maladies_transmissibles/content/maladies_respiratoires/coronavirus/expositionaucoronavirus.html#/app/symptom-checker/guides/399/what-to-do"
+            "Body": "",
+            "CTA": "Découvrez si vous devriez vous faire tester",
+            "URL": "https://www2.gnb.ca/content/gnb/fr/corporate/promo/covid-19/alerte_covid.html"
           }
         },
         "Inactive": {


### PR DESCRIPTION
Revising EN and FR content for NB based on today's meeting. Note that the URL on the exposed screen (both English and French) is still not live, so they're throwing a 404 error. Hopefully that's ok to update the URL now before the page is live.

# Summary | Résumé

> Updating NB-specific content and links in both English and French. 

---
To test, compare with mock-ups in figma ("WIP NB" page), check for type-os or weird spaces please. 


