### PR TITLE
Throw and catch specific error for work profile on Android.

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useRef} from 'react';
-import {ListRenderItem, StyleSheet, useWindowDimensions, View, Platform} from 'react-native';
+import {ListRenderItem, StyleSheet, useWindowDimensions, View} from 'react-native';
 import Carousel from 'react-native-snap-carousel';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Button, ProgressCircles} from 'components';
@@ -40,8 +40,10 @@ export const OnboardingScreen = () => {
     async (index: number) => {
       // we want the EN permission dialogue to appear on the last step.
       if (index === onboardingData.length - 1) {
-        if (!(await startExposureNotificationService())) {
-          if (Platform.OS === 'android') {
+        try {
+          await startExposureNotificationService();
+        } catch (error) {
+          if (error.message === 'API_NOT_CONNECTED') {
             navigation.reset({
               index: 0,
               routes: [{name: 'ErrorScreen'}],

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -132,13 +132,7 @@ export class ExposureNotificationService {
     this.starting = true;
 
     await this.loadExposureStatus();
-
-    try {
-      await this.exposureNotification.start();
-    } catch (error) {
-      throw error;
-    }
-
+    await this.exposureNotification.start();
     await this.updateSystemStatus();
 
     this.starting = false;

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -136,8 +136,7 @@ export class ExposureNotificationService {
     try {
       await this.exposureNotification.start();
     } catch (error) {
-      captureException('Cannot start EN framework', error);
-      return false;
+      throw error;
     }
 
     await this.updateSystemStatus();


### PR DESCRIPTION
# Summary | Résumé

This is an update to the Android Work Profile fix. This ensures that the error screen only gets displayed when the API is not available due to a profile issue on Android. The previous fix showed this error if the user declined enabling the app during the onboarding process.

# Test instructions | Instructions pour tester la modification

Test the following scenarios:
- iOS, complete onboarding, Enable framework, see normal homepage
- iOS, complete onboarding, Do not Enable framework, see homepage with error
- Android without Work Profile, complete onboarding, Enable framework, see normal homepage
- Android without Work Profile, complete onboarding, Do not Enable framework, see homepage with error
- Android with Work Profile or 2nd Profile, complete onboarding, do not see pop up with Enable option, and see "Something went wrong" error page.