### PR TITLE
Removes inline style from single line button

### DIFF
--- a/src/components/ButtonSingleLine.tsx
+++ b/src/components/ButtonSingleLine.tsx
@@ -70,6 +70,9 @@ export const ButtonSingleLine = ({
     borderBottomWidth,
     borderBottomColor: Platform.OS === 'ios' ? palette.fadedWhiteDark : borderBottomColor,
   };
+
+  const fontStyle = variant === 'bigFlatPurple' ? styles.strong : styles.normal;
+
   const content = (
     <Box
       borderRadius={borderRadius}
@@ -104,8 +107,8 @@ export const ButtonSingleLine = ({
               variant="menuItemTitle"
               style={{
                 ...styles.content,
+                ...fontStyle,
                 color: textColor || buttonColor,
-                fontWeight: variant === 'bigFlatPurple' ? 'bold' : 'normal',
               }}
             >
               {text}
@@ -176,5 +179,8 @@ const styles = StyleSheet.create({
   content: {},
   strong: {
     fontWeight: 'bold',
+  },
+  normal: {
+    fontWeight: 'normal',
   },
 });


### PR DESCRIPTION
Fixes the inline linting error for the `ButtonSingleLine` component

![Screen Shot 2020-11-27 at 1 27 15 PM](https://user-images.githubusercontent.com/62242/100476719-526c2e00-30b4-11eb-9c5d-6ebabc0a32cf.png)


**To test - use force screen** 

Visit exposed screen (bold text on purple button)
Visit diagnosed screen (normal text i.e. not bold)