### PR TITLE
Exposure detected - text rollback

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -4,7 +4,7 @@
       "AllSetTitle": "You’re all set",
       "RegionCovered": {
         "Title": "No exposure detected",
-        "Body": "The app has not found any new exposures.",
+        "Body": "You have not been near anyone who reported a COVID-19 diagnosis through this app.",
         "GuidanceUrl": "https://www.canada.ca/en/public-health/services/publications/diseases-conditions/covid-19-how-to-isolate-at-home.html",
         "AllSetBody": "Your phone is now running Bluetooth to collect codes from nearby phones."
       },

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -252,7 +252,7 @@
         "AllSetBody": "Nous vous informerons dès que les personnes en dehors de l’Ontario peuvent signaler des diagnostics avec Alerte COVID.\n\nIl est tout de même utile de garder Alerte COVID activée.\n\nDe cette façon, vous pourrez être avisé dès que les personnes dont vous avez été près signalent un diagnostic."
       },
       "RegionCovered": {
-        "Body": "L’application n’a découvert aucune nouvelle exposition.",
+        "Body": "Vous n’avez été près d’aucune personne ayant signalé un diagnostic de COVID-19 avec cette application.",
         "GuidanceUrl": "https://www.canada.ca/fr/sante-publique/services/publications/maladies-et-affections/covid-19-comment-isoler-chez-soi.html",
         "Title": "Aucune exposition détectée",
         "AllSetBody": "Votre téléphone utilise maintenant Bluetooth pour collecter les codes provenant des téléphones voisins."


### PR DESCRIPTION
Rolling back this text.  It was missed after clear exposure status feature was pulled out (for now).