### PR TITLE
Remove `resetAllData` API call.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -112,12 +112,6 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     }
 
     @ReactMethod
-    fun resetAllData(promise: Promise) {
-        // This method does not exist in the android nearby SDK.
-        promise.resolve(null)
-    }
-
-    @ReactMethod
     fun getStatus(promise: Promise) {
         promise.launch(this) {
             val status = getStatusInternal()

--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -95,7 +95,6 @@ export interface ExposureInformation {
 export interface ExposureNotification {
   start(): Promise<void>;
   stop(): Promise<void>;
-  resetAllData(): Promise<void>;
   getStatus(): Promise<Status>;
   getTemporaryExposureKeyHistory(): Promise<TemporaryExposureKey[]>;
   detectExposure(configuration: ExposureConfiguration, diagnosisKeysURLs: string[]): Promise<ExposureSummary[]>;

--- a/src/screens/testScreen/MockExposureNotification.ts
+++ b/src/screens/testScreen/MockExposureNotification.ts
@@ -12,7 +12,6 @@ export class MockExposureNotification implements ExposureNotification {
 
   start = async () => {};
   stop = async () => {};
-  resetAllData = async () => {};
 
   getStatus = async () => this.status;
 


### PR DESCRIPTION
# Summary | Résumé
Removing dead code... a call in the Exposure Notification Bridge code that does not exist in the EN API. Presumably this was for an idea that was never implemented.

# Test instructions | Instructions pour tester la modification
This code was never executed. All tests should perform exactly how they performed before, and the Jest Tests should all still pass.
