### PR TITLE
Added daysSinceOnsetOfSymptoms property to TEKs

### DIFF
--- a/src/bridge/ExposureNotification/types.ts
+++ b/src/bridge/ExposureNotification/types.ts
@@ -51,6 +51,7 @@ export interface TemporaryExposureKey {
   rollingStartIntervalNumber: number;
   rollingPeriod: number;
   transmissionRiskLevel: RiskLevel;
+  daysSinceOnsetOfSymptoms?: number;
 }
 
 export interface ExposureSummary {

--- a/src/services/BackendService/BackendService.ts
+++ b/src/services/BackendService/BackendService.ts
@@ -222,6 +222,7 @@ export class BackendService implements BackendInterface {
           transmissionRiskLevel: TRANSMISSION_RISK_LEVEL,
           rollingStartIntervalNumber: key.rollingStartIntervalNumber,
           rollingPeriod: key.rollingPeriod,
+          daysSinceOnsetOfSymptoms: 0,
         }),
       ),
     });

--- a/src/services/BackendService/covidshield/covidshield.d.ts
+++ b/src/services/BackendService/covidshield/covidshield.d.ts
@@ -776,6 +776,9 @@ export namespace covidshield {
 
         /** TemporaryExposureKey rollingPeriod */
         rollingPeriod?: (number|null);
+
+        /** TemporaryExposureKey daysSinceOnsetOfSymptoms */
+        daysSinceOnsetOfSymptoms?: (number|null);
     }
 
     /** Represents a TemporaryExposureKey. */
@@ -798,6 +801,9 @@ export namespace covidshield {
 
         /** TemporaryExposureKey rollingPeriod. */
         public rollingPeriod: number;
+
+        /** TemporaryExposureKey daysSinceOnsetOfSymptoms */
+        public daysSinceOnsetOfSymptoms: number;
 
         /**
          * Creates a new TemporaryExposureKey instance using the specified properties.


### PR DESCRIPTION
# Summary | Résumé

This adds the `daysSinceOnsetOfSymptoms` property to uploaded TEKs. Using this branch on the diagnosed phone may help us get V2 working on iOS. Will keep this a draft until we have evidence that it is working. 

[Google API docs](https://developers.google.com/android/exposure-notifications/exposure-key-file-format?hl=en)
[Apple API docs](https://developer.apple.com/documentation/exposurenotification/enexposureinfo/3644412-dayssinceonsetofsymptoms?language=objc)