### PR TITLE
Add export compliance to info.plist

### DIFF
--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -31,6 +31,8 @@
 	<key>ENDeveloperRegion</key>
 	<string>CA</string>
 	<key>LSApplicationQueriesSchemes</key>
+  <key>ITSAppUsesNonExemptEncryption</key>
+  <false/>
 	<array>
 		<string>instagram</string>
 		<string>instagram-stories</string>


### PR DESCRIPTION
# Summary | Résumé

Adds export compliance to Info.plist.

When deploying to TestFlight, sometimes the build gets stuck waiting for "Export compliance" and you have to login to AppStoreConnect and answer a question about it. This pre-answers the question so builds don't get stuck waiting for it.

