### PR TITLE
Prevent exposure checks when EN Framework is turned off on Android.

### DIFF
--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
@@ -37,9 +37,10 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
 
         Log.d("background", "ExposureCheckNotificationWorker - doWork")
 
+        val enIsEnabled = exposureNotificationClient.isEnabled.await()
         val enStatus = exposureNotificationClient.status.await()
-        if (!enStatus.contains(ExposureNotificationStatus.ACTIVATED)){
-            Log.d("background", "ExposureCheckNotificationWorker - ExposureNotification Status: not activated")
+        if (!enIsEnabled || enStatus.contains(ExposureNotificationStatus.INACTIVATED)){
+            Log.d("background", "ExposureCheckNotificationWorker - ExposureNotification: Not enabled or not activated")
             return Result.success()
         }
 

--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
@@ -26,9 +26,10 @@ class ExposureCheckSchedulerWorker (val context: Context, parameters: WorkerPara
     override suspend fun doWork(): Result {
         Log.d("background", "ExposureCheckSchedulerWorker - doWork")
         try {
+            val enIsEnabled = exposureNotificationClient.isEnabled.await()
             val enStatus = exposureNotificationClient.status.await()
-            if (!enStatus.contains(ExposureNotificationStatus.ACTIVATED)){
-                Log.d("background", "ExposureCheckSchedulerWorker - ExposureNotification Status: not activated")
+            if (!enIsEnabled || enStatus.contains(ExposureNotificationStatus.INACTIVATED)){
+                Log.d("background", "ExposureCheckSchedulerWorker - ExposureNotification: Not enabled or not activated")
                 return Result.success()
             }
             val currentReactContext = getCurrentReactContext(context)

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -146,12 +146,14 @@ export class ExposureNotificationService {
 
   initiateExposureCheckHeadless = async () => {
     if (Platform.OS !== 'android') return;
-    log.debug({category: 'background', message: 'initiateExposureCheckEvent'});
+    log.debug({category: 'background', message: 'initiateExposureCheckHeadless'});
     await this.initiateExposureCheck();
   };
 
   initiateExposureCheck = async () => {
     if (Platform.OS !== 'android') return;
+    if (!(await this.shouldPerformExposureCheck())) return;
+
     const payload: NotificationPayload = {
       alertTitle: this.i18n.translate('Notification.ExposureChecksTitle'),
       alertBody: this.i18n.translate('Notification.ExposureChecksBody'),


### PR DESCRIPTION
# Summary | Résumé

When running background tasks on Android, if the EN framework is deactivated, a visual notification briefly appears indicating that an Exposure Check is happening, even though no check is happening.

This conditional check happens at the beginning of the background task in Kotlin, prior to the execution of the code being passed off to react-native.

Closes #1315 