### PR TITLE
Refactor getInternalStatus function for readability.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -312,16 +312,9 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     }
 
     private suspend fun getStatusInternal(): Status {
-        if (!isPlayServicesAvailable()) {
-            return Status.PLAY_SERVICES_NOT_AVAILABLE
-        }
-        val isExposureNotificationEnabled = try {
-            exposureNotificationClient.isEnabled.await()
-        } catch (_: Exception) {
-            false
-        }
         return when {
-            !isExposureNotificationEnabled -> Status.DISABLED
+            !isPlayServicesAvailable() -> Status.PLAY_SERVICES_NOT_AVAILABLE
+            !isExposureNotificationEnabled() -> Status.DISABLED
             !isBluetoothEnabled() -> Status.BLUETOOTH_OFF
             !isLocationEnabled() -> Status.LOCATION_OFF
             else -> Status.ACTIVE
@@ -332,6 +325,15 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
         val context = reactApplicationContext.applicationContext
         val exposureNotificationSettingsIntent = Intent(ACTION_EXPOSURE_NOTIFICATION_SETTINGS)
         return exposureNotificationSettingsIntent.resolveActivity(context.packageManager) != null
+    }
+
+    private suspend fun isExposureNotificationEnabled(): Boolean {
+        try {
+            exposureNotificationClient.isEnabled.await()
+            return true
+        } catch (_: Exception) {
+            return false
+        }
     }
 
     private fun isBluetoothEnabled(): Boolean {


### PR DESCRIPTION
# Summary | Résumé

A small change to the `getInternalStatus` function to improve readability of the function.

# Test instructions | Instructions pour tester la modification

To fully test this change, each of the scenarios would need to be tested:
- Android phone without Play Services updated
- Exposure Notification turned off
- Bluetooth disabled
- Android 11... location services turned off, should still work
- Android 10 or lower, location services turned off, should display the error page