### PR TITLE
Bumps version and fixes package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "CovidAlert",
-  "version": "1.1.6",
+  "name": "covidalert",
+  "version": "1.1.7",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
# Summary | Résumé

We're not publishing this as a package but the package name wasn't "legal"

`package's name, and must be lowercase and one word, and may contain hyphens and underscores.`

Also bumped the version # .

![Screen Shot 2021-01-15 at 9 11 24 AM](https://user-images.githubusercontent.com/62242/104736958-a806a380-5711-11eb-86e4-799df02c6e0e.png)
