### PR TITLE
Bypass the shouldPerformExposureCheck() logic from the test menu

### DIFF
--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -167,7 +167,7 @@ const Content = () => {
           variant="bigFlat"
           onPress={async () => {
             captureMessage('Forcing Exposure Check');
-            updateExposureStatus();
+            updateExposureStatus(true);
           }}
         />
       </Section>

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -232,8 +232,8 @@ export class ExposureNotificationService {
     });
   }
 
-  async updateExposureStatus(): Promise<void> {
-    if (!(await this.shouldPerformExposureCheck())) return;
+  async updateExposureStatus(forceCheck = false): Promise<void> {
+    if (!forceCheck && !(await this.shouldPerformExposureCheck())) return;
     if (this.exposureStatusUpdatePromise) return this.exposureStatusUpdatePromise;
     const cleanUpPromise = <T>(input: T): T => {
       this.exposureStatusUpdatePromise = null;

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -118,9 +118,13 @@ export function useExposureStatus(): ExposureStatus {
 
 export function useUpdateExposureStatus(): () => void {
   const exposureNotificationService = useExposureNotificationService();
-  const update = useCallback(() => {
-    exposureNotificationService.updateExposureStatus();
-  }, [exposureNotificationService]);
+  const update = useCallback(
+    (forceCheck = false) => {
+      exposureNotificationService.updateExposureStatus(forceCheck);
+    },
+    [exposureNotificationService],
+  );
+
   return update;
 }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -116,7 +116,7 @@ export function useExposureStatus(): ExposureStatus {
   return state;
 }
 
-export function useUpdateExposureStatus(): () => void {
+export function useUpdateExposureStatus(): (forceCheck?: boolean) => void {
   const exposureNotificationService = useExposureNotificationService();
   const update = useCallback(
     (forceCheck = false) => {


### PR DESCRIPTION
# Summary | Résumé

During testing we often need to force exposure checks to happen more frequently than every 4 hours. We already have a button in the Test menu labelled "Force exposure check". This PR adds an optional argument `forceCheck` that is set to true in the test menu.