### PR TITLE
Added code to enable `locationless scanning` for Android.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -7,8 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
 import android.location.LocationManager
-import android.os.Build.VERSION;
-import android.os.Build.VERSION_CODES;
 import androidx.core.location.LocationManagerCompat
 import app.covidshield.extensions.cleanup
 import app.covidshield.extensions.launch
@@ -300,9 +298,11 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     }
 
     private fun isLocationEnabled(): Boolean {
-        return (!exposureNotificationClient.deviceSupportsLocationlessScanning()
-                && VERSION.SDK_INT >= VERSION_CODES.M
-                && (locationManager?.let { LocationManagerCompat.isLocationEnabled(it) } ?: false));
+        if (exposureNotificationClient.deviceSupportsLocationlessScanning()) {
+            return true
+        } else {
+            return (locationManager?.let { LocationManagerCompat.isLocationEnabled(it) } ?: false)
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentSender
 import android.location.LocationManager
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.core.location.LocationManagerCompat
 import app.covidshield.extensions.cleanup
 import app.covidshield.extensions.launch
@@ -298,7 +300,9 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     }
 
     private fun isLocationEnabled(): Boolean {
-        return locationManager?.let { LocationManagerCompat.isLocationEnabled(it) } ?: false
+        return (!exposureNotificationClient.deviceSupportsLocationlessScanning()
+                && VERSION.SDK_INT >= VERSION_CODES.M
+                && (locationManager?.let { LocationManagerCompat.isLocationEnabled(it) } ?: false));
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
# Summary | Résumé

Android 11 introduces "locationless scanning" for supported devices. This allows the app to work without requiring "location services" to be enabled for the app or the phone. This simple check in the code uses an API that was introduced in 1.6 of the Exposure Notification framework.

# Test instructions | Instructions pour tester la modification

This should be tested on both Android 11 and Android 10 or below.

- Launch the app and verify everything is working correctly.
- Minimize the app.
- Turn off Location Services.
- Return to the app: 
-- on Android 11, the app should still be functioning.
-- on Android 10 or below, the app should notify you that COVID Alert is Off, with instructions to turn it back on.

A full end-to-end test should also be performed, on Android 11, with Location Services turned off.

# Help requested | Aide requise

Please pay close attention to the behaviour on Android 11, as I do not yet have a phone that supports Android 11.

## This change is for Android only. It has no impact on iOS and there should be no need to test on iOS.