### PR TITLE
Android handle Work Profile or Multiple Profile error

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -22,6 +22,7 @@ import app.covidshield.models.Configuration
 import app.covidshield.models.ExposureKey
 import app.covidshield.receiver.ExposureNotificationBroadcastReceiver
 import app.covidshield.utils.ActivityResultHelper
+import app.covidshield.utils.CovidShieldException.ApiNotConnectedException
 import app.covidshield.utils.CovidShieldException.ApiNotEnabledException
 import app.covidshield.utils.CovidShieldException.InvalidActivityException
 import app.covidshield.utils.CovidShieldException.NoResolutionRequiredException
@@ -84,15 +85,19 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     @ReactMethod
     fun start(promise: Promise) {
         promise.launch(this) {
-            if (!isPlayServicesAvailable()) {
-                throw PlayServicesNotAvailableException()
+            try{
+                if (!isPlayServicesAvailable()) {
+                    throw PlayServicesNotAvailableException()
+                }
+                val status = getStatusInternal()
+                if (status != Status.ACTIVE) {
+                    stopInternal()
+                    startInternal()
+                }
+                promise.resolve(null);
+            } catch (exception: java.lang.Exception) {
+                promise.reject(exception)
             }
-            val status = getStatusInternal()
-            if (status != Status.ACTIVE) {
-                stopInternal()
-                startInternal()
-            }
-            promise.resolve(null)
         }
     }
 
@@ -233,26 +238,33 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
             if (exception !is ApiException) {
                 throw UnknownException(exception)
             }
-            if (exception.statusCode == ExposureNotificationStatusCodes.RESOLUTION_REQUIRED) {
-                startResolutionCompleter = CompletableDeferred()
-                try {
-                    exception.status.startResolutionForResult(
-                        activity,
-                        START_RESOLUTION_FOR_RESULT_REQUEST_CODE
-                    )
-                    startResolutionCompleter?.await()
-                    startResolutionCompleter = null
-                    startInternal()
-                } catch (exception: IntentSender.SendIntentException) {
-                    startResolutionCompleter?.completeExceptionally(SendIntentException(exception))
-                } catch (exception: Exception) {
-                    startResolutionCompleter?.completeExceptionally(PermissionDeniedException(exception))
-                } finally {
-                    startResolutionCompleter = null
+            when(exception.statusCode) {
+                ExposureNotificationStatusCodes.RESOLUTION_REQUIRED -> {
+                    startResolutionCompleter = CompletableDeferred()
+                    try {
+                        exception.status.startResolutionForResult(
+                                activity,
+                                START_RESOLUTION_FOR_RESULT_REQUEST_CODE
+                        )
+                        startResolutionCompleter?.await()
+                        startResolutionCompleter = null
+                        startInternal()
+                    } catch (exception: IntentSender.SendIntentException) {
+                        startResolutionCompleter?.completeExceptionally(SendIntentException(exception))
+                    } catch (exception: Exception) {
+                        startResolutionCompleter?.completeExceptionally(PermissionDeniedException(exception))
+                    } finally {
+                        startResolutionCompleter = null
+                    }
                 }
-            } else {
-                log(exception.message)
-                throw NoResolutionRequiredException(exception)
+                ExposureNotificationStatusCodes.API_NOT_CONNECTED -> {
+                    log(exception.message)
+                    throw ApiNotConnectedException(exception)
+                }
+                else -> {
+                    log(exception.message)
+                    throw NoResolutionRequiredException(exception)
+                }
             }
         }
     }

--- a/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
+++ b/android/app/src/main/java/app/covidshield/utils/CovidShieldException.kt
@@ -4,6 +4,8 @@ object CovidShieldException {
 
     class UnknownException(cause: Throwable? = null) : Exception("UNKNOWN", cause)
 
+    class ApiNotConnectedException(cause: Throwable) : Exception("API_NOT_CONNECTED", cause)
+
     class ApiNotEnabledException : Exception("API_NOT_ENABLED")
 
     class SummaryTokenNotFoundException : IllegalArgumentException("SUMMARY_TOKEN_NOT_FOUND")

--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -442,6 +442,10 @@
     "DataSharingStep2": {
       "Title": "",
       "Body": "You need to choose an answer before going to the next step."
+    },
+    "ApiNotConnected": {
+      "Title": "Something went wrong",
+      "Body": "Unfortunately, it looks like COVID Alert will not work on this phone. \n\nIf you have more than one profile on your phone, try installing the app in the main profile."
     }
   }
 }

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -156,6 +156,10 @@
     "DataSharingStep2": {
       "Title": "",
       "Body": "Vous devez sélectionner une réponse pour passer à l’étape suivante."
+    },
+    "ApiNotConnected": {
+      "Title": "Une erreur s'est produite",
+      "Body": "Malheureusement, il semble qu'Alerte COVID ne fonctionne pas sur votre téléphone. \n\nSi vous avez plusieurs profils utilisateur, essayez d'installer l'application dans le profil de base."
     }
   },
   "Home": {

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -20,6 +20,7 @@ import {SafeAreaProvider} from 'react-native-safe-area-context';
 import {OnboardingScreen} from 'screens/onboarding';
 import {LandingScreen} from 'screens/landing';
 import {TestScreen} from 'screens/testScreen';
+import {ErrorScreen} from 'screens/errorScreen/ErrorScreen';
 
 import {FormContext, FormContextDefaults} from '../shared/FormContext';
 
@@ -79,6 +80,7 @@ const LanguageScreenWithNavBar = withDarkNav(LanguageScreen);
 const RegionPickerSettingsScreenWithNavBar = withDarkNav(RegionPickerSettingsScreen);
 const NoCodeWithNavBar = withDarkNav(NoCodeScreen);
 const TestScreenWithNavBar = withDarkNav(TestScreen);
+const ErrorScreenWithNavBar = withDarkNav(ErrorScreen);
 
 const OnboardingWithNavBar = withDarkNavNonModal(OnboardingScreen);
 
@@ -145,6 +147,7 @@ const MainNavigator = () => {
       <MainStack.Screen name="RegionSelect" component={RegionPickerSettingsScreenWithNavBar} />
       <MainStack.Screen name="NoCode" component={NoCodeWithNavBar} />
       <MainStack.Screen name="TestScreen" component={TestScreenWithNavBar} />
+      <MainStack.Screen name="ErrorScreen" component={ErrorScreenWithNavBar} />
     </MainStack.Navigator>
   );
 };

