### PR TITLE
Switch default/cancel styles for alert actions

### DIFF
--- a/src/screens/home/views/ClearExposureView.tsx
+++ b/src/screens/home/views/ClearExposureView.tsx
@@ -17,7 +17,7 @@ export const DismissAlertScreen = () => {
       {
         text: i18n.translate('Home.ExposureDetected.Dismiss.Confirm.Cancel'),
         onPress: () => {},
-        style: 'cancel',
+        style: 'default',
       },
       {
         text: i18n.translate('Home.ExposureDetected.Dismiss.Confirm.Accept'),
@@ -25,7 +25,7 @@ export const DismissAlertScreen = () => {
           clearExposedStatus();
           close();
         },
-        style: 'default',
+        style: 'cancel',
       },
     ]);
   }, [clearExposedStatus, close, i18n]);


### PR DESCRIPTION
# Summary | Résumé

Switches the default action style according to the figma design.


![IMG_3236](https://user-images.githubusercontent.com/1187115/101400320-b81f9d80-389e-11eb-8c16-0b5c9a947909.PNG)
![IMG_3237](https://user-images.githubusercontent.com/1187115/101400326-ba81f780-389e-11eb-8c55-ceaa5da0cd93.PNG)



