### PR TITLE
Bump WorkManager -  2.5.0-rc01

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
         kotlinVersion = "1.3.72"
 
-        workVersion = "2.5.0-beta02"
+        workVersion = "2.5.0-rc01"
     }
     repositories {
         google()


### PR DESCRIPTION
# Summary | Résumé

Updates WorkManager to use the latest release candidate

See release notes here:
https://developer.android.com/jetpack/androidx/releases/work#2.5.0-rc01

# Testing
- Check background task is happening every X minutes 
- Check for logs in Google Play console