### PR TITLE
Refactoring `updateExposure` and `calculateNeedsSubmission`

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -774,24 +774,39 @@ describe('ExposureNotificationService', () => {
     const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: today.getDate() - 15 * ONE_DAY,
-      cycleEndsAt: today.getDate() - ONE_DAY,
+      cycleStartsAt: today.valueOf() - 15 * ONE_DAY,
+      cycleEndsAt: today.valueOf() - ONE_DAY,
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {
-      return args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-18T04:10:00+0000');
+      return args.length > 0 ? new OriginalDate(...args) : new OriginalDate();
     });
     expect(service.calculateNeedsSubmission()).toStrictEqual(false);
   });
 
   it('calculateNeedsSubmission when diagnosed true', () => {
     dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
-    const today = new OriginalDate('2020-05-18T04:10:00+0000');
+    const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: today.getDate() - 12 * ONE_DAY,
-      cycleEndsAt: today.getDate() + 3 * ONE_DAY,
+      cycleStartsAt: today.valueOf() - 12 * ONE_DAY,
+      cycleEndsAt: today.valueOf() + 3 * ONE_DAY,
       needsSubmission: false,
+    });
+    expect(service.calculateNeedsSubmission()).toStrictEqual(true);
+  });
+
+  it('calculateNeedsSubmission when already submitted for that day false', () => {
+    const today = new OriginalDate();
+    service.exposureStatus.set({
+      type: ExposureStatusType.Diagnosed,
+      cycleStartsAt: today.valueOf() - 10 * ONE_DAY,
+      cycleEndsAt: today.valueOf() + 4 * ONE_DAY,
+      submissionLastCompletedAt: today.valueOf(),
+      needsSubmission: true,
+    });
+    dateSpy.mockImplementation((...args: any[]) => {
+      return args.length > 0 ? new OriginalDate(...args) : today;
     });
     expect(service.calculateNeedsSubmission()).toStrictEqual(false);
   });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -259,10 +259,10 @@ describe('ExposureNotificationService', () => {
   );
 
   it('backfills keys when last timestamp not available', async () => {
-    dateSpy
-      .mockImplementationOnce(() => new OriginalDate('2020-05-19T07:10:00+0000'))
-      .mockImplementation((args: any) => new OriginalDate(args));
-
+    dateSpy.mockImplementation((args: any) => {
+      if (args === undefined) return new OriginalDate('2020-05-19T11:10:00+0000');
+      return new OriginalDate(args);
+    });
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
   });
@@ -747,6 +747,63 @@ describe('ExposureNotificationService', () => {
         }),
       );
     });
