### PR TITLE
Bump WorkManager

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
         kotlinVersion = "1.3.72"
 
-        workVersion = "2.5.0-beta01"
+        workVersion = "2.5.0-beta02"
     }
     repositories {
         google()


### PR DESCRIPTION
# Summary | Résumé

Bumps WorkManager to latest which includes a patch for a crash we're seeing in the Play Console

https://issuetracker.google.com/issues/170924044

Full WorkManager release notes:
https://developer.android.com/jetpack/androidx/releases/work#2.5.0-beta02


# Crash Report 

```
java.lang.IllegalStateException: 
  at android.app.ContextImpl.startServiceCommon (ContextImpl.java:1715)
  at android.app.ContextImpl.startService (ContextImpl.java:1670)
  at android.content.ContextWrapper.startService (ContextWrapper.java:720)
  at androidx.work.impl.Processor.stopForegroundService (Processor.java:312)
  at androidx.work.impl.Processor.stopForeground (Processor.java:222)
  at androidx.work.impl.WorkerWrapper.resolve (WorkerWrapper.java:448)
  at androidx.work.impl.WorkerWrapper.tryCheckForInterruptionAndResolve (WorkerWrapper.java:419)
  at androidx.work.impl.WorkerWrapper.interrupt (WorkerWrapper.java:375)
  at androidx.work.impl.Processor.interrupt (Processor.java:331)
  at androidx.work.impl.Processor.stopWork (Processor.java:188)
  at androidx.work.impl.utils.StopWorkRunnable.run (StopWorkRunnable.java:73)
  at androidx.work.impl.utils.SerialExecutor$Task.run (SerialExecutor.java:91)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1167)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:641)
  at java.lang.Thread.run (Thread.java:923)
```

