### PR TITLE
Explore supporting Android 5 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion= "29.0.2"
-        minSdkVersion = 23
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
 


### PR DESCRIPTION
Initial PR to start testing Android 5.0 device support

## Google docs
> For your app to work on all devices, set your minSdkVersion to version 6.0 (API level 23) or higher. The framework works on some devices as low as version 5.0 (API level 21), so using this version is an option to increase the number of devices eligible. If you decide to set the minSdkVersion to API level 21, you should test your app on the most popular Android 5.0 devices in your country to ensure that your app works as intended.