### PR TITLE
Add Diagnosed View to test menu

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -79,17 +79,19 @@ const Content = ({setBackgroundColor, isBottomSheetExpanded}: ContentProps) => {
 
   // this is for the test menu
   const {forceScreen} = useStorage();
-  switch (forceScreen) {
-    case 'NoExposureView':
-      return getNoExposureView(regionCase);
-    case 'ExposureView':
-      return <ExposureView isBottomSheetExpanded={isBottomSheetExpanded} />;
-    case 'DiagnosedShareView':
-      return <DiagnosedShareView isBottomSheetExpanded={isBottomSheetExpanded} />;
-    case 'DiagnosedView':
-      return <DiagnosedView isBottomSheetExpanded={isBottomSheetExpanded} />;
-    default:
-      break;
+  if (TEST_MODE) {
+    switch (forceScreen) {
+      case 'NoExposureView':
+        return getNoExposureView(regionCase);
+      case 'ExposureView':
+        return <ExposureView isBottomSheetExpanded={isBottomSheetExpanded} />;
+      case 'DiagnosedShareView':
+        return <DiagnosedShareView isBottomSheetExpanded={isBottomSheetExpanded} />;
+      case 'DiagnosedView':
+        return <DiagnosedView isBottomSheetExpanded={isBottomSheetExpanded} />;
+      default:
+        break;
+    }
   }
 
   switch (systemStatus) {

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -86,6 +86,8 @@ const Content = ({setBackgroundColor, isBottomSheetExpanded}: ContentProps) => {
       return <ExposureView isBottomSheetExpanded={isBottomSheetExpanded} />;
     case 'DiagnosedShareView':
       return <DiagnosedShareView isBottomSheetExpanded={isBottomSheetExpanded} />;
+    case 'DiagnosedView':
+      return <DiagnosedView isBottomSheetExpanded={isBottomSheetExpanded} />;
     default:
       break;
   }

--- a/src/screens/home/views/DiagnosedView.tsx
+++ b/src/screens/home/views/DiagnosedView.tsx
@@ -8,6 +8,7 @@ import {useStorage} from 'services/StorageService';
 import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
 import {isRegionActive} from 'shared/RegionLogic';
 import {useRegionalI18n} from 'locale/regional';
+import {TEST_MODE} from 'env';
 
 import {BaseHomeView} from '../components/BaseHomeView';
 import {Tip} from '../components/Tip';
@@ -19,9 +20,13 @@ export const DiagnosedView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: b
   const [exposureStatus] = useExposureStatus();
   const autoFocusRef = useAccessibilityAutoFocus(!isBottomSheetExpanded);
 
-  if (exposureStatus.type !== ExposureStatusType.Diagnosed) return null;
-
-  const daysLeft = daysBetween(getCurrentDate(), new Date(exposureStatus.cycleEndsAt)) - 1;
+  let daysLeft: number;
+  if (TEST_MODE) {
+    daysLeft = 7;
+  } else {
+    if (exposureStatus.type !== ExposureStatusType.Diagnosed) return null;
+    daysLeft = daysBetween(getCurrentDate(), new Date(exposureStatus.cycleEndsAt)) - 1;
+  }
 
   return (
     <BaseHomeView iconName="hand-thank-you-with-love" testID="diagnosed">

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -27,6 +27,7 @@ const ScreenRadioSelector = () => {
     {displayName: 'Not Exposed', value: 'NoExposureView'},
     {displayName: 'Exposed', value: 'ExposureView'},
     {displayName: 'Diagnosed Share Data', value: 'DiagnosedShareView'},
+    {displayName: 'Diagnosed', value: 'DiagnosedView'},
   ];
   return (
     <Box


### PR DESCRIPTION
# Summary | Résumé

I added the the ability to force the Diagnosed View to the test menu. Previously there were only 2 ways we could get to this screen to verify content:
- actually diagnose the phone (problematic b/c this can complicate tests going on nearby)
- modify the source code (not possible if we are testing someone else's build)

I also wrapped an `if(TEST_MODE)` around the switching behaviour in `HomeScreen` for 2 reasons:
- makes extra sure this switch will only happen if `TEST_MODE=true`
- makes it more obvious to other developers what this logic is doing
