### PR TITLE
Simplify how dates are handled.

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -518,7 +518,9 @@ describe('ExposureNotificationService', () => {
       });
 
       await service.updateExposureStatus();
-      expect(service.exposureStatus.get()).toStrictEqual(expect.objectContaining({type: ExposureStatusType.Monitoring}));
+      expect(service.exposureStatus.get()).toStrictEqual(
+        expect.objectContaining({type: ExposureStatusType.Monitoring}),
+      );
     });
   });
 


### PR DESCRIPTION
# Summary | Résumé

The unit tests for ExposureNotificationService used dates in almost every test, replicating the declaration of the date as well as the DateSpy handling of dates. Moved everything to the `beforeEach` function of the test, and calculated other dates based on "today".

# Testing

- Check out the branch and run the unit tests.
- Change the `todayDateString` to another date and re-run the tests.

#Notes

- The test for `needsSubmission status recalculates daily` still has a date in it, as I could not figure out how to remove it without breaking the test. I will revisit this at a later time.
- The tests for `getPeriodsSinceLastFetch` have a specific date set, since the periods calculated are very specific to that date.