### PR TITLE
MAX_UPLOAD_KEYS 14 -> 28, since 2 can be generated per day

### DIFF
--- a/src/services/BackendService/BackendService.spec.ts
+++ b/src/services/BackendService/BackendService.spec.ts
@@ -119,9 +119,9 @@ describe('BackendService', () => {
   });
 
   describe('reportDiagnosisKeys', () => {
-    it('returns last 14 keys if there is more than 14', async () => {
+    it('returns last 28 keys if there is more than 28', async () => {
       const backendService = new BackendService('http://localhost', 'https://localhost', 'mock', undefined);
-      const keys = generateRandomKeys(20);
+      const keys = generateRandomKeys(30);
       await backendService.reportDiagnosisKeys(
         {
           clientPrivateKey: 'mock',
@@ -133,12 +133,12 @@ describe('BackendService', () => {
 
       expect(covidshield.Upload.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          keys: expect.toHaveLength(14),
+          keys: expect.toHaveLength(28),
         }),
       );
       keys
         .sort((first, second) => second.rollingStartIntervalNumber - first.rollingStartIntervalNumber)
-        .splice(0, 14)
+        .splice(0, 28)
         .map(({rollingStartIntervalNumber, rollingPeriod}) => ({rollingStartIntervalNumber, rollingPeriod}))
         .forEach(value => {
           expect(covidshield.TemporaryExposureKey.create).toHaveBeenCalledWith(expect.objectContaining(value));

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -20,7 +20,7 @@ import {Region, RegionContentResponse} from '../../shared/Region';
 import {covidshield} from './covidshield';
 import {BackendInterface, SubmissionKeySet} from './types';
 
-const MAX_UPLOAD_KEYS = 14;
+const MAX_UPLOAD_KEYS = 28;
 const FETCH_HEADERS = {headers: {'Cache-Control': 'no-store'}};
 const TRANSMISSION_RISK_LEVEL = 1;
 


### PR DESCRIPTION
# Summary | Résumé

This fixes some old code left over from before when the limit was 1 TEK generated per day. It is now 2 TEKs per day if the user uploads on that day. This applies to current Android and the V2 framework API on iOS. 
The framework returns keys that cover (at most) the last 14 days, so there is no danger of this change causing keys older than 14 days from being uploaded.
This PR should probably include some tests - I will convert from draft once those are written.