### PR TITLE
Add check for user stopped - for Unauthorized status panel

### DIFF
--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -277,7 +277,7 @@ export const OverlayView = ({status, notificationWarning, turnNotificationsOn, b
                 <SystemStatusOff i18n={i18n} />
               </Box>
             )}
-            {status === SystemStatus.Unauthorized && (
+            {!userStopped && status === SystemStatus.Unauthorized && (
               <Box marginBottom="m" marginHorizontal="m">
                 <SystemStatusUnauthorized i18n={i18n} />
               </Box>


### PR DESCRIPTION
Fixes iOS 13.6 bug where Status unauthorized panel was showing when Turn off was pressed + the user turned off from iOS settings.