--- a/src/screens/errorScreen/ErrorScreen.tsx
+++ b/src/screens/errorScreen/ErrorScreen.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Box} from 'components';
+
+import {ApiNotConnectedView} from './views/ApiNotConnectedView';
+
+const Content = () => {
+  return <ApiNotConnectedView />;
+};
+
+export const ErrorScreen = () => {
+  return (
+    <Box flex={1} alignItems="center" backgroundColor="mainBackground">
+      <Box
+        flex={1}
+        paddingTop="m"
+        paddingBottom="m"
+        alignSelf="stretch"
+        accessibilityElementsHidden={false}
+        importantForAccessibility="no-hide-descendants"
+      >
+        <Content />
+      </Box>
+    </Box>
+  );
+};

--- a/src/screens/errorScreen/components/BaseErrorView.tsx
+++ b/src/screens/errorScreen/components/BaseErrorView.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {StyleSheet, ScrollView} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {Box, Header, Icon, IconName} from 'components';
+
+interface BaseHomeViewProps {
+  children?: React.ReactNode;
+  iconName?: IconName;
+  testID?: string;
+}
+
+export const BaseErrorView = ({children, iconName, testID}: BaseHomeViewProps) => {
+  return (
+    <>
+      <SafeAreaView edges={['top']}>
+        <Header />
+      </SafeAreaView>
+      <ScrollView
+        alwaysBounceVertical={false}
+        style={styles.scrollView}
+        testID={testID}
+        contentContainerStyle={styles.scrollContainer}
+      >
+        <SafeAreaView edges={['left', 'right']}>
+          <Box width="100%" justifyContent="flex-start" marginBottom="-l">
+            <Box style={{...styles.primaryIcon}}>
+              <Icon name={iconName} height={120} width={150} />
+            </Box>
+          </Box>
+          <Box
+            width="100%"
+            flex={1}
+            alignItems="flex-start"
+            justifyContent="flex-start"
+            paddingHorizontal="m"
+            marginBottom="l"
+          >
+            {children}
+          </Box>
+        </SafeAreaView>
+      </ScrollView>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  primaryIcon: {marginLeft: -40, marginBottom: 30},
+  scrollContainerWithAnimation: {
+    marginTop: -100,
+  },
+  scrollView: {
+    height: '100%',
+  },
+  scrollContainer: {
+    maxWidth: 600,
+    alignItems: 'flex-start',
+  },
+});

