### PR TITLE
react-native patch to fix image rendering issue on iOS 14

### DIFF
--- a/patches/react-native+0.62.2.patch
+++ b/patches/react-native+0.62.2.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m b/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
+index 21f1a06..2444713 100644
+--- a/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
++++ b/node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
+@@ -272,6 +272,9 @@ - (void)displayDidRefresh:(CADisplayLink *)displayLink
+
+ - (void)displayLayer:(CALayer *)layer
+ {
++  if (!_currentFrame) {
++    _currentFrame = self.image;
++  }
+   if (_currentFrame) {
+     layer.contentsScale = self.animatedImageScale;
+     layer.contents = (__bridge id)_currentFrame.CGImage;
+diff --git a/node_modules/react-native/scripts/.packager.env b/node_modules/react-native/scripts/.packager.env
+new file mode 100644
+index 0000000..361f5fb
+--- /dev/null
++++ b/node_modules/react-native/scripts/.packager.env
+@@ -0,0 +1 @@
++export RCT_METRO_PORT=8081


### PR DESCRIPTION
# Summary | Résumé

This patches an issue in react-native related to rendering images in iOS 14. We first noticed this issue on the onboarding screen in builds generated by Xcode 12 on iOS 14 devices.

# Test instructions | Instructions pour tester la modification

Compile/build on Xcode 12, test on iOS 14 devices. Check all images, look for any unintended side effects.

# Help requested | Aide requise

Needs more extensive testing

