### PR TITLE
initial testUpdateExposure

### DIFF
--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -48,7 +48,7 @@ export class BackendService implements BackendInterface {
     const message = `${MCC_CODE}:${periodStr}:${Math.floor(getMillisSinceUTCEpoch() / 1000 / 3600)}`;
     const hmac = hmac256(message, encHex.parse(this.hmacKey)).toString(encHex);
     const url = `${this.retrieveUrl}/retrieve/${MCC_CODE}/${periodStr}/${hmac}`;
-    // captureMessage('retrieveDiagnosisKeys', {period, url});
+    captureMessage('retrieveDiagnosisKeys', {period, url});
     return downloadDiagnosisKeysFile(url);
   }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -477,7 +477,7 @@ describe('ExposureNotificationService', () => {
       [10, ExposureStatusType.Exposed],
       [14, ExposureStatusType.Monitoring],
       [20, ExposureStatusType.Monitoring],
-    ])('if exposed %p days ago, state should be %p', async (daysAgo, expectedStatus) => {
+    ])('if exposed %p days ago, state expected to be %p', async (daysAgo, expectedStatus) => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
       dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       const period = periodSinceEpoch(today, HOURS_PER_PERIOD);

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -411,6 +411,7 @@ export class ExposureNotificationService {
   }
 
   private summaryExceedsMinimumMinutes(summary: ExposureSummary, minimumExposureDurationMinutes: number) {
+    captureMessage('summaryExceedsMinimumMinutes', summary);
     // on ios attenuationDurations is in seconds, on android it is in minutes
     const divisor = Platform.OS === 'ios' ? 60 : 1;
     const durationAtImmediateMinutes = summary.attenuationDurations[0] / divisor;


### PR DESCRIPTION
This PR improves tests on the ExposureNotificationService. Here are the changes:
- wrote helper function to create summaries for use in tests
- wrote helper function to run tests where a new summary is returned from the framework, and the new status is returned
- added parameterized tests to check the new status when we vary: the number of days ago an exposure occurred, and  the `attenuationDuration` values
