### PR TITLE
Change LOG to ERROR.

### DIFF
--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -57,6 +57,6 @@ export const captureException = async (message: string, error: any, params: {[ke
   };
 
   if (__DEV__ && !isTest()) {
-    console.log(finalMessage, finalParams); // eslint-disable-line no-console
+    console.error(finalMessage, finalParams); // eslint-disable-line no-console
   }
 };


### PR DESCRIPTION
# Summary | Résumé

This is a simple change that highlights **console.error()** in the logs.

# Test instructions | Instructions pour tester la modification

Run the app in DEV mode. Anytime a `capture.exception()` call is made, it should show up in the logs with an ERROR tag on it, instead of the LOG tag.