### PR TITLE
Strip non-alpha chars from month string

### DIFF
--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -69,11 +69,16 @@ export function parseDateString(dateString: string) {
 
 export const formatExposedDate = (locale: string, localeString: string) => {
   const parts = localeString.split(' ');
+  const day = parts[1];
+  // remove non-alpha chars from month
+  const month = parts[0].replace(/\W/g, '');
+  const year = parts[2];
+
   // @note \u00a0 is a non breaking space so the date doesn't wrap
   if (locale === 'en-CA') {
-    return `${parts[0]}.\u00a0${parts[1]}\u00a0${parts[2]}`;
+    return `${month}.\u00a0${day}\u00a0${year}`;
   } else if (locale === 'fr-CA') {
-    return `${parts[0]}\u00a0${parts[1]}\u00a0${parts[2]}`;
+    return `${month}\u00a0${day}\u00a0${year}`;
   }
 
   return localeString;

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -69,9 +69,9 @@ export function parseDateString(dateString: string) {
 
 export const formatExposedDate = (locale: string, localeString: string) => {
   const parts = localeString.split(' ');
-  const day = parts[1];
   // remove non-alpha chars from month
   const month = parts[0].replace(/\W/g, '');
+  const day = parts[1];
   const year = parts[2];
 
   // @note \u00a0 is a non breaking space so the date doesn't wrap


### PR DESCRIPTION
The test spec around the date formatting function here was failing on some systems (ok, just one of mine). Caused by the system returning a short month string with a `.` character, to which we then appended another `.`

This change strips all non-word chars from the month string before creating the new date string.