### PR TITLE
Removing `BackgroundFetch.scheduleTask()` call on Android.

### DIFF
--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -32,10 +32,12 @@ const registerPeriodicTask = async (task: PeriodicTask) => {
       BackgroundFetch.finish(taskId);
     },
   );
-  const result = await BackgroundFetch.scheduleTask({taskId: BACKGROUND_TASK_ID, delay: 0, periodic: true}).catch(
-    () => false,
-  );
-  captureMessage('registerPeriodicTask', {result});
+  if (Platform.OS === 'ios') {
+    const result = await BackgroundFetch.scheduleTask({taskId: BACKGROUND_TASK_ID, delay: 0, periodic: true}).catch(
+      () => false,
+    );
+    captureMessage('registerPeriodicTask', {result});
+  }
 };
 
 const registerAndroidHeadlessPeriodicTask = (task: PeriodicTask) => {


### PR DESCRIPTION
# Summary | Résumé

Removing the BackgroundFetch.scheduleTask() call on Android, since it is unnecessary and redundant. iOS relies on 2 different types of background tasks, whereas Android treats them both the same. BackgroundFetch.configure() not only configures the task, but also initiates it.

# Test instructions | Instructions pour tester la modification

- Install the app on Android and get past onboarding.
- The background checks should happen every 4-8 hours.
