### PR TITLE
Add an enum for the `forceScreen` variable

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -10,15 +10,15 @@ import {
   useExposureStatus,
   useUpdateExposureStatus,
   useStartExposureNotificationService,
+  useExposureNotificationSystemStatusAutomaticUpdater,
   useSystemStatus,
 } from 'services/ExposureNotificationService';
 import {useStorage} from 'services/StorageService';
+import {RegionCase} from 'shared/Region';
 import {getRegionCase} from 'shared/RegionLogic';
 import {usePrevious} from 'shared/usePrevious';
+import {ForceScreen} from 'shared/ForceScreen';
 import {useRegionalI18n} from 'locale';
-
-import {useExposureNotificationSystemStatusAutomaticUpdater} from '../../services/ExposureNotificationService';
-import {RegionCase} from '../../shared/Region';
 
 import {BluetoothDisabledView} from './views/BluetoothDisabledView';
 import {CollapsedOverlayView} from './views/CollapsedOverlayView';
@@ -83,17 +83,17 @@ const Content = ({isBottomSheetExpanded}: ContentProps) => {
   const {forceScreen} = useStorage();
   if (TEST_MODE) {
     switch (forceScreen) {
-      case 'NoExposureView':
+      case ForceScreen.NoExposureView:
         return getNoExposureView(regionCase);
-      case 'ExposureView':
+      case ForceScreen.ExposureView:
         return <ExposureView isBottomSheetExpanded={isBottomSheetExpanded} />;
-      case 'DiagnosedShareView':
+      case ForceScreen.DiagnosedShareView:
         return <DiagnosedShareView isBottomSheetExpanded={isBottomSheetExpanded} />;
-      case 'DiagnosedView':
+      case ForceScreen.DiagnosedView:
         return <DiagnosedView isBottomSheetExpanded={isBottomSheetExpanded} />;
-      case 'DiagnosedShareUploadView':
+      case ForceScreen.DiagnosedShareUploadView:
         return <DiagnosedShareUploadView isBottomSheetExpanded={isBottomSheetExpanded} />;
-      case 'FrameworkUnavailableView':
+      case ForceScreen.FrameworkUnavailableView:
         return <FrameworkUnavailableView isBottomSheetExpanded={isBottomSheetExpanded} />;
       default:
         break;

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -3,6 +3,7 @@ import {Text} from 'components';
 import {useI18n} from 'locale';
 import {useExposureNotificationService} from 'services/ExposureNotificationService';
 import {formatExposedDate} from 'shared/date-fns';
+import {ForceScreen} from 'shared/ForceScreen';
 import {useStorage} from 'services/StorageService';
 
 export const ExposureDateView = () => {
@@ -22,7 +23,7 @@ export const ExposureDateView = () => {
 
     if (timeStamp)
       return formatExposedDate(dateLocale, new Date(timeStamp).toLocaleString(dateLocale, dateFormatOptions));
-    else if (forceScreen)
+    else if (forceScreen && forceScreen !== ForceScreen.None)
       return formatExposedDate(dateLocale, new Date().toLocaleString(dateLocale, dateFormatOptions));
   }, [dateFormatOptions, dateLocale, exposureNotificationService, forceScreen]);
 

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -16,6 +16,7 @@ import {captureMessage} from 'shared/log';
 import {useNavigation} from '@react-navigation/native';
 import {ContagiousDateType} from 'shared/DataSharing';
 import {getLogUUID, setLogUUID} from 'shared/logging/uuid';
+import {ForceScreen} from 'shared/ForceScreen';
 
 import {RadioButton} from './components/RadioButtons';
 import {MockProvider} from './MockProvider';
@@ -24,14 +25,19 @@ import {Section} from './views/Section';
 
 const ScreenRadioSelector = () => {
   const {forceScreen, setForceScreen} = useStorage();
+  const forceScreenOnPress = (value: string) => {
+    if (Object.values(ForceScreen).includes(value as ForceScreen)) {
+      setForceScreen(value as ForceScreen);
+    }
+  };
   const screenData = [
-    {displayName: 'None', value: 'None'},
-    {displayName: 'Not Exposed', value: 'NoExposureView'},
-    {displayName: 'Exposed', value: 'ExposureView'},
-    {displayName: 'Diagnosed Share Data', value: 'DiagnosedShareView'},
-    {displayName: 'Diagnosed', value: 'DiagnosedView'},
-    {displayName: 'Diagnosed Share Upload', value: 'DiagnosedShareUploadView'},
-    {displayName: 'Unsupported Framework', value: 'FrameworkUnavailableView'},
+    {displayName: 'None', value: ForceScreen.None},
+    {displayName: 'Not Exposed', value: ForceScreen.NoExposureView},
+    {displayName: 'Exposed', value: ForceScreen.ExposureView},
+    {displayName: 'Diagnosed Share Data', value: ForceScreen.DiagnosedShareView},
+    {displayName: 'Diagnosed', value: ForceScreen.DiagnosedView},
+    {displayName: 'Diagnosed Share Upload', value: ForceScreen.DiagnosedShareUploadView},
+    {displayName: 'Unsupported Framework', value: ForceScreen.FrameworkUnavailableView},
   ];
   return (
     <Box
@@ -47,7 +53,7 @@ const ScreenRadioSelector = () => {
             testID={x.value}
             key={x.displayName}
             selected={forceScreen === x.value}
-            onPress={setForceScreen}
+            onPress={forceScreenOnPress}
             name={x.displayName}
             value={x.value}
           />

--- a/src/services/StorageService/StorageService.ts
+++ b/src/services/StorageService/StorageService.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-community/async-storage';
 import {Observable} from 'shared/Observable';
+import {ForceScreen} from 'shared/ForceScreen';
 import {Region} from 'shared/Region';
 import {getSystemLocale} from 'locale/utils';
 
@@ -18,7 +19,7 @@ export class StorageService {
   locale: Observable<string>;
   region: Observable<Region | undefined>;
   onboardedDatetime: Observable<Date | undefined>;
-  forceScreen: Observable<string | undefined>;
+  forceScreen: Observable<ForceScreen | undefined>;
   skipAllSet: Observable<boolean>;
   userStopped: Observable<boolean>;
 
@@ -27,7 +28,7 @@ export class StorageService {
     this.locale = new Observable<string>(getSystemLocale());
     this.region = new Observable<Region | undefined>(undefined);
     this.onboardedDatetime = new Observable<Date | undefined>(undefined);
-    this.forceScreen = new Observable<string | undefined>(undefined);
+    this.forceScreen = new Observable<ForceScreen | undefined>(undefined);
     this.skipAllSet = new Observable<boolean>(false);
     this.userStopped = new Observable<boolean>(false);
   }
@@ -52,7 +53,7 @@ export class StorageService {
     this.onboardedDatetime.set(value);
   };
 
-  setForceScreen = async (value: string | undefined) => {
+  setForceScreen = async (value: ForceScreen | undefined) => {
     await AsyncStorage.setItem(Key.ForceScreen, value ? value : '');
     this.forceScreen.set(value);
   };
@@ -82,7 +83,7 @@ export class StorageService {
     const onboardedDatetime = onboardedDatetimeStr ? new Date(onboardedDatetimeStr) : undefined;
     this.onboardedDatetime.set(onboardedDatetime);
 
-    const forceScreen = ((await AsyncStorage.getItem(Key.ForceScreen)) as string | undefined) || undefined;
+    const forceScreen = ((await AsyncStorage.getItem(Key.ForceScreen)) as ForceScreen | undefined) || undefined;
     this.forceScreen.set(forceScreen);
 
     const skipAllSet = (await AsyncStorage.getItem(Key.SkipAllSet)) === '1';

--- a/src/shared/ForceScreen.ts
+++ b/src/shared/ForceScreen.ts
@@ -1,0 +1,9 @@
+export enum ForceScreen {
+  'None' = 'None',
+  'NoExposureView' = 'NoExposureView',
+  'ExposureView' = 'ExposureView',
+  'DiagnosedShareView' = 'DiagnosedShareView',
+  'DiagnosedView' = 'DiagnosedView',
+  'DiagnosedShareUploadView' = 'DiagnosedShareUploadView',
+  'FrameworkUnavailableView' = 'FrameworkUnavailableView',
+}


### PR DESCRIPTION
# Summary | Résumé

This is in response to a bug in #1316 where we checked that no screen was forced with:
```
if (forceScreen) {
// assume that user is forcing a screen
}
```

This was a bug because `forceScreen === 'None'` when the user makes a selection and then resets the option. Using an enum will reduce the chances we will make this mistake again.