### PR TITLE
Added tests to check that correct exposure summary is used

### DIFF
--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -1,4 +1,5 @@
 import {unzip} from 'react-native-zip-archive';
+import {captureMessage} from 'shared/log';
 
 import {ExposureNotification, ExposureSummary} from './types';
 import {getLastExposureTimestamp} from './utils';
@@ -11,6 +12,7 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: any
       if (diagnosisKeysURLs.length === 0) {
         throw new Error('Attempt to call detectExposure with empty list of downloaded files');
       }
+      captureMessage('diagnosisKeysURLs.length', {length: diagnosisKeysURLs.length});
 
       for (const keysZipUrl of diagnosisKeysURLs) {
         const components = keysZipUrl.split('/');

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -514,16 +514,11 @@ export class ExposureNotificationService {
   private selectExposureSummary(nextSummary: ExposureSummary): ExposureSummary {
     const exposureStatus = this.exposureStatus.get();
     if (exposureStatus.type !== ExposureStatusType.Exposed) {
-      captureMessage('selectExposureSummary use next Summary', {nextSummary});
+      captureMessage('selectExposureSummary use nextSummary', {nextSummary});
       return nextSummary;
     }
     const currentSummary = exposureStatus.summary;
-    // const currentLastExposureTimestamp = currentSummary.lastExposureTimestamp;
-    // const nextLastExposureTimestamp = nextSummary.lastExposureTimestamp;
-    // if (nextLastExposureTimestamp > currentLastExposureTimestamp) {
-    //   return nextSummary;
-    // }
-    captureMessage('selectExposureSummary use current Summary', {nextSummary});
+    captureMessage('selectExposureSummary use currentSummary', {currentSummary});
     return currentSummary;
   }
 


### PR DESCRIPTION
# Summary | Résumé

Added the following tests:
- selects current exposure summary if user is already exposed
- selects next exposure summary if user is not already exposed

I also improved the logging in a couple places.