### PR TITLE
Change importance for notification channel.

### DIFF
--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
@@ -48,7 +48,7 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
                 .setOngoing(true)
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            notification.setPriority(inputData.getInt("priority", NotificationCompat.PRIORITY_MAX))
+            notification.setPriority(inputData.getInt("priority", NotificationCompat.PRIORITY_DEFAULT))
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -79,7 +79,7 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
             disableSound: Boolean
     ): NotificationChannel {
         return NotificationChannel(
-                channelId, name, NotificationManager.IMPORTANCE_HIGH
+                channelId, name, NotificationManager.IMPORTANCE_DEFAULT
         ).also { channel ->
             if (disableSound) {
                 channel.setSound(null, null)
@@ -89,7 +89,10 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
     }
 
     companion object {
-        private const val CHANNEL_ID = "COVID Alert Exposure Checks"
+        // A randomly generated constant.
+        // If either the channel importance / priority or the sound are changed,
+        // then CHANNEL_ID also needs to be changed.
+        private const val CHANNEL_ID = "NVYJYRQYOM"
     }
 
 }


### PR DESCRIPTION
# Summary | Résumé

By changing the notification channel IMPORTANCE from HIGH to DEFAULT, the notification will no longer appear as an overlay on the screen when the screen is unlocked.

# Test instructions | Instructions pour tester la modification

Build and run the app on Android. With the screen unlocked, observe that the notifications now appear only as the icon in the system bar, and not as an overlay.


# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their review | Voici une suggestion de liste de vérification comprenant des questions que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce que ça devrait être divisé en de plus petites demandes de tirage (« pull requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce changement (fichier README, etc.)?

