### PR TITLE
Configuration files for i18n-ally extension for VS Code.

### DIFF
--- a/.vscode/i18n-ally-custom-framework.yml
+++ b/.vscode/i18n-ally-custom-framework.yml
@@ -1,0 +1,19 @@
+# .vscode/i18n-ally-custom-framework.yml
+
+# An array of string which contains Language Ids defined by vscode
+# You can check avaliable language ids here: https://code.visualstudio.com/docs/languages/overview#_language-id
+languageIds:
+  - javascript
+  - typescript
+  - javascriptreact
+  - typescriptreact
+
+# An Array of regex to find the keys usage. **The key should captured in the first match group**.
+# You should unescape regex string in order to fit in YAML file
+# for that, you can use https://www.freeformatter.com/json-escape.html
+keyMatchReg:
+  # The following examples show how to detect `t("your.i18n.keys")`
+  - "[^\\w\\d]i18n\\.translate\\(['\"`]([[\\w\\d\\. \\-\\[\\]]*?)['\"`]"
+
+# If set to true, only enables custom framework (will disable all built-in frameworks)
+monopoly: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,5 +27,8 @@
   "editor.tabSize": 2,
   "editor.detectIndentation": false,
   "eslint.packageManager": "yarn",
-  "java.configuration.updateBuildConfiguration": "disabled"
+  "java.configuration.updateBuildConfiguration": "disabled",
+  "i18n-ally.localesPaths": [
+    "src/locale/translations"
+  ]
 }


### PR DESCRIPTION
# Summary | Résumé

This is a modification for use in development only. It has no impact on the released app.

Adding configuration files for use with **VS Code** for the i18n-ally extension: 

The extension will help:
-- identify strings that haven't been translated in any language
-- show in-line copy of the actual string
-- have a side-by-side editor for all languages of the string in question
-- show lint warnings for any strings in the code that can't be found in the language files
-- plus some more stuff
-- show all translations when hovering over the code

# Test instructions | Instructions pour tester la modification

Install the i18n-ally extension: https://marketplace.visualstudio.com/items?itemName=antfu.i18n-ally

Open the project in VS Code, and look for the "globe" icon on the left-hand side. Clicking on that should open the extension. Check the documentation for the extension for further details.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Should probably move the `region.json` file, since it's not translated in the same way. Also move other files that are not language specific JSON files.

<img width="1636" alt="Screen Shot 2020-12-23 at 5 16 11 PM" src="https://user-images.githubusercontent.com/77435/103824362-beda3580-5041-11eb-99a2-8483ef0702b0.png">
