### PR TITLE
Switched demo builds from Diawi to Staging distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "deploy-ios:production": "bundle exec fastlane ios build_and_deploy type:production",
     "deploy-ios:diawi": "bundle exec fastlane ios adhoc",
     "deploy-android:diawi": "bundle exec fastlane android adhoc",
-    "deploy-ios:demo": "bundle exec fastlane ios adhoc env:demo"
+    "deploy-ios:demo": "bundle exec fastlane ios build_and_deploy type:demo"
   },
   "dependencies": {
     "@react-native-community/async-storage": "1.9.0",


### PR DESCRIPTION
# Summary | Résumé

Previously, our Demo builds were configured to use Diawi for distribution, but we've actually been using the Staging bundle, and having to make this local change to deploy. This just makes that change official.