+  });
+
+  it('calculateNeedsSubmission when monitoring', () => {
+    service.exposureStatus.set({
+      type: ExposureStatusType.Monitoring,
+    });
+    expect(service.calculateNeedsSubmission()).toStrictEqual(false);
+  });
+
+  it('calculateNeedsSubmission when exposed', () => {
+    const today = new OriginalDate();
+    service.exposureStatus.set({
+      type: ExposureStatusType.Exposed,
+      summary: getSummary({
+        today,
+        hasMatchedKey: true,
+        daysSinceLastExposure: 7,
+        attenuationDurations: [20, 0, 0],
+      }),
+    });
+    expect(service.calculateNeedsSubmission()).toStrictEqual(false);
+  });
+
+  it('calculateNeedsSubmission when diagnosed false', () => {
+    service.exposureStatus.set({
+      type: ExposureStatusType.Diagnosed,
+      cycleStartsAt: new OriginalDate('2020-05-18T04:10:00+0000').getDate(),
+      cycleEndsAt: 0,
+      needsSubmission: true,
+    });
+    dateSpy.mockImplementation((...args: any[]) => {
+      return args.length > 0 ? new OriginalDate(... args) : new OriginalDate('2020-05-18T04:10:00+0000');
+    });
+    expect(service.calculateNeedsSubmission()).toStrictEqual(false);
+  });
+
+  it('calculateNeedsSubmission when diagnosed true', () => {
+    dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
+    const today = new OriginalDate('2020-05-18T04:10:00+0000');
+    service.exposureStatus.set({
+      type: ExposureStatusType.Diagnosed,
+      cycleStartsAt: today.getDate() - 12 * ONE_DAY,
+      cycleEndsAt: today.getDate() + 3 * ONE_DAY,
+      needsSubmission: false,
+    });
+    expect(service.calculateNeedsSubmission()).toStrictEqual(false);
+  });
+
+  it('updateExposure, stay Monitoring', () => {
+    service.exposureStatus.set({
+      type: ExposureStatusType.Monitoring,
+    });
+    expect(service.updateExposure()).toStrictEqual(
+      expect.objectContaining({
+        type: ExposureStatusType.Monitoring,
+      }),
+    );
   });
 
   describe('getPeriodsSinceLastFetch', () => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -771,10 +771,11 @@ describe('ExposureNotificationService', () => {
   });
 
   it('calculateNeedsSubmission when diagnosed false', () => {
+    const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: new OriginalDate('2020-05-18T04:10:00+0000').getDate(),
-      cycleEndsAt: 0,
+      cycleStartsAt: today.getDate() - 15 * ONE_DAY,
+      cycleEndsAt: today.getDate() - 1 * ONE_DAY,
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -778,7 +778,7 @@ describe('ExposureNotificationService', () => {
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {
-      return args.length > 0 ? new OriginalDate(... args) : new OriginalDate('2020-05-18T04:10:00+0000');
+      return args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-18T04:10:00+0000');
     });
     expect(service.calculateNeedsSubmission()).toStrictEqual(false);
   });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -775,7 +775,7 @@ describe('ExposureNotificationService', () => {
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
       cycleStartsAt: today.getDate() - 15 * ONE_DAY,
-      cycleEndsAt: today.getDate() - 1 * ONE_DAY,
+      cycleEndsAt: today.getDate() - ONE_DAY,
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -774,8 +774,8 @@ describe('ExposureNotificationService', () => {
     const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: today.valueOf() - 15 * ONE_DAY,
-      cycleEndsAt: today.valueOf() - ONE_DAY,
+      cycleStartsAt: today.getTime() - 15 * ONE_DAY,
+      cycleEndsAt: today.getTime() - ONE_DAY,
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {
@@ -789,8 +789,8 @@ describe('ExposureNotificationService', () => {
     const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: today.valueOf() - 12 * ONE_DAY,
-      cycleEndsAt: today.valueOf() + 3 * ONE_DAY,
+      cycleStartsAt: today.getTime() - 12 * ONE_DAY,
+      cycleEndsAt: today.getTime() + 3 * ONE_DAY,
       needsSubmission: false,
     });
     expect(service.calculateNeedsSubmission()).toStrictEqual(true);
@@ -800,9 +800,9 @@ describe('ExposureNotificationService', () => {
     const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
-      cycleStartsAt: today.valueOf() - 10 * ONE_DAY,
-      cycleEndsAt: today.valueOf() + 4 * ONE_DAY,
-      submissionLastCompletedAt: today.valueOf(),
+      cycleStartsAt: today.getTime() - 10 * ONE_DAY,
+      cycleEndsAt: today.getTime() + 4 * ONE_DAY,
+      submissionLastCompletedAt: today.getTime(),
       needsSubmission: true,
     });
     dateSpy.mockImplementation((...args: any[]) => {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -394,6 +394,7 @@ export class ExposureNotificationService {
     const updatedExposure = this.updateExposure();
     if (updatedExposure !== currentExposureStatus) {
       this.exposureStatus.set(updatedExposure);
+      this.finalize();
     }
 
     const {keysFileUrls, lastCheckedPeriod} = await this.getKeysFileUrls();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -256,6 +256,68 @@ export class ExposureNotificationService {
     await this.recordKeySubmission();
   }
 
+  public calculateNeedsSubmission(): boolean {
+    const exposureStatus: ExposureStatus = this.exposureStatus.get()
+    const today: Date = getCurrentDate();
+
+    if (exposureStatus === null || today === null) return false;
+    if (exposureStatus.type !== ExposureStatusType.Diagnosed) return false;
+
+    if (isNaN(today.getTime())) return true;
+
+    const cycleEndsAt = new Date(exposureStatus.cycleEndsAt);
+    if (isNaN(cycleEndsAt.getTime()) === false) {
+      // We're done submitting keys
+      // This has to be based on UTC timezone https://github.com/cds-snc/covid-shield-mobile/issues/676
+      if (daysBetweenUTC(today, cycleEndsAt) <= 0) return false;
+    }
+
+    const submissionLastCompletedAt = exposureStatus.submissionLastCompletedAt;
+    if (!submissionLastCompletedAt) {
+      return true;
+    }
+
+    const lastSubmittedDay = new Date(submissionLastCompletedAt);
+
+    if (isNaN(lastSubmittedDay.getTime())) return true;
+
+    // This has to be based on UTC timezone https://github.com/cds-snc/covid-shield-mobile/issues/676
+    return daysBetweenUTC(lastSubmittedDay, today) > 0;
+  }
+
+  public updateExposure(): ExposureStatus {
+    const exposureStatus: ExposureStatus = this.exposureStatus.get()
+    const today: Date = getCurrentDate();
+
+    if (exposureStatus.type === ExposureStatusType.Monitoring) return exposureStatus;
+    switch (exposureStatus.type) {
+      case ExposureStatusType.Diagnosed:
+        // There is a case where using UTC and device timezone could mess up user experience. See `date-fn.spec.ts`
+        // Let's use device timezone for resetting exposureStatus for now
+        // Ref https://github.com/cds-snc/covid-shield-mobile/issues/676
+        if (daysBetween(today, new Date(exposureStatus.cycleEndsAt)) <= 0) {
+          return {type: ExposureStatusType.Monitoring, lastChecked: exposureStatus.lastChecked};
+        } else {
+          return {
+            ...exposureStatus,
+            needsSubmission: this.calculateNeedsSubmission(),
+          };
+        }
+      case ExposureStatusType.Exposed:
+        if (
+          daysBetween(new Date(exposureStatus.summary.lastExposureTimestamp || today.getTime()), today) >=
+          EXPOSURE_NOTIFICATION_CYCLE
+        ) {
+          return {type: ExposureStatusType.Monitoring, lastChecked: exposureStatus.lastChecked};
+        } else {
+          return exposureStatus;
+        }
+      default:
+        // return the unchanged exposureStatus
+        return exposureStatus;
+    }
+  }
+
   private async loadExposureStatus() {
     const exposureStatus = JSON.parse((await this.storage.getItem(EXPOSURE_STATUS)) || 'null');
     this.exposureStatus.append({...exposureStatus});
@@ -297,27 +359,6 @@ export class ExposureNotificationService {
     return minimumExposureDurationMinutes && Math.round(exposureDurationMinutes) >= minimumExposureDurationMinutes;
   }
 
-  private async calculateNeedsSubmission(): Promise<boolean> {
-    const exposureStatus = this.exposureStatus.get();
-    if (exposureStatus.type !== ExposureStatusType.Diagnosed) return false;
-
-    const today = getCurrentDate();
-    const cycleEndsAt = new Date(exposureStatus.cycleEndsAt);
-    // We're done submitting keys
-    // This has to be based on UTC timezone https://github.com/cds-snc/covid-shield-mobile/issues/676
-    if (daysBetweenUTC(today, cycleEndsAt) <= 0) return false;
-
-    const submissionLastCompletedAt = exposureStatus.submissionLastCompletedAt;
-    if (!submissionLastCompletedAt) return true;
-
-    const lastSubmittedDay = new Date(submissionLastCompletedAt);
-
-    // This has to be based on UTC timezone https://github.com/cds-snc/covid-shield-mobile/issues/676
-    if (daysBetweenUTC(lastSubmittedDay, today) > 0) return true;
-
-    return false;
-  }
-
   private finalize = async (
     status: Partial<ExposureStatus> = {},
     lastCheckedPeriod: number | undefined = undefined,
@@ -349,27 +390,13 @@ export class ExposureNotificationService {
       return;
     }
     captureMessage('past pending summary check');
-    const currentStatus = this.exposureStatus.get();
 
-    if (currentStatus.type === ExposureStatusType.Diagnosed) {
-      const today = getCurrentDate();
-      const cycleEndsAt = new Date(currentStatus.cycleEndsAt);
-      // There is a case where using UTC and device timezone could mess up user experience. See `date-fn.spec.ts`
-      // Let's use device timezone for resetting exposureStatus for now
-      // Ref https://github.com/cds-snc/covid-shield-mobile/issues/676
-      if (daysBetween(today, cycleEndsAt) <= 0) {
-        this.exposureStatus.set({type: ExposureStatusType.Monitoring, lastChecked: currentStatus.lastChecked});
-        return this.finalize();
-      }
-      return this.finalize({needsSubmission: await this.calculateNeedsSubmission()});
-    } else if (currentStatus.type === ExposureStatusType.Exposed) {
-      const today = getCurrentDate();
-      const lastExposureAt = new Date(currentStatus.summary.lastExposureTimestamp || today.getTime());
-      if (daysBetween(lastExposureAt, today) >= EXPOSURE_NOTIFICATION_CYCLE) {
-        this.exposureStatus.set({type: ExposureStatusType.Monitoring, lastChecked: currentStatus.lastChecked});
-        return this.finalize();
-      }
+    const currentExposureStatus: ExposureStatus = this.exposureStatus.get();
+    const updatedExposure = this.updateExposure();
+    if (updatedExposure !== currentExposureStatus) {
+      this.exposureStatus.set(updatedExposure);
     }
+
     const {keysFileUrls, lastCheckedPeriod} = await this.getKeysFileUrls();
 
     try {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -289,7 +289,6 @@ export class ExposureNotificationService {
     const exposureStatus: ExposureStatus = this.exposureStatus.get();
     const today: Date = getCurrentDate();
 
-    if (exposureStatus.type === ExposureStatusType.Monitoring) return exposureStatus;
     switch (exposureStatus.type) {
       case ExposureStatusType.Diagnosed:
         // There is a case where using UTC and device timezone could mess up user experience. See `date-fn.spec.ts`

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -257,7 +257,7 @@ export class ExposureNotificationService {
   }
 
   public calculateNeedsSubmission(): boolean {
-    const exposureStatus: ExposureStatus = this.exposureStatus.get()
+    const exposureStatus: ExposureStatus = this.exposureStatus.get();
     const today: Date = getCurrentDate();
 
     if (exposureStatus === null || today === null) return false;
@@ -286,7 +286,7 @@ export class ExposureNotificationService {
   }
 
   public updateExposure(): ExposureStatus {
-    const exposureStatus: ExposureStatus = this.exposureStatus.get()
+    const exposureStatus: ExposureStatus = this.exposureStatus.get();
     const today: Date = getCurrentDate();
 
     if (exposureStatus.type === ExposureStatusType.Monitoring) return exposureStatus;


### PR DESCRIPTION
# Summary | Résumé

An ongoing attempt to refactor the code to make it more manageable and easier to unit test. This pulls out the code to update the exposure status to a monitoring state.

# Test instructions | Instructions pour tester la modification

