### PR TITLE
Fastlane: don't submit for review on staging bundle

### DIFF
--- a/fastlane/iOS.Fastfile
+++ b/fastlane/iOS.Fastfile
@@ -70,6 +70,7 @@ platform :ios do
     groups = ENV["TEST_GROUPS"].split(",")
     upload_to_testflight(
       groups: groups,
+      skip_submission: release ? true : false,
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH]
     )
 


### PR DESCRIPTION
# Summary | Résumé

By default, the upload_to_testflight fastlane action will submit a build for beta app review. This stops that on our second bundle id.

