### PR TITLE
Update FrameworkUnavailable text

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -103,7 +103,7 @@
     },
     "FrameworkUnavailable": {
       "Title": "Something went wrong",
-      "Body": "To use COVID Alert, please update your operating system."
+      "Body": "To use COVID Alert, you need to update your phone’s operating system."
     },
     "UnknownProblem": {
       "Title": "Something went wrong",

--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -33,7 +33,7 @@
     "DiagnosedShareUploadView": {
       "Title": "Presque terminé",
       "Body1": "Vous avez entré votre clé à usage unique, mais vous n’avez pas encore partagé vos expositions. Les personnes que vous avez côtoyées n’ont pas encore été notifiées.",
-      "ButtonCTA":"Terminer le partage d’expositions"
+      "ButtonCTA": "Terminer le partage d’expositions"
     },
     "ExposureDetected": {
       "Title": "Vous avez été exposé",
@@ -103,7 +103,7 @@
     },
     "FrameworkUnavailable": {
       "Title": "Une erreur s’est produite",
-      "Body": "Pour utiliser Alerte COVID, veuillez mettre à jour votre système d’exploitation."
+      "Body": "Pour utiliser Alerte COVID, vous devez mettre à jour le système d’exploitation de votre téléphone."
     },
     "UnknownProblem": {
       "Title": "Une erreur s’est produite",


### PR DESCRIPTION
## Summary

Updates text for cases where the app can be install but the framework isn't available i.e. iOS 13.0-13.4

## Test

See text updates

https://www.figma.com/file/0pLawavG1fnBTXSYn4pdKZ/Exposure-notification?node-id=14569%3A45417