### PR TITLE
Update iOS Push Notification package

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -318,8 +318,8 @@ PODS:
     - React
   - RNCPicker (1.6.6):
     - React
-  - RNCPushNotificationIOS (1.3.0):
-    - React
+  - RNCPushNotificationIOS (1.7.3):
+    - React-Core
   - RNGestureHandler (1.6.1):
     - React
   - RNLocalize (1.4.0):
@@ -573,7 +573,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 453cd7c335ec9ba3b877e27d02238956b76f3268
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNCPicker: 494015f2b7ec4bee5484b6f235aa19691426dcdb
-  RNCPushNotificationIOS: d5fd66aed4e03c6491ca0c6111a03d4f6455ff6c
+  RNCPushNotificationIOS: edeeea93b7210d2f918fc0e46e1a2a189b5fdacc
   RNGestureHandler: 8f09cd560f8d533eb36da5a6c5a843af9f056b38
   RNLocalize: b6df30cc25ae736d37874f9bce13351db2f56796
   RNPermissions: 3635b407c15f2fe591bd2101c8f20aa0912caba8

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/netinfo": "^5.9.5",
     "@react-native-community/picker": "^1.6.6",
-    "@react-native-community/push-notification-ios": "^1.3.0",
+    "@react-native-community/push-notification-ios": "^1.7.3",
     "@react-navigation/drawer": "^5.8.6",
     "@react-navigation/native": "^5.7.1",
     "@react-navigation/stack": "^5.7.1",

--- a/src/bridge/PushNotification.ts
+++ b/src/bridge/PushNotification.ts
@@ -15,7 +15,11 @@ const PushNotificationIOS: PushNotificationInterface = {
   requestPermissions: RNPushNotification.requestPermissions,
   presentLocalNotification: payload => {
     RNPushNotification.removeAllDeliveredNotifications();
-    RNPushNotification.presentLocalNotification(payload);
+    RNPushNotification.addNotificationRequest({
+      id: 'exposureNotification',
+      title: payload.alertTitle,
+      body: payload.alertBody,
+    });
   },
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1313,9 +1313,10 @@
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/picker/-/picker-1.6.6.tgz#827edfbcb6c2e3f6f5c68674f52249fd7d03a0bc"
 
-"@react-native-community/push-notification-ios@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.3.0.tgz#349095f5dda42f59501316c7ef7896adb8c2a1db"
+"@react-native-community/push-notification-ios@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@react-native-community/push-notification-ios/-/push-notification-ios-1.7.3.tgz#7b41add329996df59382820d8a729fe609c2fb75"
+  integrity sha512-SLGQMxSB4WTvATjCXELxansnseLcmqJ6jIC8U4AyjxL30k3m1YmbrO4wGMw/ZF/VSC1toK+a39aD+ozDjon3mw==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Summary | Résumé

Updates `@react-native-community/push-notification-ios` to 1.7.3 from 1.3.0. This changed the API slightly, which we were able to handle in the bridge code.

# Test instructions | Instructions pour tester la modification

You will need to update packages and pods:

```
yarn install
yarn pod-install
```

Run the app on iOS, open Demo menu, trigger notification

This does not affect the Android implementation of same
