### PR TITLE
Add ability to specify an EN_CONFIG_URL in .env file

### DIFF
--- a/REGIONS.md
+++ b/REGIONS.md
@@ -1,13 +1,21 @@
-## Adding specific content
+# Testing changes to Regional config and EN config
+
+## Testing region content
 
 - Pull content from https://docs.google.com/document/d/1pgof04oFkjSqlBJ3shWnC2oO_2qxol-nr7C9BgJoFgE/edit
 
-## Test locally
+### Steps to test locally
 
-- brew cask install ngrok
-- yarn global add json-server
-- cd src/locale/translations
-- json-server --watch region.json
-- ngrok http 3000
-- Update BackendService.ts -> getRegionContent (regionContentUrl)
-  i.e. https://a6764c6fd6ce.ngrok.io/db
+- `brew cask install ngrok`
+- `yarn global add json-server`
+- `json-server --watch src/locale/translations/region.json`
+- `ngrok http 3000`
+- Add the following to your .env file and do a build: `REGION_JSON_URL=https://XXXXXXXXXX.ngrok.io/db`
+
+## Testing EN Config changes
+
+A similar process can be used to test changes to the EN config.
+
+- make changes to `src/services/ExposureNotificationService/ExposureConfigurationDefault.json`
+- commit and push your changes to a branch
+- Add the following to your .env file and do a build: `EN_CONFIG_URL=`

--- a/REGIONS.md
+++ b/REGIONS.md
@@ -18,4 +18,4 @@ A similar process can be used to test changes to the EN config.
 
 - make changes to `src/services/ExposureNotificationService/ExposureConfigurationDefault.json`
 - commit and push your changes to a branch
-- Add the following to your .env file and do a build: `EN_CONFIG_URL=`
+- Add the following to your .env file and do a build: `EN_CONFIG_URL=https://raw.githubusercontent.com/cds-snc/covid-alert-app/YOUR_BRANCH_NAME/src/services/ExposureNotificationService/ExposureConfigurationDefault.json`

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -25,6 +25,8 @@ export const MOCK_SERVER = Config.MOCK_SERVER === 'true' || false;
 
 export const REGION_JSON_URL = Config.REGION_JSON_URL;
 
+export const EN_CONFIG_URL = Config.EN_CONFIG_URL;
+
 /**
  * Set reachability check url to empty to prevent
  * unnecessary background network activity

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -6,7 +6,7 @@ import {ExposureConfiguration, TemporaryExposureKey} from 'bridge/ExposureNotifi
 import nacl from 'tweetnacl';
 import {getRandomBytes, downloadDiagnosisKeysFile} from 'bridge/CovidShield';
 import {blobFetch} from 'shared/fetch';
-import {MCC_CODE, REGION_JSON_URL} from 'env';
+import {MCC_CODE, REGION_JSON_URL, EN_CONFIG_URL} from 'env';
 import {captureMessage, captureException} from 'shared/log';
 import {getMillisSinceUTCEpoch} from 'shared/date-fns';
 import {ContagiousDateInfo} from 'screens/datasharing/components';
@@ -102,7 +102,9 @@ export class BackendService implements BackendInterface {
     // purposely setting 'region' to the default value of `CA` regardless of what the user selected.
     // this is only for the purpose of downloading the configuration file.
     const region = 'CA';
-    const exposureConfigurationUrl = `${this.retrieveUrl}/exposure-configuration/${region}.json`;
+    const exposureConfigurationUrl = EN_CONFIG_URL
+      ? EN_CONFIG_URL
+      : `${this.retrieveUrl}/exposure-configuration/${region}.json`;
     captureMessage('getExposureConfiguration', {exposureConfigurationUrl});
     return (await fetch(exposureConfigurationUrl, FETCH_HEADERS)).json();
   }


### PR DESCRIPTION
# Summary | Résumé

This PR adds functionality where an `EN_CONFIG_URL` in .env file. This is useful for testing different EN Framework configurations. To test, add in some logging to src/services/ExposureNotificationService/ExposureNotificationService.ts to print out the config being used. Then follow the instructions in REGIONS.md.