### PR TITLE
Fix info-plist entry from previous change

### DIFF
--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -30,9 +30,9 @@
 	<integer>1</integer>
 	<key>ENDeveloperRegion</key>
 	<string>CA</string>
-	<key>LSApplicationQueriesSchemes</key>
   <key>ITSAppUsesNonExemptEncryption</key>
   <false/>
+	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>instagram</string>
 		<string>instagram-stories</string>


### PR DESCRIPTION
# Summary | Résumé

Fixes an Info.plist entry that was added in a previous PR. It was added in the wrong place, which caused the info.plist to be invalid. To check if the Info.plist is still valid after this change, open Xcode and then find Info.plist in the directory listing and open it. Xcode will not open it if it is invalid.

