### PR TITLE
Fixes an issue with pre-onboarded devices and the loggly transport

### DIFF
--- a/src/shared/logging/transports/loggly.ts
+++ b/src/shared/logging/transports/loggly.ts
@@ -21,7 +21,7 @@ const logglyTransport: transportFunctionType = async (msg, level, _options) => {
 
     if (exposureStatusJson) {
       const exposureStatus = JSON.parse(exposureStatusJson);
-      const lastCheckedTimestamp = exposureStatus.lastChecked.timestamp;
+      const lastCheckedTimestamp = exposureStatus.lastChecked?.timestamp;
       const lastCheckedDate = new Date(lastCheckedTimestamp);
       lastCheckedMinutesAgo = Math.ceil(minutesBetween(lastCheckedDate, today)).toString();
       currentStatus = exposureStatus.type;


### PR DESCRIPTION
# Summary | Résumé

The Loggly transport would throw an error on logs for pre-onboarded devices due to the exposureStatus.lastChecked not being set yet.
