### PR TITLE
Add date formatting

### DIFF
--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -15,7 +15,6 @@ export const ExposureDateView = () => {
   const exposureNotificationService = useExposureNotificationService();
 
   const formatDate = (locale: string, localeString: string) => {
-    console.log(locale, localeString);
     const parts = localeString.split(' ');
     // @note \u00a0 is a non breaking space so the date doesn't wrap
     if (locale === 'en-CA') {
@@ -31,7 +30,7 @@ export const ExposureDateView = () => {
     // const timeStamp = exposureNotificationService.getExposureDetectedAt();
     const timeStamp = 1605721270000;
     if (timeStamp) return formatDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
-  }, [dateFormatOptions, dateLocale, exposureNotificationService]);
+  }, [dateFormatOptions, dateLocale]);
 
   return date ? (
     <Text marginBottom="m">

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -2,6 +2,7 @@ import React, {useMemo} from 'react';
 import {Text} from 'components';
 import {useI18n} from 'locale';
 import {useExposureNotificationService} from 'services/ExposureNotificationService';
+import {formatExposedDate} from 'shared/date-fns';
 
 export const ExposureDateView = () => {
   const i18n = useI18n();
@@ -14,21 +15,10 @@ export const ExposureDateView = () => {
 
   const exposureNotificationService = useExposureNotificationService();
 
-  const formatDate = (locale: string, localeString: string) => {
-    const parts = localeString.split(' ');
-    // @note \u00a0 is a non breaking space so the date doesn't wrap
-    if (locale === 'en-CA') {
-      return `${parts[0]}.\u00a0${parts[1]}\u00a0${parts[2]}`;
-    } else if (locale === 'fr-CA') {
-      return `${parts[0]}\u00a0${parts[1]}\u00a0${parts[2]}`;
-    }
-
-    return localeString;
-  };
-
   const date = useMemo(() => {
     const timeStamp = exposureNotificationService.getExposureDetectedAt();
-    if (timeStamp) return formatDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
+    if (timeStamp)
+      return formatExposedDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
   }, [dateFormatOptions, dateLocale]);
 
   return date ? (

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -6,7 +6,7 @@ import {useExposureNotificationService} from 'services/ExposureNotificationServi
 export const ExposureDateView = () => {
   const i18n = useI18n();
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
-  const dateFormat = {
+  const dateFormatOptions = {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -14,10 +14,24 @@ export const ExposureDateView = () => {
 
   const exposureNotificationService = useExposureNotificationService();
 
+  const formatDate = (locale: string, localeString: string) => {
+    console.log(locale, localeString);
+    const parts = localeString.split(' ');
+    // @note \u00a0 is a non breaking space so the date doesn't wrap
+    if (locale === 'en-CA') {
+      return `${parts[0]}.\u00a0${parts[1]}\u00a0${parts[2]}`;
+    } else if (locale === 'fr-CA') {
+      return `${parts[0]}\u00a0${parts[1]}\u00a0${parts[2]}`;
+    }
+
+    return localeString;
+  };
+
   const date = useMemo(() => {
-    const timeStamp = exposureNotificationService.getExposureDetectedAt();
-    if (timeStamp) return new Date(timeStamp).toLocaleString(dateLocale, dateFormat);
-  }, [dateFormat, dateLocale, exposureNotificationService]);
+    // const timeStamp = exposureNotificationService.getExposureDetectedAt();
+    const timeStamp = 1605721270000;
+    if (timeStamp) return formatDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
+  }, [dateFormatOptions, dateLocale, exposureNotificationService]);
 
   return date ? (
     <Text marginBottom="m">

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -19,7 +19,7 @@ export const ExposureDateView = () => {
     const timeStamp = exposureNotificationService.getExposureDetectedAt();
     if (timeStamp)
       return formatExposedDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
-  }, [dateFormatOptions, dateLocale]);
+  }, [dateFormatOptions, dateLocale, exposureNotificationService]);
 
   return date ? (
     <Text marginBottom="m">

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -27,8 +27,7 @@ export const ExposureDateView = () => {
   };
 
   const date = useMemo(() => {
-    // const timeStamp = exposureNotificationService.getExposureDetectedAt();
-    const timeStamp = 1605721270000;
+    const timeStamp = exposureNotificationService.getExposureDetectedAt();
     if (timeStamp) return formatDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
   }, [dateFormatOptions, dateLocale]);
 

--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -8,6 +8,7 @@ import {
   getUploadDaysLeft,
   getCurrentDate,
   parseDateString,
+  formatExposedDate,
 } from './date-fns';
 
 /**
@@ -145,6 +146,20 @@ describe('date-fns', () => {
       const d1 = new Date('2020-07-06 00:00:01 GMT+0600');
       const d2 = new Date('2020-07-06 00:00:01 GMT+0500');
       expect(minutesBetween(d1, d2)).toStrictEqual(60);
+    });
+  });
+
+  //formatExposedDate
+  describe('formatExposedDate', () => {
+    it('returns formatted date for en', () => {
+      const dateFormatOptions = {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      };
+      //en-CA
+      const enStr = new Date(1605814310000).toLocaleString('en-CA', dateFormatOptions);
+      expect(formatExposedDate('en-CA', enStr)).toEqual('Nov.\u00a019,\u00a02020');
     });
   });
 

--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -149,7 +149,7 @@ describe('date-fns', () => {
     });
   });
 
-  //formatExposedDate
+  // formatExposedDate
   describe('formatExposedDate', () => {
     it('returns formatted date for en', () => {
       const dateFormatOptions = {
@@ -157,9 +157,9 @@ describe('date-fns', () => {
         day: 'numeric',
         year: 'numeric',
       };
-      //en-CA
+      // en-CA
       const enStr = new Date(1605814310000).toLocaleString('en-CA', dateFormatOptions);
-      expect(formatExposedDate('en-CA', enStr)).toEqual('Nov.\u00a019,\u00a02020');
+      expect(formatExposedDate('en-CA', enStr)).toStrictEqual('Nov.\u00a019,\u00a02020');
     });
   });
 

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -66,3 +66,15 @@ export function parseDateString(dateString: string) {
   const dateParts = dateString.split('-');
   return new Date(Number(dateParts[0]), Number(dateParts[1]) - 1, Number(dateParts[2]));
 }
+
+export const formatExposedDate = (locale: string, localeString: string) => {
+  const parts = localeString.split(' ');
+  // @note \u00a0 is a non breaking space so the date doesn't wrap
+  if (locale === 'en-CA') {
+    return `${parts[0]}.\u00a0${parts[1]}\u00a0${parts[2]}`;
+  } else if (locale === 'fr-CA') {
+    return `${parts[0]}\u00a0${parts[1]}\u00a0${parts[2]}`;
+  }
+
+  return localeString;
+};


### PR DESCRIPTION
Adds a date formatter to handle slightly customized date formatting vs the JS built in formatting.

**Before:**
<img width="200" src="https://user-images.githubusercontent.com/62242/99712733-76ef5700-2a71-11eb-9562-4ed1fa287843.png" />

**After:**
<img width="200" src="https://user-images.githubusercontent.com/62242/99712822-92f2f880-2a71-11eb-9d59-5d0844d0a7cb.png" />

Note: Bumped on the font size for these screens to show the wrapping.