--- a/src/screens/errorScreen/views/ApiNotConnectedView.tsx
+++ b/src/screens/errorScreen/views/ApiNotConnectedView.tsx
@@ -1,0 +1,20 @@
+import {useI18n} from 'locale';
+import {Text, TextMultiline} from 'components';
+import React from 'react';
+import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
+
+import {BaseErrorView} from '../components/BaseErrorView';
+
+export const ApiNotConnectedView = () => {
+  const i18n = useI18n();
+
+  const autoFocusRef = useAccessibilityAutoFocus(true);
+  return (
+    <BaseErrorView iconName="icon-bluetooth-disabled">
+      <Text focusRef={autoFocusRef} variant="bodyTitle" marginBottom="m" accessibilityRole="header">
+        {i18n.translate('Errors.ApiNotConnected.Title')}
+      </Text>
+      <TextMultiline marginBottom="m" text={i18n.translate('Errors.ApiNotConnected.Body')} />
+    </BaseErrorView>
+  );
+};

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -37,10 +37,12 @@ export const OnboardingScreen = () => {
   );
 
   const onSnapToNewPage = useCallback(
-    (index: number) => {
+    async (index: number) => {
       // we want the EN permission dialogue to appear on the last step.
       if (index === onboardingData.length - 1) {
-        startExposureNotificationService();
+        if (!(await startExposureNotificationService())) {
+          navigation.navigate('ErrorScreen');
+        }
       }
 
       // we want region cleared on the 2nd last step

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -41,7 +41,10 @@ export const OnboardingScreen = () => {
       // we want the EN permission dialogue to appear on the last step.
       if (index === onboardingData.length - 1) {
         if (!(await startExposureNotificationService())) {
-          navigation.navigate('ErrorScreen');
+          navigation.reset({
+            index: 0,
+            routes: [{name: 'ErrorScreen'}],
+          });
         }
       }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -123,9 +123,9 @@ export class ExposureNotificationService {
     });
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<boolean> {
     if (this.starting) {
-      return;
+      return true;
     }
 
     this.starting = true;
@@ -136,11 +136,13 @@ export class ExposureNotificationService {
       await this.exposureNotification.start();
     } catch (error) {
       captureException('Cannot start EN framework', error);
+      return false;
     }
 
     await this.updateSystemStatus();
 
     this.starting = false;
+    return true;
   }
 
   async updateSystemStatus(): Promise<void> {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -85,10 +85,10 @@ export function useExposureNotificationService() {
   return useContext(ExposureNotificationServiceContext)!;
 }
 
-export function useStartExposureNotificationService(): () => Promise<void> {
+export function useStartExposureNotificationService(): () => Promise<boolean> {
   const exposureNotificationService = useExposureNotificationService();
   return useCallback(async () => {
-    await exposureNotificationService.start();
+    return exposureNotificationService.start();
   }, [exposureNotificationService]);
 }
 


### PR DESCRIPTION
# Summary | Résumé

re-submit of #1224 

**ANDROID ONLY**
When a work profile or second profile is installed on the phone, Exposure Notifications are not available. This fix will show an error letting the user know that it's not working.

Unfortunately, it is not possible to detect this scenario until attempting to turn on the EN framework, which we don't do until onboarding is almost complete.

Fixes #1214 

# Test instructions | Instructions pour tester la modification

On an Android phone, create a 2nd profile. This can be a work profile, or simply a second profile.

- Install a fresh version of the app. 
- Launch app.
- Select language.
- Go through on-boarding.
- Once you get to the province selection page, there should be a brief pause, and then the error page should appear.

# Help requested | Aide requise


# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

It would be nice if the user couldn't use the Android system button to navigate back to the onboarding screens.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :


- [x] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [x] Is it accessible? | Est-ce que c’est accessible?
- [x] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
- [x] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [x] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?


