### PR TITLE
Proof of Concept - Sharing the app

### DIFF
--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState, useEffect} from 'react';
-import {TextInput, StyleSheet, ScrollView, Share} from 'react-native';
+import {TextInput, StyleSheet, ScrollView, Share, Platform} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useI18n} from 'locale';
 import PushNotification from 'bridge/PushNotification';
@@ -99,16 +99,22 @@ const Content = () => {
   }, [i18n]);
 
   const onShare = async () => {
-    const result = await Share.share(
-      {
+    let content;
+    if (Platform.OS === 'ios') {
+      content = {
         url: 'https://apps.apple.com/ca/app/covid-alert/id1520284227',
-        title: 'Share CovidAlert: https://apps.apple.com/ca/app/covid-alert/id1520284227',
-      },
-      {
-        subject: 'I installed Covid Alert and so should you!',
-        dialogTitle: 'I installed Covid Alert and so should you!',
-      },
-    );
+      };
+    } else {
+      content = {
+        title: 'Check out Covid Alert!',
+        message: 'https://play.google.com/store/apps/details?id=ca.gc.hcsc.canada.stopcovid',
+      };
+    }
+
+    await Share.share(content, {
+      subject: 'Check out Covid Alert!',
+      dialogTitle: 'Check out Covid Alert!',
+    });
   };
 
   const exposureNotificationService = useExposureNotificationService();
@@ -138,7 +144,7 @@ const Content = () => {
         <Button text="Show sample notification" onPress={onShowSampleNotification} variant="bigFlat" />
       </Section>
       <Section>
-        <Button text="share this app" onPress={onShare} variant="bigFlat" />
+        <Button text="Share this app" onPress={onShare} variant="bigFlat" />
       </Section>
       <Section>
         <Item title="Force screen" />

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState, useEffect} from 'react';
-import {TextInput, StyleSheet, ScrollView} from 'react-native';
+import {TextInput, StyleSheet, ScrollView, Share} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useI18n} from 'locale';
 import PushNotification from 'bridge/PushNotification';
@@ -98,6 +98,19 @@ const Content = () => {
     });
   }, [i18n]);
 
+  const onShare = async () => {
+    const result = await Share.share(
+      {
+        url: 'https://apps.apple.com/ca/app/covid-alert/id1520284227',
+        title: 'Share CovidAlert: https://apps.apple.com/ca/app/covid-alert/id1520284227',
+      },
+      {
+        subject: 'I installed Covid Alert and so should you!',
+        dialogTitle: 'I installed Covid Alert and so should you!',
+      },
+    );
+  };
+
   const exposureNotificationService = useExposureNotificationService();
   const [, updateExposureStatus] = useExposureStatus();
 
@@ -123,6 +136,9 @@ const Content = () => {
       </Section>
       <Section>
         <Button text="Show sample notification" onPress={onShowSampleNotification} variant="bigFlat" />
+      </Section>
+      <Section>
+        <Button text="share this app" onPress={onShare} variant="bigFlat" />
       </Section>
       <Section>
         <Item title="Force screen" />

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -106,8 +106,7 @@ const Content = () => {
       };
     } else {
       content = {
-        title: 'Check out Covid Alert!',
-        message: 'https://play.google.com/store/apps/details?id=ca.gc.hcsc.canada.stopcovid',
+        message: 'Check out Covid Alert! https://play.google.com/store/apps/details?id=ca.gc.hcsc.canada.stopcovid',
       };
     }
 


### PR DESCRIPTION
# Summary | Résumé

Quick proof-of-concept for app sharing.

Uses the [react-native Share API](https://reactnative.dev/docs/share) which passes content to the OS-level share sheet.

To test, run a debug build with the TestMenu enabled. You'll find a "Share this app" button in the menu.

The Share Sheet will look different depending on the apps installed on the device. ie, if the user has Twitter installed, it will show up in the list. If they don't have Facebook installed, it will not appear in the list, etc. Users can also customize their share sheets.

The various apps will treat the content differently. For example, for emails we can provide a Subject line, but this doesn't work on all email clients. Messages on iOS renders a preview of the app store listing. Twitter doesn't seem to render a social card, at least not in the preview - it may 'unfurl' in the tweet when sent. Not sure about FB.

Here's what the share sheet looks like on each os:

iOS | Android
----- | -----
![image](https://user-images.githubusercontent.com/1187115/96309124-b3431980-0fd2-11eb-9880-ef8d7bb0d722.png) | ![image](https://user-images.githubusercontent.com/1187115/96309903-3ca71b80-0fd4-11eb-9a85-42aa109dbab5.png)




