### PR TITLE
Update ENAPIVersion to use v2 framework

### DIFF
--- a/ios/CovidShield/Info-debug.plist
+++ b/ios/CovidShield/Info-debug.plist
@@ -27,7 +27,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(APP_VERSION_CODE)</string>
 	<key>ENAPIVersion</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>ENDeveloperRegion</key>
 	<string>CA</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -27,7 +27,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(APP_VERSION_CODE)</string>
 	<key>ENAPIVersion</key>
-	<integer>1</integer>
+	<integer>2</integer>
 	<key>ENDeveloperRegion</key>
 	<string>CA</string>
   <key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
# Summary | Résumé

Bumps iOS Exposure Notification Framework to v2
