### PR TITLE
Feature/v2 adapters

### DIFF
--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -66,7 +66,7 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
         infectiousness: Infectiousness.Standard,
         calibrationConfidence: CalibrationConfidence.Medium,
       };
-      return exposureWindow;
+      return [exposureWindow];
     },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -1,6 +1,15 @@
 import {captureMessage} from 'shared/log';
 
-import {ExposureConfiguration, ExposureNotificationAPI, ExposureSummary} from './types';
+import {
+  CalibrationConfidence,
+  ExposureConfiguration,
+  ExposureNotificationAPI,
+  ExposureSummary,
+  ExposureWindow,
+  Infectiousness,
+  Report,
+  ScanInstance,
+} from './types';
 import {getLastExposureTimestamp} from './utils';
 
 export default function ExposureNotificationAdapter(exposureNotificationAPI: ExposureNotificationAPI) {
@@ -42,6 +51,22 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
         // todo: replace mock with exposureNotificationAPI.provideDiagnosisKeys
         await mock([diagnosisKeysURL]);
       }
+    },
+    getExposureWindows: async () => {
+      // todo: replace mock with exposureNotificationAPI.getExposureWindows
+      const scanInstance: ScanInstance = {
+        typicalAttenuation: 60,
+        minAttenuation: 80,
+        secondsSinceLastScan: 120,
+      };
+      const exposureWindow: ExposureWindow = {
+        day: 0,
+        scanInstances: [scanInstance, scanInstance],
+        reportType: Report.ConfirmedClinicalDiagnosis,
+        infectiousness: Infectiousness.Standard,
+        calibrationConfidence: CalibrationConfidence.Medium,
+      };
+      return exposureWindow;
     },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.android.ts
@@ -33,5 +33,15 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
       }
       return [];
     },
+    provideDiagnosisKeys: async (diagnosisKeysURLs: string[]) => {
+      if (diagnosisKeysURLs.length === 0) {
+        throw new Error('Attempt to call provideDiagnosisKeys with empty list of downloaded files');
+      }
+      const mock = async (keys: any) => keys;
+      for (const diagnosisKeysURL of diagnosisKeysURLs) {
+        // todo: replace mock with exposureNotificationAPI.provideDiagnosisKeys
+        await mock([diagnosisKeysURL]);
+      }
+    },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -36,5 +36,23 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
       return summaries;
     },
     getPendingExposureSummary: async () => undefined,
+    provideDiagnosisKeys: async (diagnosisKeysURLs: string[]) => {
+      if (diagnosisKeysURLs.length === 0) {
+        throw new Error('Attempt to call provideDiagnosisKeys with empty list of downloaded files');
+      }
+      captureMessage('diagnosisKeysURLs.length', {length: diagnosisKeysURLs.length});
+
+      for (const keysZipUrl of diagnosisKeysURLs) {
+        const components = keysZipUrl.split('/');
+        components.pop();
+        components.push('keys-export');
+        const targetDir = components.join('/');
+        const unzippedLocation = await unzip(keysZipUrl, targetDir);
+        const mock = async (keys: any) => keys;
+        // todo: change mock to exposureNotificationAPI.provideDiagnosisKeys when the native
+        // layer is implemented
+        await mock([`${unzippedLocation}/export.bin`, `${unzippedLocation}/export.sig`]);
+      }
+    },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -77,7 +77,7 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
         infectiousness: Infectiousness.Standard,
         calibrationConfidence: CalibrationConfidence.Medium,
       };
-      return exposureWindow;
+      return [exposureWindow];
     },
   };
 }

--- a/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
+++ b/src/bridge/ExposureNotification/ExposureNotificationAdapter.ios.ts
@@ -1,7 +1,16 @@
 import {unzip} from 'react-native-zip-archive';
 import {captureMessage} from 'shared/log';
 
