### PR TITLE
ExposureNotificationService spec cleanup

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -147,11 +147,7 @@ describe('ExposureNotificationService', () => {
     when(storage.getItem)
       .calledWith(Key.OnboardedDatetime)
       .mockResolvedValue(today.getTime());
-    service.exposureStatus.append({
-      lastChecked: {
-        timestamp: today.getTime() - ONE_DAY,
-      },
-    });
+
     dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
   });
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -358,7 +358,10 @@ describe('ExposureNotificationService', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('stores last update timestamp', async () => {
     const currentDatetime = new OriginalDate('2020-05-19T07:10:00+0000');
-
+    dateSpy.mockImplementation((args: any) => {
+      if (args === undefined) return currentDatetime;
+      return new OriginalDate(args);
+    });
     service.exposureStatus.append({
       lastChecked: {
         timestamp: new OriginalDate('2020-05-18T04:10:00+0000').getTime(),

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -204,7 +204,6 @@ describe('ExposureNotificationService', () => {
     async (argAttenuationDurations, os, expectedStatus) => {
       Platform.OS = os;
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
 
       const currentStatus: ExposureStatus = {
         type: ExposureStatusType.Monitoring,
@@ -247,7 +246,6 @@ describe('ExposureNotificationService', () => {
       // before or after the old match
       Platform.OS = os;
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
 
       const currentSummary = getSummary({
         today,
@@ -306,12 +304,6 @@ describe('ExposureNotificationService', () => {
   });
 
   it('backfills keys when last timestamp not available', async () => {
-    const today = new OriginalDate('2020-05-18T04:10:00+0000');
-    dateSpy.mockImplementation((args: any) => {
-      if (args === undefined) return new OriginalDate('2020-05-19T11:10:00+0000');
-      return new OriginalDate(args);
-    });
-
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
   });
@@ -366,10 +358,6 @@ describe('ExposureNotificationService', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('stores last update timestamp', async () => {
     const currentDatetime = new OriginalDate('2020-05-19T07:10:00+0000');
-    dateSpy.mockImplementation((args: any) => {
-      if (args === undefined) return currentDatetime;
-      return new OriginalDate(args);
-    });
 
     service.exposureStatus.append({
       lastChecked: {
@@ -397,9 +385,6 @@ describe('ExposureNotificationService', () => {
   });
 
   it('enters Diagnosed flow when start keys submission process', async () => {
-    dateSpy.mockImplementation(() => {
-      return new OriginalDate();
-    });
     when(server.claimOneTimeCode)
       .calledWith('12345678')
       .mockResolvedValue({
@@ -427,9 +412,6 @@ describe('ExposureNotificationService', () => {
           cycleStartsAt: new OriginalDate('2020-05-18T04:10:00+0000').toString(),
         }),
       );
-    dateSpy.mockImplementation((...args) =>
-      args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-19T04:10:00+0000'),
-    );
 
     await service.start();
 
@@ -438,18 +420,6 @@ describe('ExposureNotificationService', () => {
         type: ExposureStatusType.Diagnosed,
       }),
     );
-  });
-
-  describe('NeedsSubmission status calculated initially', () => {
-    beforeEach(() => {
-      dateSpy.mockImplementation((...args) =>
-        args.length > 0 ? new OriginalDate(...args) : new OriginalDate('2020-05-19T04:10:00+0000'),
-      );
-      service.exposureStatus.append({
-        type: ExposureStatusType.Diagnosed,
-        cycleStartsAt: new OriginalDate('2020-05-14T04:10:00+0000').getTime(),
-      });
-    });
   });
 
   it('needsSubmission status recalculates daily', async () => {
@@ -515,7 +485,6 @@ describe('ExposureNotificationService', () => {
   describe('isReminderNeeded', () => {
     it('returns true when missing uploadReminderLastSentAt', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
 
       const status = {
         type: ExposureStatusType.Diagnosed,
@@ -529,7 +498,6 @@ describe('ExposureNotificationService', () => {
     it('returns true when uploadReminderLastSentAt is a day old', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
       const lastSent = new OriginalDate('2020-05-17T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
 
       const status = {
         type: ExposureStatusType.Diagnosed,
@@ -543,7 +511,6 @@ describe('ExposureNotificationService', () => {
     it('returns false when uploadReminderLastSentAt is < 1 day old', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
       const lastSent = today;
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
 
       const status = {
         type: ExposureStatusType.Diagnosed,
@@ -558,7 +525,7 @@ describe('ExposureNotificationService', () => {
   describe('updateExposureStatus', () => {
     it('keeps lastChecked when reset from diagnosed state to monitoring state', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((args: any) => (args ? new OriginalDate(args) : today));
+
       const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
       service.exposureStatus.set({
         type: ExposureStatusType.Diagnosed,
@@ -590,7 +557,6 @@ describe('ExposureNotificationService', () => {
       [20, ExposureStatusType.Monitoring],
     ])('if exposed %p days ago, state expected to be %p', async (daysAgo, expectedStatus) => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
 
       service.exposureStatus.set({
@@ -622,7 +588,6 @@ describe('ExposureNotificationService', () => {
 
     it('does not reset to monitoring state when lastExposureTimestamp is not available', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
       service.exposureStatus.set({
         type: ExposureStatusType.Exposed,
@@ -688,7 +653,6 @@ describe('ExposureNotificationService', () => {
     it('selects current exposure summary if user is already exposed', async () => {
       // abc
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       const period = periodSinceEpoch(today, HOURS_PER_PERIOD);
       const currentSummary = getSummary({
         today,
@@ -755,7 +719,6 @@ describe('ExposureNotificationService', () => {
     it('processes the reminder push notification when diagnosed', async () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
       const lastSent = new OriginalDate('2020-05-17T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       service.exposureStatus.set({
         type: ExposureStatusType.Diagnosed,
         needsSubmission: true,
@@ -807,14 +770,11 @@ describe('ExposureNotificationService', () => {
       cycleEndsAt: today.getTime() - ONE_DAY,
       needsSubmission: true,
     });
-    dateSpy.mockImplementation((...args: any[]) => {
-      return args.length > 0 ? new OriginalDate(...args) : new OriginalDate();
-    });
+    dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
     expect(service.calculateNeedsSubmission()).toStrictEqual(false);
   });
 
   it('calculateNeedsSubmission when diagnosed true', () => {
-    dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
     const today = new OriginalDate();
     service.exposureStatus.set({
       type: ExposureStatusType.Diagnosed,
@@ -834,9 +794,7 @@ describe('ExposureNotificationService', () => {
       submissionLastCompletedAt: today.getTime(),
       needsSubmission: true,
     });
-    dateSpy.mockImplementation((...args: any[]) => {
-      return args.length > 0 ? new OriginalDate(...args) : today;
-    });
+
     expect(service.calculateNeedsSubmission()).toStrictEqual(false);
   });
 
@@ -854,25 +812,21 @@ describe('ExposureNotificationService', () => {
   describe('getPeriodsSinceLastFetch', () => {
     it('returns an array of [0, runningPeriod] if _lastCheckedPeriod is undefined', () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       expect(service.getPeriodsSinceLastFetch()).toStrictEqual([0, 18400]);
     });
 
     it('returns an array of checkdates between lastCheckedPeriod and runningPeriod', () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       expect(service.getPeriodsSinceLastFetch(18395)).toStrictEqual([18400, 18399, 18398, 18397, 18396, 18395]);
     });
 
     it('returns an array of runningPeriod when current runningPeriod == _lastCheckedPeriod', () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       expect(service.getPeriodsSinceLastFetch(18400)).toStrictEqual([18400]);
     });
 
     it('returns an array of [runningPeriod, runningPeriod - 1] when current runningPeriod = _lastCheckedPeriod + 1', () => {
       const today = new OriginalDate('2020-05-18T04:10:00+0000');
-      dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
       expect(service.getPeriodsSinceLastFetch(18399)).toStrictEqual([18400, 18399]);
     });
   });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -146,7 +146,7 @@ describe('ExposureNotificationService', () => {
     service.systemStatus.set(SystemStatus.Active);
     when(storage.getItem)
       .calledWith(Key.OnboardedDatetime)
-      .mockResolvedValueOnce(today.getTime());
+      .mockResolvedValue(today.getTime());
     service.exposureStatus.append({
       lastChecked: {
         timestamp: today.getTime() - ONE_DAY,
@@ -157,6 +157,7 @@ describe('ExposureNotificationService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    resetAllWhenMocks();
     dateSpy.mockReset();
   });
 
@@ -331,7 +332,9 @@ describe('ExposureNotificationService', () => {
         period: periodSinceEpoch(new OriginalDate('2020-05-19T06:10:00+0000'), HOURS_PER_PERIOD),
       },
     });
+
     await service.updateExposureStatus();
+
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(1);
 
     server.retrieveDiagnosisKeys.mockClear();
@@ -890,8 +893,6 @@ describe('ExposureNotificationService', () => {
     });
 
     it('returns false if not onboarded', async () => {
-      resetAllWhenMocks();
-
       when(storage.getItem)
         .calledWith(Key.OnboardedDatetime)
         .mockResolvedValueOnce(false);

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -304,6 +304,12 @@ describe('ExposureNotificationService', () => {
   });
 
   it('backfills keys when last timestamp not available', async () => {
+    const today = new OriginalDate('2020-05-18T04:10:00+0000');
+    dateSpy.mockImplementation((args: any) => {
+      if (args === undefined) return new OriginalDate('2020-05-19T11:10:00+0000');
+      return new OriginalDate(args);
+    });
+
     await service.updateExposureStatus();
     expect(server.retrieveDiagnosisKeys).toHaveBeenCalledTimes(2);
   });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -820,22 +820,18 @@ describe('ExposureNotificationService', () => {
 
   describe('getPeriodsSinceLastFetch', () => {
     it('returns an array of [0, runningPeriod] if _lastCheckedPeriod is undefined', () => {
-      const today = new OriginalDate('2020-05-18T04:10:00+0000');
       expect(service.getPeriodsSinceLastFetch()).toStrictEqual([0, 18400]);
     });
 
     it('returns an array of checkdates between lastCheckedPeriod and runningPeriod', () => {
-      const today = new OriginalDate('2020-05-18T04:10:00+0000');
       expect(service.getPeriodsSinceLastFetch(18395)).toStrictEqual([18400, 18399, 18398, 18397, 18396, 18395]);
     });
 
     it('returns an array of runningPeriod when current runningPeriod == _lastCheckedPeriod', () => {
-      const today = new OriginalDate('2020-05-18T04:10:00+0000');
       expect(service.getPeriodsSinceLastFetch(18400)).toStrictEqual([18400]);
     });
 
     it('returns an array of [runningPeriod, runningPeriod - 1] when current runningPeriod = _lastCheckedPeriod + 1', () => {
-      const today = new OriginalDate('2020-05-18T04:10:00+0000');
       expect(service.getPeriodsSinceLastFetch(18399)).toStrictEqual([18400, 18399]);
     });
   });


### PR DESCRIPTION
# Summary | Résumé

Some cleanup in the ExposureNotificationService test file to make tests more consistent and less cluttered.
- Remove repetitive/unnecessary Date mocks. The mock is already setup in beforeEach
- Make tests more consistent by setting OnboardedDateTime mock to continuous (instead of once)
- Remove unnecessary exposureStatus config from beforeEach
- Add `resetAllWhenMocks` to afterEach
