### PR TITLE
Add Québec support to region.json

### DIFF
--- a/src/locale/translations/region.json
+++ b/src/locale/translations/region.json
@@ -1,5 +1,5 @@
 {
-  "Active": ["ON", "NL", "NB", "SK", "MB"],
+  "Active": ["ON", "NL", "NB", "SK", "MB", "QC"],
   "en": {
     "RegionContent": {
       "Home": {

--- a/src/shared/RegionLogic.spec.ts
+++ b/src/shared/RegionLogic.spec.ts
@@ -70,7 +70,7 @@ describe('getExposedHelpURL', () => {
     });
   });
   it('gives the right URL for inactive regions', async () => {
-    ['AB', 'BC', 'MB', 'NT', 'NS', 'NU', 'PE', 'QC', 'YT'].forEach(region => {
+    ['AB', 'BC', 'MB', 'NT', 'NS', 'NU', 'PE', 'YT'].forEach(region => {
       expect(getExposedHelpURL(region, regionalI18n)).toStrictEqual(
         regionalI18n.translate(`RegionContent.ExposureView.Inactive.${region}.URL`),
       );


### PR DESCRIPTION
Hi! I'm [Sean Coates](https://seancoates.com/blogs/how-i-helped-fix-canadas-covid-alert-app).

You might remember me from such issues as "[app contacts google and discloses IP addresses of all users](https://github.com/cds-snc/covid-alert-app/issues/1003)".

I live in Montréal, Québec.

# Summary | Résumé

On Tuesday September 29th, Québec Health Minister Christian Dubé said, during a press conference, that Québec is close to adopting an app to help stem the spread of COVID-19. When pressed, he acknowledged that this would be the (this) federal COVID Alert app, and the [CBC subsequently confirmed](https://www.cbc.ca/news/canada/montreal/quebec-covid-alert-contact-tracing-app-1.5743287).

I have been personally [evangelizing this approach](https://twitter.com/coates/status/1301957469275643906) for many weeks, and have had an ongoing conversation with my [MNA's office](https://plq.org/en/team/enrico-ciccone/). I recognize that many people have been part of this movement, as well, and it's a huge relief that our efforts are paying off.

It feels like we're finally close.

I've been keeping an eye on the [app configuration](https://github.com/cds-snc/covid-alert-app/blob/master/src/locale/translations/region.json#L2), awaiting official blessing [like Manitoba received on October 1st](https://github.com/cds-snc/covid-alert-app/commit/ffeddc3f5e857d6c39d8bfa5038502859dfe2e18), and I thought you fine folks at CDS might like to have a little more-symbolic-than-practical PR to merge when you're ready to add Québec to the supported regions list. A little bit of made-in-Québec to finally put us on board.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Clearly this needs to wait until there's officially-agreed-upon support between Health Canada / CDS / and Québec.

Also, no hard feelings if you'd prefer to close this PR and do things 100% your own internal way. I understand.
