### PR TITLE
Update to English copy

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -329,7 +329,7 @@
       "Title": "Finish sharing exposures",
       "List":{
         "1a":"1. ",
-        "1b": "Done",
+        "1b": "Done.",
         "2a": "2. Give the app details ",
         "2b": "to help narrow down when you were likely most contagious. You can choose not to give any details.",
         "3a": "3. Allow your phone to share ",


### PR DESCRIPTION
# Summary | Résumé

Added a period in the 'Finish sharing exposures' screen.
