### PR TITLE
Add types to log

### DIFF
--- a/src/shared/logging/config.ts
+++ b/src/shared/logging/config.ts
@@ -23,12 +23,12 @@ const config = {
 
 type Category = 'debug' | 'background' | 'configuration';
 
-export type Log = {
-  info: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
-  warn: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
-  debug: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
-  error: ({}: {category?: Category; message?: string; error?: string | {}}) => void;
-};
+interface Log {
+  info: (payload: {category?: Category; message?: string; payload?: string | {}}) => void;
+  warn: (payload: {category?: Category; message?: string; payload?: string | {}}) => void;
+  debug: (payload: {category?: Category; message?: string; payload?: string | {}}) => void;
+  error: (payload: {category?: Category; message?: string; error?: string | {}}) => void;
+}
 
 const reactLogger = logger.createLogger(config);
 

--- a/src/shared/logging/config.ts
+++ b/src/shared/logging/config.ts
@@ -21,7 +21,31 @@ const config = {
   },
 };
 
-export const log = logger.createLogger(config);
+type Category = 'debug' | 'background' | 'configuration';
+
+export type Log = {
+  info: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
+  warn: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
+  debug: ({}: {category?: Category; message?: string; payload?: string | {}}) => void;
+  error: ({}: {category?: Category; message?: string; error?: string | {}}) => void;
+};
+
+const reactLogger = logger.createLogger(config);
+
+export const log: Log = {
+  debug: payload => {
+    reactLogger.debug(payload);
+  },
+  info: payload => {
+    reactLogger.info(payload);
+  },
+  warn: payload => {
+    reactLogger.warn(payload);
+  },
+  error: payload => {
+    reactLogger.error(payload);
+  },
+};
 
 export const isTest = () => {
   return process.env.JEST_WORKER_ID !== undefined;


### PR DESCRIPTION
Add TypeScript definitions to log.error, log.debug etc..

![Screen Shot 2020-12-07 at 11 31 45 AM](https://user-images.githubusercontent.com/62242/101377593-04a7b080-3880-11eb-9aee-41259eb3a376.png)

This helps to ensure we're passing the correct parameters without the need to look them up :)

Note: I'm inline the payload definitions which ends up being repetitive but seems without doing that this seems to be the output (vs the "full preview") above.

![Screen Shot 2020-12-07 at 11 51 35 AM](https://user-images.githubusercontent.com/62242/101379962-eb543380-3882-11eb-9219-ddab93ab718b.png)


 
