### PR TITLE
Removed ability to change UUID from test menu, added copy to clipboard functionality

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -310,6 +310,8 @@ PODS:
     - React
   - RNCAsyncStorage (1.9.0):
     - React
+  - RNCClipboard (1.3.0):
+    - React-Core
   - RNCMaskedView (0.1.10):
     - React
   - RNCPicker (1.6.6):
@@ -398,6 +400,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNBackgroundFetch (from `../node_modules/react-native-background-fetch`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNCPicker (from `../node_modules/@react-native-community/picker`)"
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
@@ -494,6 +497,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-background-fetch"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-community/async-storage"
+  RNCClipboard:
+    :path: "../node_modules/@react-native-community/clipboard"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNCPicker:
@@ -564,6 +569,7 @@ SPEC CHECKSUMS:
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
   RNBackgroundFetch: 8dbb63141792f1473e863a0797ffbd5d987af2fc
   RNCAsyncStorage: 453cd7c335ec9ba3b877e27d02238956b76f3268
+  RNCClipboard: 78d9b0e67d025cbdf563f3dba897800306cdb86a
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 494015f2b7ec4bee5484b6f235aa19691426dcdb
   RNCPushNotificationIOS: d5fd66aed4e03c6491ca0c6111a03d4f6455ff6c

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "1.9.0",
+    "@react-native-community/clipboard": "^1.3.0",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
     "@react-native-community/picker": "^1.6.6",

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -135,7 +135,7 @@ const Content = () => {
       </Section>
       <Section>
         <Box flexDirection="row">
-          <Text padding="m" style={styles.uuidText}>
+          <Text padding="m" style={styles.flex}>
             <Text>Debug UUID: </Text>
             <Text fontWeight="bold">{UUID}</Text>
           </Text>
@@ -198,9 +198,5 @@ export const TestScreen = () => {
 const styles = StyleSheet.create({
   flex: {
     flex: 1,
-  },
-  uuidText: {
-    flex: 1,
-    height: '100%',
   },
 });

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useState, useEffect} from 'react';
-import {TextInput, StyleSheet, ScrollView} from 'react-native';
+import {StyleSheet, ScrollView} from 'react-native';
+import Clipboard from '@react-native-community/clipboard';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useI18n} from 'locale';
 import PushNotification from 'bridge/PushNotification';
@@ -12,7 +13,7 @@ import {
   useReportDiagnosis,
 } from 'services/ExposureNotificationService';
 import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
-import {setLogUUID, getLogUUID, captureMessage} from 'shared/log';
+import {getLogUUID, captureMessage} from 'shared/log';
 import {useNavigation} from '@react-navigation/native';
 
 import {RadioButton} from './components/RadioButtons';
@@ -104,8 +105,8 @@ const Content = () => {
   const {fetchAndSubmitKeys} = useReportDiagnosis();
 
   const [UUID, setUUID] = useState('');
-  const onApplyUUID = useCallback(() => {
-    setLogUUID(UUID);
+  const onCopyUuid = useCallback(() => {
+    Clipboard.setString(UUID);
   }, [UUID]);
 
   useEffect(() => {
@@ -133,10 +134,12 @@ const Content = () => {
         <SkipAllSetRadioSelector />
       </Section>
       <Section>
-        <Item title="UUID for debugging" />
         <Box flexDirection="row">
-          <TextInput style={styles.uuidTextInput} placeholder="UUID..." value={UUID} onChangeText={setUUID} />
-          <Button variant="thinFlat" text="Apply" onPress={onApplyUUID} />
+          <Text padding="m" style={styles.uuidText}>
+            <Text>Debug UUID: </Text>
+            <Text fontWeight="bold">{UUID}</Text>
+          </Text>
+          <Button variant="bigFlat" text="Copy" onPress={onCopyUuid} />
         </Box>
       </Section>
       <Section>
@@ -196,8 +199,8 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1,
   },
-  uuidTextInput: {
+  uuidText: {
     flex: 1,
-    color: '#000000',
+    height: '100%',
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,6 +1065,10 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
+"@react-native-community/clipboard@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.3.0.tgz#9aec68e39403c936288db8bf73d1980b9f908cc4"
+
 "@react-native-community/eslint-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-1.1.0.tgz#2dacad06dd44d13e778510864473fc6091f080c0"
@@ -1463,7 +1467,6 @@
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
-  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -1472,7 +1475,6 @@
 "@types/react-native-snap-carousel@^3.8.2":
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/@types/react-native-snap-carousel/-/react-native-snap-carousel-3.8.2.tgz#31fb91530198183c658db0d23935ca79850419f5"
-  integrity sha512-ItvLo19gQstxcir6wIXJxwohxdYj9t/lXv+MXfqhwMSYaR+Xa3vOP7b6TYQCe9GqDPH3sEgEg/uH6CLV+fhcWA==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"
@@ -1480,7 +1482,6 @@
 "@types/react-native@*":
   version "0.63.18"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.18.tgz#748d82c6453befe97285393ad9530472d8de56af"
-  integrity sha512-WwEWqmHiqFn61M1FZR/+frj+E8e2o8i5cPqu9mjbjtZS/gBfCKVESF2ai/KAlaQECkkWkx/nMJeCc5eHMmLQgw==
   dependencies:
     "@types/react" "*"
 
@@ -1499,7 +1500,6 @@
 "@types/react@*":
   version "16.9.49"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2724,7 +2724,6 @@ cssstyle@^2.2.0:
 csstype@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
-  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
# Summary | Résumé

This PR removes the ability to change the Debug UUID and adds a copy UUID to clipboard button. It turns out we don't actually want people to change the UUID during a test run. If it gets changed, that means we don't have an easily searchable, complete log of all events coming from that device any more. So best to remove the feature and make it easier to copy the existing UUID so it can be sent out.

I tested the copy functionality on Android 9 and iOS 13.7.

<img width="370" alt="Screen Shot 2020-10-02 at 3 30 21 PM" src="https://user-images.githubusercontent.com/5498428/94971418-3db05700-04c4-11eb-89fa-ee5521608024.png">

