### PR TITLE
Update French notification

### DIFF
--- a/src/locale/translations/fr.json
+++ b/src/locale/translations/fr.json
@@ -424,7 +424,7 @@
     "ExposureChecksAndroidChannelName": "Vérifications d’exposition",
     "PausedMessageTitle": "Vous avez désactivé l’application",
     "PausedMessageBody": "L’application ne peut pas enregistrer d’expositions puisque vous l’avez désactivée.",
-    "OTKNotSharedTitle": "Presque terminé",
+    "OTKNotSharedTitle": "Pas tout à fait fini",
     "OTKNotSharedBody": "Vous avez entré votre clé à usage unique, mais vous n’avez pas encore partagé vos expositions. Les personnes que vous avez côtoyées n’ont pas encore été notifiées."
   },
   "Partners": {


### PR DESCRIPTION
# Summary | Résumé

Update to the French notification title for when a person has entered a OTK but not shared exposures yet. [Related Figma screen](https://www.figma.com/file/0pLawavG1fnBTXSYn4pdKZ/Exposure-notification?node-id=14333%3A217)
