### PR TITLE
Remove the option to use AlarmManager for Android.

### DIFF
--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -17,7 +17,7 @@ const registerPeriodicTask = async (task: PeriodicTask) => {
   BackgroundFetch.configure(
     {
       minimumFetchInterval: TEST_MODE ? EXACT_JOB_INTERNVAL_IN_MINUTES : DEFERRED_JOB_INTERNVAL_IN_MINUTES,
-      forceAlarmManager: TEST_MODE,
+      forceAlarmManager: false,
       enableHeadless: true,
       startOnBoot: true,
       stopOnTerminate: false,


### PR DESCRIPTION
# Summary | Résumé

The `BackgroundFetch` package can use AlarmManager for Android. In early development testing, this was a convenient way of testing background tasks on Android, and getting them to execute more frequently. However, since the production code will always use JobScheduler to execute background tasks, it is recommended that developers do not bypass that code for the sake of accelerating the testing cycle.

It is still possible to run the AlarmManager version of the background task, but it should be done by explicitly setting `forceAlarmManager` to true, and not be tied to the .env variable `TEST_MODE`.

NOTE: This change affects Android only, and only in the development environment, not in production.

# Test instructions | Instructions pour tester la modification

- Set `TEST_MODE` in the .env file to be **TRUE**.
- `yarn run-android`
- In Android Studio, place a breakpoint on line 116 of the decompiled class file **BGTask.class**.
- Build and run for Android in Debug mode.
- Upon hitting the breakpoint, observe that the code for JobScheduler is executed, and not the code for AlarmManager.