### PR TITLE
Error handling messages for TEKs.

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -228,13 +228,15 @@ export class ExposureNotificationService {
     let temporaryExposureKeys: TemporaryExposureKey[];
     try {
       temporaryExposureKeys = await this.exposureNotification.getTemporaryExposureKeyHistory();
-    } catch {
+    } catch (error) {
+      captureException('getTemporaryExposureKeyHistory', error);
       throw cannotGetTEKsError;
     }
     if (temporaryExposureKeys.length > 0) {
+      captureMessage('getTemporaryExposureKeyHistory', temporaryExposureKeys);
       await this.backendInterface.reportDiagnosisKeys(auth, temporaryExposureKeys, contagiousDateInfo);
     } else {
-      captureMessage('No TEKs available to upload');
+      captureMessage('getTemporaryExposureKeyHistory', {message: 'No TEKs available to upload'});
     }
     await this.recordKeySubmission();
   }


### PR DESCRIPTION
# Summary | Résumé

This PR was done last week, but got lost when reverting. Adding error handling for the TEKs to know what is being returned from the framework.

Used for debugging, only in dev environment, to see if there is an error message from retrieving the TEKs from the framework, and to confirm what TEKs are being uploaded. This does not log any messages in the production environment.

# Test instructions | Instructions pour tester la modification

Run the app in debug mode. Complete the steps to upload TEKs. Look in the logs for the messages.