### PR TITLE
Add version number to drawer menu

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -135,6 +135,7 @@
     "TapPrompt": "Tap for menu"
   },
   "OverlayOpen": {
+    "Version": "Version",
     "BluetoothCardBody": "You need to turn on Bluetooth in your phone’s settings so COVID Alert can work.",
     "BluetoothCardAction": "Turn on Bluetooth",
     "EnterCodeCardTitle": "Diagnosed with COVID-19?",

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -33,7 +33,7 @@
     "DiagnosedShareUploadView": {
       "Title": "Presque terminé",
       "Body1": "Vous avez entré votre clé à usage unique, mais vous n’avez pas encore partagé vos expositions. Les personnes que vous avez côtoyées n’ont pas encore été notifiées.",
-      "ButtonCTA":"Terminer le partage d’expositions"
+      "ButtonCTA": "Terminer le partage d’expositions"
     },
     "ExposureDetected": {
       "Title": "Vous avez été exposé",
@@ -135,6 +135,7 @@
     "TapPrompt": "Appuyez pour voir le menu"
   },
   "OverlayOpen": {
+    "Version": "Version",
     "BluetoothCardBody": "Vous devez l’activer dans les paramètres de votre téléphone pour qu’Alerte COVID fonctionne.",
     "BluetoothCardAction": "Activez Bluetooth",
     "EnterCodeCardTitle": "Avez-vous reçu un diagnostic de COVID-19?",

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -38,7 +38,7 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
     }
   }, [navigation, region, regionalI18n]);
 
-  const versionNumber = `${i18n.translate('OverlayOpen.Version')}: ${APP_VERSION_NAME}(${APP_VERSION_CODE})`;
+  const versionNumber = `${i18n.translate('OverlayOpen.Version')}: ${APP_VERSION_NAME} (${APP_VERSION_CODE})`;
 
   return (
     <>

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -6,9 +6,9 @@ import {useI18n, useRegionalI18n} from 'locale';
 import {captureException} from 'shared/log';
 import {useStorage} from 'services/StorageService';
 import {getExposedHelpMenuURL} from 'shared/RegionLogic';
-
 import {OnOffButton} from '../components/OnOffButton';
 import {InfoShareItem} from '../components/InfoShareItem';
+import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
 
 export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomSheetBehavior}) => {
   const i18n = useI18n();
@@ -92,6 +92,11 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
           text={i18n.translate('Info.Privacy')}
           lastItem
         />
+      </Box>
+      <Box paddingBottom="l">
+        <Text variant="smallText">{`${i18n.translate(
+          'OverlayOpen.Version',
+        )}: ${APP_VERSION_NAME}(${APP_VERSION_CODE})`}</Text>
       </Box>
     </>
   );

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -6,9 +6,10 @@ import {useI18n, useRegionalI18n} from 'locale';
 import {captureException} from 'shared/log';
 import {useStorage} from 'services/StorageService';
 import {getExposedHelpMenuURL} from 'shared/RegionLogic';
+import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
+
 import {OnOffButton} from '../components/OnOffButton';
 import {InfoShareItem} from '../components/InfoShareItem';
-import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
 
 export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomSheetBehavior}) => {
   const i18n = useI18n();
@@ -36,6 +37,8 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
       navigation.navigate('RegionSelectExposedNoPT', {drawerMenu: true});
     }
   }, [navigation, region, regionalI18n]);
+
+  const versionNumber = `${i18n.translate('OverlayOpen.Version')}: ${APP_VERSION_NAME}(${APP_VERSION_CODE})`;
 
   return (
     <>
@@ -94,9 +97,7 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
         />
       </Box>
       <Box paddingBottom="l">
-        <Text variant="smallText">{`${i18n.translate(
-          'OverlayOpen.Version',
-        )}: ${APP_VERSION_NAME}(${APP_VERSION_CODE})`}</Text>
+        <Text variant="smallText">{versionNumber}</Text>
       </Box>
     </>
   );


### PR DESCRIPTION
# Summary | Résumé

Adds the app version number to the drawer menu.

This will help with support when asking folks what version of the app they are using.

---


# Test instructions | Instructions pour tester la modification

Open the drawer menu
Scroll to the bottom
Note the version #

<img width="300" src="https://user-images.githubusercontent.com/62242/103774592-d510d300-4ffa-11eb-93a2-628253d01d47.png"> 