-import {ExposureConfiguration, ExposureNotificationAPI, ExposureSummary} from './types';
+import {
+  CalibrationConfidence,
+  ExposureConfiguration,
+  ExposureNotificationAPI,
+  ExposureSummary,
+  ExposureWindow,
+  Infectiousness,
+  Report,
+  ScanInstance,
+} from './types';
 import {getLastExposureTimestamp} from './utils';
 
 export default function ExposureNotificationAdapter(exposureNotificationAPI: ExposureNotificationAPI) {
@@ -53,6 +62,22 @@ export default function ExposureNotificationAdapter(exposureNotificationAPI: Exp
         // layer is implemented
         await mock([`${unzippedLocation}/export.bin`, `${unzippedLocation}/export.sig`]);
       }
+    },
+    getExposureWindows: async () => {
+      // todo: replace mock with exposureNotificationAPI.getExposureWindows
+      const scanInstance: ScanInstance = {
+        typicalAttenuation: 60,
+        minAttenuation: 80,
+        secondsSinceLastScan: 120,
+      };
+      const exposureWindow: ExposureWindow = {
+        day: 0,
+        scanInstances: [scanInstance, scanInstance],
+        reportType: Report.ConfirmedClinicalDiagnosis,
+        infectiousness: Infectiousness.Standard,
+        calibrationConfidence: CalibrationConfidence.Medium,
+      };
+      return exposureWindow;
     },
   };
 }

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -105,6 +105,8 @@ export interface ExposureNotification {
 export interface ExposureNotificationAPI {
   detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary>;
   getPendingExposureSummary(): Promise<ExposureSummary | undefined> /* used only by Android */;
+  provideDiagnosisKeys(diagnosisKeysURLs: string[]): Promise<undefined>;
+  getExposureWindows(): ExposureWindow[];
 }
 
 export interface ExposureWindow {

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -24,7 +24,7 @@ export enum Status {
   Authorized = 'authorized',
 }
 
-export enum ReportType {
+export enum Report {
   Revoked = 'REVOKED',
   ConfirmedClinicalDiagnosis = 'CONFIRMED_CLINICAL_DIAGNOSIS',
   SelfReport = 'SELF_REPORT',
@@ -32,13 +32,13 @@ export enum ReportType {
   Recursive = 'RECURSIVE',
 }
 
-export enum InfectiousnessType {
+export enum Infectiousness {
   None = 'NONE',
   Standard = 'STANDARD',
   High = 'HIGH',
 }
 
-export enum CalibrationConfidenceType {
+export enum CalibrationConfidence {
   Lowest = 'LOWEST',
   Low = 'LOW',
   Medium = 'MEDIUM',
@@ -75,8 +75,8 @@ export interface ExposureConfiguration {
 }
 
 export interface DailySummariesConfig {
-  reportTypeWeights: Record<ReportType, number>;
-  infectiousnessWeights: Record<InfectiousnessType, number>;
+  reportTypeWeights: Record<Report, number>;
+  infectiousnessWeights: Record<Infectiousness, number>;
   attenuationBucketThresholdDb: number[];
   attenuationBucketWeights: number[];
   daysSinceExposureThreshold: number;
@@ -110,9 +110,9 @@ export interface ExposureNotificationAPI {
 export interface ExposureWindow {
   day: number;
   scanInstances: ScanInstance[];
-  reportType: ReportType;
-  infectiousness: InfectiousnessType;
-  calibrationConfidence: CalibrationConfidenceType;
+  reportType: Report;
+  infectiousness: Infectiousness;
+  calibrationConfidence: CalibrationConfidence;
 }
 
 export interface ScanInstance {

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -24,6 +24,27 @@ export enum Status {
   Authorized = 'authorized',
 }
 
+export enum ReportType {
+  Revoked = 'REVOKED',
+  ConfirmedClinicalDiagnosis = 'CONFIRMED_CLINICAL_DIAGNOSIS',
+  SelfReport = 'SELF_REPORT',
+  ConfirmedTest = 'CONFIRMED_TEST',
+  Recursive = 'RECURSIVE',
+}
+
+export enum InfectiousnessType {
+  None = 'NONE',
+  Standard = 'STANDARD',
+  High = 'HIGH',
+}
+
+export enum CalibrationConfidenceType {
+  Lowest = 'LOWEST',
+  Low = 'LOW',
+  Medium = 'MEDIUM',
+  High = 'HIGH',
+}
+
 export interface TemporaryExposureKey {
   keyData: string;
   rollingStartIntervalNumber: number;
@@ -53,6 +74,15 @@ export interface ExposureConfiguration {
   transmissionRiskWeight: number;
 }
 
+export interface DailySummariesConfig {
+  reportTypeWeights: Record<ReportType, number>;
+  infectiousnessWeights: Record<InfectiousnessType, number>;
+  attenuationBucketThresholdDb: number[];
+  attenuationBucketWeights: number[];
+  daysSinceExposureThreshold: number;
+  minimumWindowScore: number;
+}
+
 export interface ExposureInformation {
   dateMillisSinceEpoch: number;
   durationMinutes: number;
@@ -75,4 +105,18 @@ export interface ExposureNotification {
 export interface ExposureNotificationAPI {
   detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary>;
   getPendingExposureSummary(): Promise<ExposureSummary | undefined> /* used only by Android */;
+}
+
+export interface ExposureWindow {
+  day: number;
+  scanInstances: number[];
+  reportType: ReportType;
+  infectiousness: InfectiousnessType;
+  calibrationConfidence: CalibrationConfidenceType;
+}
+
+export interface ScanInstance {
+  typicalAttenuation: number;
+  minAttenuation: number;
+  secondsSinceLastScan: number;
 }

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -109,7 +109,7 @@ export interface ExposureNotificationAPI {
 
 export interface ExposureWindow {
   day: number;
-  scanInstances: number[];
+  scanInstances: ScanInstance[];
   reportType: ReportType;
   infectiousness: InfectiousnessType;
   calibrationConfidence: CalibrationConfidenceType;


### PR DESCRIPTION
# Summary | Résumé

This mocks 2 of the new V2 methods in the adapters: `provideDiagnosisKeys` and `getExposureWindows`. 
I left todo comments to replace these mocks after the native code is implemented. I figure this will let us move forward and implement new methods in `ExposureNotificationService` and write tests, so we can have the code in master but not switch it on until a later date.