### PR TITLE
Remove unused package - @react-navigation/drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@react-native-community/netinfo": "^5.9.5",
     "@react-native-community/picker": "^1.6.6",
     "@react-native-community/push-notification-ios": "^1.7.3",
-    "@react-navigation/drawer": "^5.8.6",
     "@react-navigation/native": "^5.7.1",
     "@react-navigation/stack": "^5.7.1",
     "@shopify/react-hooks": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,13 +1331,6 @@
     react-is "^16.13.0"
     use-subscription "^1.4.0"
 
-"@react-navigation/drawer@^5.8.6":
-  version "5.8.6"
-  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-5.8.6.tgz#390f4dc267f833cc4f5f12ce535a916ad295561f"
-  dependencies:
-    color "^3.1.2"
-    react-native-iphone-x-helper "^1.2.1"
-
 "@react-navigation/native@^5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.7.1.tgz#5a59be6f7c1bf4cdf5e16625bf59688aeab808f8"


### PR DESCRIPTION
# Summary | Résumé

This package was previously used for the test menu, which is now a page not a drawer.