### PR TITLE
Fix Work Profile - error handling

### DIFF
--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -40,15 +40,12 @@ export const OnboardingScreen = () => {
     async (index: number) => {
       // we want the EN permission dialogue to appear on the last step.
       if (index === onboardingData.length - 1) {
-        try {
-          await startExposureNotificationService();
-        } catch (error) {
-          if (error.message === 'API_NOT_CONNECTED') {
-            navigation.reset({
-              index: 0,
-              routes: [{name: 'ErrorScreen'}],
-            });
-          }
+        const start = await startExposureNotificationService();
+        if (typeof start !== 'boolean' && start?.error === 'API_NOT_CONNECTED') {
+          navigation.reset({
+            index: 0,
+            routes: [{name: 'ErrorScreen'}],
+          });
         }
       }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -195,13 +195,11 @@ export class ExposureNotificationService {
       this.starting = false;
       await this.updateSystemStatus();
 
-      log.debug({message:'failed to start framework', payload:{error});
+      log.debug({message: 'failed to start framework', payload: error});
 
       if (error.message === 'API_NOT_CONNECTED') {
         return {success: false, error: 'API_NOT_CONNECTED'};
       }
-
-
 
       return {success: false, error};
     }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -194,7 +194,15 @@ export class ExposureNotificationService {
     } catch (error) {
       this.starting = false;
       await this.updateSystemStatus();
-      captureException('Failed to start framework', error);
+
+      log.debug({message:'failed to start framework', payload:{error});
+
+      if (error.message === 'API_NOT_CONNECTED') {
+        return {success: false, error: 'API_NOT_CONNECTED'};
+      }
+
+
+
       return {success: false, error};
     }
   }

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -7,10 +7,10 @@ import RNSecureKeyStore from 'react-native-secure-key-store';
 import SystemSetting from 'react-native-system-setting';
 import {ContagiousDateInfo} from 'shared/DataSharing';
 import {useStorage} from 'services/StorageService';
+import {log} from 'shared/logging/config';
 
 import {BackendInterface} from '../BackendService';
 import {BackgroundScheduler} from '../BackgroundSchedulerService';
-import {log} from 'shared/logging/config';
 
 import {
   ExposureNotificationService,

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -10,7 +10,7 @@ import {useStorage} from 'services/StorageService';
 
 import {BackendInterface} from '../BackendService';
 import {BackgroundScheduler} from '../BackgroundSchedulerService';
-import {captureMessage} from '../../shared/log';
+import {log} from 'shared/logging/config';
 
 import {
   ExposureNotificationService,
@@ -60,7 +60,6 @@ export const ExposureNotificationServiceProvider = ({
 
   useEffect(() => {
     const onAppStateChange = async (newState: AppStateStatus) => {
-      captureMessage(`ExposureNotificationServiceProvider onAppStateChange: ${newState}`);
       if (newState !== 'active') return;
       exposureNotificationService.updateExposure();
       await exposureNotificationService.updateExposureStatus();
@@ -94,13 +93,15 @@ export function useExposureNotificationService() {
   return useContext(ExposureNotificationServiceContext)!;
 }
 
-export function useStartExposureNotificationService(): () => Promise<boolean> {
+export function useStartExposureNotificationService(): () => Promise<boolean | {success: boolean; error?: string}> {
   const exposureNotificationService = useExposureNotificationService();
   const {setUserStopped} = useStorage();
 
   return useCallback(async () => {
     const start = await exposureNotificationService.start();
-    captureMessage(`useStartExposureNotificationService ${start}`);
+
+    log.debug({message: 'exposureNotificationService.start()', payload: start});
+
     if (Platform.OS === 'ios') {
       setUserStopped(false);
     }
@@ -111,6 +112,11 @@ export function useStartExposureNotificationService(): () => Promise<boolean> {
       setUserStopped(false);
       return true;
     }
+
+    if (start?.error === 'API_NOT_CONNECTED') {
+      return {success: false, error: 'API_NOT_CONNECTED'};
+    }
+
     return false;
   }, [exposureNotificationService, setUserStopped]);
 }
@@ -121,7 +127,7 @@ export function useStopExposureNotificationService(): () => Promise<boolean> {
   return useCallback(async () => {
     setUserStopped(true);
     const stopped = await exposureNotificationService.stop();
-    captureMessage(`useStopExposureNotificationService ${stopped}`);
+    log.debug({message: 'exposureNotificationService.stop()', payload: stopped});
     return stopped;
   }, [exposureNotificationService, setUserStopped]);
 }


### PR DESCRIPTION
# Summary | Résumé

This updates the error handling when the framework throws an API_NOT_CONNECTED error.

When the stop start functionality was introduced the error handling higher up changed and this appears to have been missed along the way.

The older code was looking for an error to be thrown versus the new code after stop start was returning false.

# Test instructions | Instructions pour tester la modification


Android - Using a WorkProfile
- Install the app (current app)
- Onboard
- Land on the Covid Alert is off screen

Android - Using a WorkProfile
- Install the app (this PR)
- Onboard
- Land on the "ErrorScreen" component screen

