### PR TITLE
Fix typo in french

### DIFF
--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -54,7 +54,7 @@
         "Title": "Pas encore de signalement dans votre région",
         "Body": "Les personnes de votre région ne peuvent pas encore obtenir de clé à usage unique.\n\nVous ne pourrez pas aviser les personnes d’une exposition. Mais vous pouvez tout de même vous isoler pendant 14\u00A0jours, et ainsi :",
         "Body2": "Assurer la sécurité de votre communauté.",
-        "Body3": "Protéger les personnes et les animaux vivant avec vous.",
+        "Body3": "Protéger les personnes et les animaux vivants avec vous.",
         "Body4": "Prendre soin de vous."
       }
     }


### PR DESCRIPTION
The word "vivants" should have an "s" at the end, because there is more than one "personnes" and "animaux".