### PR TITLE
Don't show WorkProfile error on iOS

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useRef} from 'react';
-import {ListRenderItem, StyleSheet, useWindowDimensions, View} from 'react-native';
+import {ListRenderItem, StyleSheet, useWindowDimensions, View, Platform} from 'react-native';
 import Carousel from 'react-native-snap-carousel';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Button, ProgressCircles} from 'components';
@@ -41,10 +41,12 @@ export const OnboardingScreen = () => {
       // we want the EN permission dialogue to appear on the last step.
       if (index === onboardingData.length - 1) {
         if (!(await startExposureNotificationService())) {
-          navigation.reset({
-            index: 0,
-            routes: [{name: 'ErrorScreen'}],
-          });
+          if (Platform.OS === 'android') {
+            navigation.reset({
+              index: 0,
+              routes: [{name: 'ErrorScreen'}],
+            });
+          }
         }
       }
 
@@ -53,7 +55,7 @@ export const OnboardingScreen = () => {
         setRegion(undefined);
       }
     },
-    [setRegion, startExposureNotificationService],
+    [navigation, setRegion, startExposureNotificationService],
   );
 
   const nextItem = useCallback(async () => {


### PR DESCRIPTION
# Summary | Résumé

Skips rendering the Work/Multiple Profile error if we're on iOS.

