### PR TITLE
lint: missing dependency: 'setIsUploading'. 

### DIFF
--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -83,7 +83,7 @@ export const BaseTekUploadView = ({
       setIsUploading(false);
       onError(error);
     }
-  }, [contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess]);
+  }, [contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess, setIsUploading]);
 
   if (loading) {
     return (


### PR DESCRIPTION
Fixes lint warning:
```
86:6  warning  React Hook useCallback has a missing dependency: 'setIsUploading'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```