### PR TITLE
Error handling messages for TEKs.

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -235,10 +235,12 @@ export class ExposureNotificationService {
     let temporaryExposureKeys: TemporaryExposureKey[];
     try {
       temporaryExposureKeys = await this.exposureNotification.getTemporaryExposureKeyHistory();
-    } catch {
+    } catch (error) {
+      captureException('getTemporaryExposureKeyHistory', error);
       throw cannotGetTEKsError;
     }
     if (temporaryExposureKeys.length > 0) {
+      captureMessage('getTemporaryExposureKeyHistory', temporaryExposureKeys);
       await this.backendInterface.reportDiagnosisKeys(auth, temporaryExposureKeys, contagiousDateInfo);
     } else {
       captureMessage('No TEKs available to upload');


### PR DESCRIPTION
# Summary | Résumé

Used for debugging, only in dev environment, to see if there is an error message from retrieving the TEKs from the framework, and to confirm what TEKs are being uploaded. This does not log any messages in the production environment.

# Test instructions | Instructions pour tester la modification

Run the app in debug mode. Complete the steps to upload TEKs. Look in the logs for the messages.