### PR TITLE
Check if uploading

### DIFF
--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -31,7 +31,7 @@ export const BaseTekUploadView = ({
   const navigation = useNavigation();
   const i18n = useI18n();
   const [loading, setLoading] = useState(false);
-  const {fetchAndSubmitKeys, isUploading} = useReportDiagnosis();
+  const {fetchAndSubmitKeys, setIsUploading} = useReportDiagnosis();
 
   const onSuccess = useCallback(() => {
     AsyncStorage.setItem(INITIAL_TEK_UPLOAD_COMPLETE, 'true');
@@ -71,16 +71,16 @@ export const BaseTekUploadView = ({
   };
   const handleUpload = useCallback(async () => {
     setLoading(true);
-    isUploading(true);
+    setIsUploading(true);
 
     try {
       await fetchAndSubmitKeys(contagiousDateInfo);
       setLoading(false);
-      isUploading(false);
+      setIsUploading(false);
       onSuccess();
     } catch (error) {
       setLoading(false);
-      isUploading(false);
+      setIsUploading(false);
       onError(error);
     }
   }, [contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess]);

--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -31,7 +31,7 @@ export const BaseTekUploadView = ({
   const navigation = useNavigation();
   const i18n = useI18n();
   const [loading, setLoading] = useState(false);
-  const {fetchAndSubmitKeys} = useReportDiagnosis();
+  const {fetchAndSubmitKeys, isUploading} = useReportDiagnosis();
 
   const onSuccess = useCallback(() => {
     AsyncStorage.setItem(INITIAL_TEK_UPLOAD_COMPLETE, 'true');
@@ -71,12 +71,16 @@ export const BaseTekUploadView = ({
   };
   const handleUpload = useCallback(async () => {
     setLoading(true);
+    isUploading(true);
+
     try {
       await fetchAndSubmitKeys(contagiousDateInfo);
       setLoading(false);
+      isUploading(false);
       onSuccess();
     } catch (error) {
       setLoading(false);
+      isUploading(false);
       onError(error);
     }
   }, [contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess]);

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -60,7 +60,7 @@ export const ExposureNotificationServiceProvider = ({
 
   useEffect(() => {
     const onAppStateChange = async (newState: AppStateStatus) => {
-      if (newState === 'background') {
+      if (newState === 'background' && !(await exposureNotificationService.isUploading())) {
         exposureNotificationService.processOTKNotSharedNotification();
       } else if (newState !== 'active') {
         return;
@@ -186,9 +186,18 @@ export function useReportDiagnosis() {
     },
     [exposureNotificationService],
   );
+
+  const isUploading = useCallback(
+    async (status: boolean) => {
+      return exposureNotificationService.setUploadStatus(status);
+    },
+    [exposureNotificationService],
+  );
+
   return {
     startSubmission,
     fetchAndSubmitKeys,
+    isUploading,
   };
 }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -187,7 +187,7 @@ export function useReportDiagnosis() {
     [exposureNotificationService],
   );
 
-  const isUploading = useCallback(
+  const setIsUploading = useCallback(
     async (status: boolean) => {
       return exposureNotificationService.setUploadStatus(status);
     },
@@ -197,7 +197,7 @@ export function useReportDiagnosis() {
   return {
     startSubmission,
     fetchAndSubmitKeys,
-    isUploading,
+    setIsUploading,
   };
 }
 


### PR DESCRIPTION
Patch fix for https://github.com/cds-snc/covid-alert-app/pull/1346

Adds check to see if the user is in the upload flow - this will be used to prevent a "not quite done" notification if the user is still in the upload flow.   Issue found where the app would move into `the background` when the share screen prompt appears vs the user closing the flow and sending he app to the background. 

Android
1. Enter OTK, go through share exposure flow (date or not date route)
2. Tap share exposures
3. Observe the OS prompt to “Share your random IDs with COVID Alert” AND a notification doesn't appear i.e. "you’re not quite done"
