### PR TITLE
Add metrics hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,6 @@ import {AccessibilityServiceProvider} from 'services/AccessibilityService';
 
 import regionContentDefault from './locale/translations/region.json';
 import {RegionContent, RegionContentResponse} from './shared/Region';
-
 import {MetricsProvider} from './shared/MetricsProvider';
 
 // this allows us to use new Date().toLocaleString() for date formatting on android

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import {AccessibilityServiceProvider} from 'services/AccessibilityService';
 import regionContentDefault from './locale/translations/region.json';
 import {RegionContent, RegionContentResponse} from './shared/Region';
 
+import {MetricsProvider} from './shared/MetricsProvider';
+
 // this allows us to use new Date().toLocaleString() for date formatting on android
 // https://github.com/facebook/react-native/issues/19410#issuecomment-482804142
 if (Platform.OS === 'android') {
@@ -79,13 +81,15 @@ const App = () => {
   return (
     <I18nProvider>
       <RegionalProvider activeRegions={[]} translate={id => id} regionContent={regionContent.payload}>
-        <ExposureNotificationServiceProvider backendInterface={backendService}>
-          <DevPersistedNavigationContainer persistKey="navigationState">
-            <AccessibilityServiceProvider>
-              <MainNavigator />
-            </AccessibilityServiceProvider>
-          </DevPersistedNavigationContainer>
-        </ExposureNotificationServiceProvider>
+        <MetricsProvider>
+          <ExposureNotificationServiceProvider backendInterface={backendService}>
+            <DevPersistedNavigationContainer persistKey="navigationState">
+              <AccessibilityServiceProvider>
+                <MainNavigator />
+              </AccessibilityServiceProvider>
+            </DevPersistedNavigationContainer>
+          </ExposureNotificationServiceProvider>
+        </MetricsProvider>
       </RegionalProvider>
     </I18nProvider>
   );

--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -8,7 +8,7 @@ import {covidshield} from 'services/BackendService/covidshield';
 import {xhrError} from 'shared/fetch';
 import AsyncStorage from '@react-native-community/async-storage';
 import {INITIAL_TEK_UPLOAD_COMPLETE, ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
-import {useMetrics} from 'shared/metrics';
+import {EventType, useMetrics} from 'shared/metrics';
 
 import {BaseDataSharingView} from './BaseDataSharingView';
 
@@ -80,7 +80,12 @@ export const BaseTekUploadView = ({
       setLoading(false);
       setIsUploading(false);
 
-      const eventType = contagiousDateInfo.date ? 'otk-with-date' : 'otk';
+      let eventType: EventType = 'otk-with-date';
+
+      if (!contagiousDateInfo || contagiousDateInfo.dateType === ContagiousDateType.None || !contagiousDateInfo.date) {
+        eventType = 'otk-no-date';
+      }
+
       addEvent(eventType);
 
       onSuccess();

--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -8,7 +8,7 @@ import {covidshield} from 'services/BackendService/covidshield';
 import {xhrError} from 'shared/fetch';
 import AsyncStorage from '@react-native-community/async-storage';
 import {INITIAL_TEK_UPLOAD_COMPLETE, ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
-import {EventType, useMetrics} from 'shared/metrics';
+import {EventTypeMetric, useMetrics} from 'shared/metrics';
 
 import {BaseDataSharingView} from './BaseDataSharingView';
 
@@ -80,10 +80,10 @@ export const BaseTekUploadView = ({
       setLoading(false);
       setIsUploading(false);
 
-      let eventType: EventType = 'otk-with-date';
+      let eventType: EventTypeMetric = EventTypeMetric.OtkWithDate;
 
       if (!contagiousDateInfo || contagiousDateInfo.dateType === ContagiousDateType.None || !contagiousDateInfo.date) {
-        eventType = 'otk-no-date';
+        eventType = EventTypeMetric.OtkNoDate;
       }
 
       addEvent(eventType);

--- a/src/screens/datasharing/components/BaseTekUploadView.tsx
+++ b/src/screens/datasharing/components/BaseTekUploadView.tsx
@@ -8,6 +8,7 @@ import {covidshield} from 'services/BackendService/covidshield';
 import {xhrError} from 'shared/fetch';
 import AsyncStorage from '@react-native-community/async-storage';
 import {INITIAL_TEK_UPLOAD_COMPLETE, ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
+import {useMetrics} from 'shared/metrics';
 
 import {BaseDataSharingView} from './BaseDataSharingView';
 
@@ -32,6 +33,7 @@ export const BaseTekUploadView = ({
   const i18n = useI18n();
   const [loading, setLoading] = useState(false);
   const {fetchAndSubmitKeys, setIsUploading} = useReportDiagnosis();
+  const addEvent = useMetrics();
 
   const onSuccess = useCallback(() => {
     AsyncStorage.setItem(INITIAL_TEK_UPLOAD_COMPLETE, 'true');
@@ -77,13 +79,17 @@ export const BaseTekUploadView = ({
       await fetchAndSubmitKeys(contagiousDateInfo);
       setLoading(false);
       setIsUploading(false);
+
+      const eventType = contagiousDateInfo.date ? 'otk-with-date' : 'otk';
+      addEvent(eventType);
+
       onSuccess();
     } catch (error) {
       setLoading(false);
       setIsUploading(false);
       onError(error);
     }
-  }, [contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess, setIsUploading]);
+  }, [addEvent, contagiousDateInfo, fetchAndSubmitKeys, onError, onSuccess, setIsUploading]);
 
   if (loading) {
     return (

--- a/src/screens/home/components/OnOffButton.tsx
+++ b/src/screens/home/components/OnOffButton.tsx
@@ -10,6 +10,7 @@ import NativePushNotification from 'bridge/PushNotification';
 import {useI18n} from 'locale';
 import {BottomSheetBehavior} from 'components';
 import {useStorage} from 'services/StorageService';
+import {useMetrics} from 'shared/metrics';
 
 import {InfoShareItem} from './InfoShareItem';
 
@@ -18,6 +19,7 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
   const {userStopped} = useStorage();
   const startExposureNotificationService = useStartExposureNotificationService();
   const stopExposureNotificationService = useStopExposureNotificationService();
+  const addEvent = useMetrics();
 
   const onStop = useCallback(() => {
     Alert.alert(
@@ -39,6 +41,8 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
               alertBody: i18n.translate('Notification.PausedMessageBody'),
               channelName: i18n.translate('Notification.AndroidChannelName'),
             });
+
+            addEvent('enToggle');
           },
           style: 'default',
         },
@@ -49,6 +53,7 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
   const onStart = useCallback(async () => {
     bottomSheetBehavior.collapse();
     await startExposureNotificationService();
+    addEvent('enToggle');
   }, [bottomSheetBehavior, startExposureNotificationService]);
 
   const [systemStatus] = useSystemStatus();

--- a/src/screens/home/components/OnOffButton.tsx
+++ b/src/screens/home/components/OnOffButton.tsx
@@ -10,7 +10,7 @@ import NativePushNotification from 'bridge/PushNotification';
 import {useI18n} from 'locale';
 import {BottomSheetBehavior} from 'components';
 import {useStorage} from 'services/StorageService';
-import {useMetrics} from 'shared/metrics';
+import {useMetrics, EventTypeMetric} from 'shared/metrics';
 
 import {InfoShareItem} from './InfoShareItem';
 
@@ -42,7 +42,7 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
               channelName: i18n.translate('Notification.AndroidChannelName'),
             });
 
-            addEvent('en-toggle');
+            addEvent(EventTypeMetric.EnToggle);
           },
           style: 'default',
         },
@@ -53,7 +53,7 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
   const onStart = useCallback(async () => {
     bottomSheetBehavior.collapse();
     await startExposureNotificationService();
-    addEvent('en-toggle');
+    addEvent(EventTypeMetric.EnToggle);
   }, [addEvent, bottomSheetBehavior, startExposureNotificationService]);
 
   const [systemStatus] = useSystemStatus();

--- a/src/screens/home/components/OnOffButton.tsx
+++ b/src/screens/home/components/OnOffButton.tsx
@@ -42,19 +42,19 @@ export const OnOffButton = ({bottomSheetBehavior}: {bottomSheetBehavior: BottomS
               channelName: i18n.translate('Notification.AndroidChannelName'),
             });
 
-            addEvent('enToggle');
+            addEvent('en-toggle');
           },
           style: 'default',
         },
       ],
     );
-  }, [bottomSheetBehavior, i18n, stopExposureNotificationService]);
+  }, [addEvent, bottomSheetBehavior, i18n, stopExposureNotificationService]);
 
   const onStart = useCallback(async () => {
     bottomSheetBehavior.collapse();
     await startExposureNotificationService();
-    addEvent('enToggle');
-  }, [bottomSheetBehavior, startExposureNotificationService]);
+    addEvent('en-toggle');
+  }, [addEvent, bottomSheetBehavior, startExposureNotificationService]);
 
   const [systemStatus] = useSystemStatus();
 

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -17,8 +17,8 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
     Linking.openSettings();
   }, []);
 
-  const startEn = useCallback(() => {
-    startExposureNotificationService();
+  const startEn = useCallback(async () => {
+    await startExposureNotificationService();
     addEvent(EventTypeMetric.EnToggle);
   }, [startExposureNotificationService]);
 

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -4,12 +4,14 @@ import React, {useCallback} from 'react';
 import {Linking, Platform} from 'react-native';
 import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
+import {EventTypeMetric, useMetrics} from 'shared/metrics';
 
 import {BaseHomeView} from '../components/BaseHomeView';
 
 export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBottomSheetExpanded: boolean}) => {
   const i18n = useI18n();
   const startExposureNotificationService = useStartExposureNotificationService();
+  const addEvent = useMetrics();
 
   const toSettings = useCallback(() => {
     Linking.openSettings();
@@ -17,6 +19,7 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
 
   const startEn = useCallback(() => {
     startExposureNotificationService();
+    addEvent(EventTypeMetric.EnToggle);
   }, [startExposureNotificationService]);
 
   const onPress = () => {

--- a/src/screens/home/views/ExposureNotificationsDisabledView.tsx
+++ b/src/screens/home/views/ExposureNotificationsDisabledView.tsx
@@ -20,7 +20,7 @@ export const ExposureNotificationsDisabledView = ({isBottomSheetExpanded}: {isBo
   const startEn = useCallback(async () => {
     await startExposureNotificationService();
     addEvent(EventTypeMetric.EnToggle);
-  }, [startExposureNotificationService]);
+  }, [addEvent, startExposureNotificationService]);
 
   const onPress = () => {
     if (Platform.OS === 'android') {

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -17,7 +17,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStorage} from 'services/StorageService';
-import {useMetrics} from 'shared/metrics';
+import {useMetrics, EventTypeMetric} from 'shared/metrics';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
@@ -227,7 +227,7 @@ const TurnAppBackOn = ({
         text: i18n.translate('OverlayOpen.TurnAppBackOn.CTA'),
         action: () => {
           onStart();
-          addEvent('en-toggle');
+          addEvent(EventTypeMetric.EnToggle);
         },
       }}
       backgroundColor="danger25Background"

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -17,6 +17,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStorage} from 'services/StorageService';
+import {useMetrics} from 'shared/metrics';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
@@ -210,6 +211,8 @@ const TurnAppBackOn = ({
   bottomSheetBehavior: BottomSheetBehavior;
 }) => {
   const startExposureNotificationService = useStartExposureNotificationService();
+  const addEvent = useMetrics();
+
   const onStart = useCallback(async () => {
     bottomSheetBehavior.collapse();
     await startExposureNotificationService();
@@ -224,6 +227,7 @@ const TurnAppBackOn = ({
         text: i18n.translate('OverlayOpen.TurnAppBackOn.CTA'),
         action: () => {
           onStart();
+          addEvent('en-toggle');
         },
       }}
       backgroundColor="danger25Background"

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -17,10 +17,10 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStorage} from 'services/StorageService';
+import {EventTypeMetric, useMetrics} from 'shared/metrics';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
-import {EventTypeMetric, useMetrics} from 'shared/metrics';
 
 const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -25,9 +25,9 @@ import {EventTypeMetric, useMetrics} from 'shared/metrics';
 const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();
   const addEvent = useMetrics();
-  const onPress = () => {
+  const onPress = async () => {
     if (Platform.OS === 'android') {
-      startExposureNotificationService();
+      await startExposureNotificationService();
       addEvent(EventTypeMetric.EnToggle);
       return;
     }
@@ -52,9 +52,9 @@ const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
 const SystemStatusUnauthorized = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();
   const addEvent = useMetrics();
-  const onPress = () => {
+  const onPress = async () => {
     if (Platform.OS === 'android') {
-      startExposureNotificationService();
+      await startExposureNotificationService();
       addEvent(EventTypeMetric.EnToggle);
       return;
     }

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -17,16 +17,18 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStorage} from 'services/StorageService';
-import {useMetrics, EventTypeMetric} from 'shared/metrics';
 
 import {InfoShareView} from './InfoShareView';
 import {StatusHeaderView} from './StatusHeaderView';
+import {EventTypeMetric, useMetrics} from 'shared/metrics';
 
 const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();
+  const addEvent = useMetrics();
   const onPress = () => {
     if (Platform.OS === 'android') {
       startExposureNotificationService();
+      addEvent(EventTypeMetric.EnToggle);
       return;
     }
     return toSettings();
@@ -49,9 +51,11 @@ const SystemStatusOff = ({i18n}: {i18n: I18n}) => {
 
 const SystemStatusUnauthorized = ({i18n}: {i18n: I18n}) => {
   const startExposureNotificationService = useStartExposureNotificationService();
+  const addEvent = useMetrics();
   const onPress = () => {
     if (Platform.OS === 'android') {
       startExposureNotificationService();
+      addEvent(EventTypeMetric.EnToggle);
       return;
     }
     return toSettings();

--- a/src/screens/landing/LandingScreen.tsx
+++ b/src/screens/landing/LandingScreen.tsx
@@ -5,7 +5,7 @@ import {Box, Button, Icon} from 'components';
 import {useI18n} from 'locale';
 import {useNavigation} from '@react-navigation/native';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {useMetrics} from 'shared/metrics';
+import {useMetrics, EventTypeMetric} from 'shared/metrics';
 
 export const LandingScreen = () => {
   const i18n = useI18n();
@@ -38,7 +38,7 @@ export const LandingScreen = () => {
         nextRoute = 'FrameworkUnavailableScreen';
       }
 
-      addEvent('installed');
+      addEvent(EventTypeMetric.Installed);
 
       navigation.reset({
         index: -1,

--- a/src/screens/landing/LandingScreen.tsx
+++ b/src/screens/landing/LandingScreen.tsx
@@ -5,11 +5,13 @@ import {Box, Button, Icon} from 'components';
 import {useI18n} from 'locale';
 import {useNavigation} from '@react-navigation/native';
 import {SafeAreaView} from 'react-native-safe-area-context';
+import {useMetrics} from 'shared/metrics';
 
 export const LandingScreen = () => {
   const i18n = useI18n();
   const navigation = useNavigation();
   const {setLocale} = useStorage();
+  const addEvent = useMetrics();
 
   const isENFrameworkSupported = async () => {
     if (Platform.OS === 'ios') {
@@ -36,12 +38,14 @@ export const LandingScreen = () => {
         nextRoute = 'FrameworkUnavailableScreen';
       }
 
+      addEvent('installed');
+
       navigation.reset({
         index: -1,
         routes: [{name: nextRoute}],
       });
     },
-    [navigation, setLocale],
+    [addEvent, navigation, setLocale],
   );
   return (
     <SafeAreaView style={styles.flex}>

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -9,7 +9,7 @@ import {useStorage} from 'services/StorageService';
 import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 import {getCurrentDate} from 'shared/date-fns';
 import {useAccessibilityService} from 'services/AccessibilityService';
-import {useMetrics} from 'shared/metrics';
+import {useMetrics, EventTypeMetric} from 'shared/metrics';
 
 import {OnboardingContent, onboardingData, OnboardingKey} from './OnboardingContent';
 
@@ -62,7 +62,7 @@ export const OnboardingScreen = () => {
   const nextItem = useCallback(async () => {
     if (isEnd) {
       await setOnboarded(true);
-      addEvent('onboarded');
+      addEvent(EventTypeMetric.Onboarded);
       await setOnboardedDatetime(getCurrentDate());
       navigation.reset({
         index: 0,

--- a/src/screens/onboarding/Onboarding.tsx
+++ b/src/screens/onboarding/Onboarding.tsx
@@ -9,6 +9,7 @@ import {useStorage} from 'services/StorageService';
 import {useStartExposureNotificationService} from 'services/ExposureNotificationService';
 import {getCurrentDate} from 'shared/date-fns';
 import {useAccessibilityService} from 'services/AccessibilityService';
+import {useMetrics} from 'shared/metrics';
 
 import {OnboardingContent, onboardingData, OnboardingKey} from './OnboardingContent';
 
@@ -24,6 +25,7 @@ export const OnboardingScreen = () => {
   const isEnd = currentStep === onboardingData.length - 1;
   const {isScreenReaderEnabled} = useAccessibilityService();
   const currentStepForRenderItem = isScreenReaderEnabled ? currentStep : -1;
+  const addEvent = useMetrics();
 
   const renderItem: ListRenderItem<OnboardingKey> = useCallback(
     ({item, index}) => {
@@ -60,6 +62,7 @@ export const OnboardingScreen = () => {
   const nextItem = useCallback(async () => {
     if (isEnd) {
       await setOnboarded(true);
+      addEvent('onboarded');
       await setOnboardedDatetime(getCurrentDate());
       navigation.reset({
         index: 0,
@@ -68,7 +71,7 @@ export const OnboardingScreen = () => {
       return;
     }
     carouselRef.current?.snapToNext();
-  }, [isEnd, navigation, setOnboarded, setOnboardedDatetime]);
+  }, [addEvent, isEnd, navigation, setOnboarded, setOnboardedDatetime]);
 
   const prevItem = useCallback(() => {
     carouselRef.current?.snapToPrev();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -17,6 +17,10 @@ import {
   SystemStatus,
 } from './ExposureNotificationService';
 
+jest.mock('react-native-permissions', () => {
+  return {checkNotifications: jest.fn(), requestNotifications: jest.fn()};
+});
+
 const ONE_DAY = 3600 * 24 * 1000;
 
 jest.mock('react-native-zip-archive', () => ({

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -24,7 +24,7 @@ import {log} from 'shared/logging/config';
 import {DeviceEventEmitter, Platform} from 'react-native';
 import {ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
 import {EN_API_VERSION} from 'env';
-import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
+// import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
@@ -849,11 +849,13 @@ export class ExposureNotificationService {
     exposureHistory.push(exposureDetectedAt);
     this.exposureHistory.set(exposureHistory);
 
+    /*
     sendMetricEvent({
       identifier: EventTypeMetric.Exposed,
       timestamp: getCurrentDate().getTime(),
       region: (await this.storage.getItem(Key.Region)) || '',
     });
+    */
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -849,7 +849,11 @@ export class ExposureNotificationService {
     exposureHistory.push(exposureDetectedAt);
     this.exposureHistory.set(exposureHistory);
 
-    sendMetricEvent('exposed');
+    sendMetricEvent({
+      identifier: 'exposed',
+      timestamp: getCurrentDate().getTime(),
+      region: (await this.storage.getItem(Key.Region)) || '',
+    });
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -34,6 +34,8 @@ import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 import {ExposureConfigurationValidator, ExposureConfigurationValidationError} from './ExposureConfigurationValidator';
 
+import {sendMetricEvent} from 'shared/metrics';
+
 const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys';
 const EXPOSURE_CONFIGURATION = 'exposureConfiguration';
 
@@ -847,6 +849,8 @@ export class ExposureNotificationService {
     const exposureHistory = this.exposureHistory.get();
     exposureHistory.push(exposureDetectedAt);
     this.exposureHistory.set(exposureHistory);
+
+    sendMetricEvent('exposed');
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -24,6 +24,7 @@ import {log} from 'shared/logging/config';
 import {DeviceEventEmitter, Platform} from 'react-native';
 import {ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
 import {EN_API_VERSION} from 'env';
+import {sendMetricEvent} from 'shared/metrics';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
@@ -33,8 +34,6 @@ import ExposureCheckScheduler from '../../bridge/ExposureCheckScheduler';
 import exposureConfigurationDefault from './ExposureConfigurationDefault.json';
 import exposureConfigurationSchema from './ExposureConfigurationSchema.json';
 import {ExposureConfigurationValidator, ExposureConfigurationValidationError} from './ExposureConfigurationValidator';
-
-import {sendMetricEvent} from 'shared/metrics';
 
 const SUBMISSION_AUTH_KEYS = 'submissionAuthKeys';
 const EXPOSURE_CONFIGURATION = 'exposureConfiguration';

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -24,7 +24,7 @@ import {log} from 'shared/logging/config';
 import {DeviceEventEmitter, Platform} from 'react-native';
 import {ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
 import {EN_API_VERSION} from 'env';
-import {sendMetricEvent} from 'shared/metrics';
+import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
@@ -850,7 +850,7 @@ export class ExposureNotificationService {
     this.exposureHistory.set(exposureHistory);
 
     sendMetricEvent({
-      identifier: 'exposed',
+      identifier: EventTypeMetric.Exposed,
       timestamp: getCurrentDate().getTime(),
       region: (await this.storage.getItem(Key.Region)) || '',
     });

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -24,7 +24,7 @@ import {log} from 'shared/logging/config';
 import {DeviceEventEmitter, Platform} from 'react-native';
 import {ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
 import {EN_API_VERSION} from 'env';
-// import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
+import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
@@ -125,6 +125,7 @@ export class ExposureNotificationService {
   private i18n: I18n;
   private storage: PersistencyProvider;
   private secureStorage: SecurePersistencyProvider;
+  private metricService: any;
 
   constructor(
     backendInterface: BackendInterface,
@@ -132,6 +133,7 @@ export class ExposureNotificationService {
     storage: PersistencyProvider,
     secureStorage: SecurePersistencyProvider,
     exposureNotification: typeof ExposureNotification,
+    metricService?: any,
   ) {
     this.i18n = i18n;
     this.exposureNotification = exposureNotification;
@@ -141,6 +143,7 @@ export class ExposureNotificationService {
     this.backendInterface = backendInterface;
     this.storage = storage;
     this.secureStorage = secureStorage;
+    this.metricService = metricService;
     this.exposureStatus.observe(status => {
       this.storage.setItem(EXPOSURE_STATUS, JSON.stringify(status));
     });
@@ -849,13 +852,14 @@ export class ExposureNotificationService {
     exposureHistory.push(exposureDetectedAt);
     this.exposureHistory.set(exposureHistory);
 
-    /*
-    sendMetricEvent({
-      identifier: EventTypeMetric.Exposed,
-      timestamp: getCurrentDate().getTime(),
-      region: (await this.storage.getItem(Key.Region)) || '',
-    });
-    */
+    sendMetricEvent(
+      {
+        identifier: EventTypeMetric.Exposed,
+        timestamp: getCurrentDate().getTime(),
+        region: (await this.storage.getItem(Key.Region)) || '',
+      },
+      this.metricService,
+    );
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -19,6 +19,8 @@ import {
   SecurePersistencyProvider,
 } from './ExposureNotificationService';
 
+import {useMetricsContext} from 'shared/MetricsProvider';
+
 const ExposureNotificationServiceContext = createContext<ExposureNotificationService | undefined>(undefined);
 
 export interface ExposureNotificationServiceProviderProps {
@@ -40,6 +42,7 @@ export const ExposureNotificationServiceProvider = ({
 }: ExposureNotificationServiceProviderProps) => {
   const i18n = useI18nRef();
   const {setUserStopped} = useStorage();
+  const metrics = useMetricsContext();
   const exposureNotificationService = useMemo(
     () =>
       new ExposureNotificationService(
@@ -48,6 +51,7 @@ export const ExposureNotificationServiceProvider = ({
         storage || AsyncStorage,
         secureStorage || RNSecureKeyStore,
         exposureNotification || ExposureNotification,
+        metrics.service,
       ),
     [backendInterface, exposureNotification, i18n, secureStorage, storage],
   );

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -8,6 +8,7 @@ import SystemSetting from 'react-native-system-setting';
 import {ContagiousDateInfo} from 'shared/DataSharing';
 import {useStorage} from 'services/StorageService';
 import {log} from 'shared/logging/config';
+import {useMetricsContext} from 'shared/MetricsProvider';
 
 import {BackendInterface} from '../BackendService';
 import {BackgroundScheduler} from '../BackgroundSchedulerService';
@@ -18,8 +19,6 @@ import {
   PersistencyProvider,
   SecurePersistencyProvider,
 } from './ExposureNotificationService';
-
-import {useMetricsContext} from 'shared/MetricsProvider';
 
 const ExposureNotificationServiceContext = createContext<ExposureNotificationService | undefined>(undefined);
 
@@ -53,7 +52,7 @@ export const ExposureNotificationServiceProvider = ({
         exposureNotification || ExposureNotification,
         metrics.service,
       ),
-    [backendInterface, exposureNotification, i18n, secureStorage, storage],
+    [backendInterface, exposureNotification, i18n, metrics.service, secureStorage, storage],
   );
 
   useEffect(() => {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceV2.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceV2.spec.ts
@@ -28,8 +28,6 @@ jest.mock('react-native-background-fetch', () => {
   };
 });
 
-//import {checkNotifications, requestNotifications} from 'react-native-permissions/mock';
-
 jest.mock('react-native-permissions', () => {
   return {checkNotifications: jest.fn(), requestNotifications: jest.fn()};
 });

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceV2.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceV2.spec.ts
@@ -28,6 +28,12 @@ jest.mock('react-native-background-fetch', () => {
   };
 });
 
+//import {checkNotifications, requestNotifications} from 'react-native-permissions/mock';
+
+jest.mock('react-native-permissions', () => {
+  return {checkNotifications: jest.fn(), requestNotifications: jest.fn()};
+});
+
 jest.mock('../../bridge/CovidShield', () => ({
   getRandomBytes: jest.fn().mockResolvedValue(new Uint8Array(32)),
   downloadDiagnosisKeysFile: jest.fn(),

--- a/src/shared/MetricsProvider.tsx
+++ b/src/shared/MetricsProvider.tsx
@@ -32,13 +32,11 @@ export class Logger {
   }
 
   public log(payload: any) {
-    console.log(payload); // eslint-disable-line no-console
-
     if (LOGGLY_URL) {
       log.debug({
         category: 'metrics',
         message: payload.identifier,
-        payload: {appVersion: this.appVersion, appOs: this.appOs},
+        payload: {appVersion: this.appVersion, appOs: this.appOs, payload},
       });
     }
   }

--- a/src/shared/MetricsProvider.tsx
+++ b/src/shared/MetricsProvider.tsx
@@ -4,7 +4,7 @@ import {APP_VERSION_CODE, LOGGLY_URL} from 'env';
 import {Platform} from 'react-native';
 
 interface MetricsProviderProps {
-  service: MetricsService;
+  service?: MetricsService;
   children?: React.ReactElement;
 }
 

--- a/src/shared/MetricsProvider.tsx
+++ b/src/shared/MetricsProvider.tsx
@@ -1,0 +1,68 @@
+import React, {useContext} from 'react';
+import {log} from 'shared/logging/config';
+import {APP_VERSION_CODE, LOGGLY_URL} from 'env';
+import {Platform} from 'react-native';
+
+interface MetricsProviderProps {
+  children?: React.ReactElement;
+}
+
+// this will be replaced with DefaultMetricsService #1371
+class MetricsService implements MetricsService {
+  static initialize(logger: Logger) {
+    console.log('===== MetricsService initialize ======');
+    return new MetricsService(logger);
+  }
+
+  private logger: any;
+
+  private constructor(logger: any) {
+    this.logger = logger;
+  }
+
+  sendMetrics(timestamp: number, identifier: string, region: string | undefined, data: {}): Promise<void> {
+    return this.logger.log({timestamp, identifier, region, data});
+  }
+}
+
+// this will be replaces with DefaultMetricsJsonSerializer #1371
+export class Logger {
+  private appVersion: number;
+  private appOs: string;
+
+  constructor(appVersion: number, appOs: string) {
+    console.log('===== new logger ======');
+    this.appVersion = appVersion;
+    this.appOs = appOs;
+  }
+
+  log(payload: any) {
+    console.log(payload); // eslint-disable-line no-console
+
+    if (LOGGLY_URL) {
+      log.debug({
+        category: 'metrics',
+        message: payload.identifier,
+        payload: {appVersion: this.appVersion, appOs: this.appOs},
+      });
+    }
+  }
+}
+
+const MetricsContext = React.createContext<MetricsProviderProps | undefined>(undefined);
+
+const createMetricsService = () => {
+  const metricsJsonSerializer = new Logger(APP_VERSION_CODE, Platform.OS);
+  const metricsService = MetricsService.initialize(metricsJsonSerializer);
+  return {metricsService};
+};
+
+export const MetricsProvider = ({children}: MetricsProviderProps) => {
+  const value = createMetricsService();
+
+  return <MetricsContext.Provider value={value}>{children}</MetricsContext.Provider>;
+};
+
+export const useMetricsProvider = () => {
+  return useContext(MetricsContext)!!;
+};

--- a/src/shared/logging/config.ts
+++ b/src/shared/logging/config.ts
@@ -21,7 +21,7 @@ const config = {
   },
 };
 
-type Category = 'debug' | 'background' | 'configuration' | 'exposure-check' | 'summary';
+type Category = 'debug' | 'background' | 'configuration' | 'exposure-check' | 'summary' | 'metrics';
 
 interface Log {
   info: (payload: {category?: Category; message?: string; payload?: string | {}}) => void;

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -17,7 +17,7 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   return {exposed: false};
 };
 
-export type EventType = 'installed' | 'onboarded' | 'exposed' | 'otk' | 'otk-with-date' | 'en-toggle';
+export type EventType = 'installed' | 'onboarded' | 'exposed' | 'otk-no-date' | 'otk-with-date' | 'en-toggle';
 
 export const sendMetricEvent = (payload: any) => {
   log.debug({message: 'metric', payload});
@@ -28,7 +28,6 @@ export const useMetrics = () => {
   const {region, userStopped} = useStorage();
   const [systemStatus] = useSystemStatus();
   const [notificationStatus] = useNotificationPermissionStatus();
-  // const notificationStatus = '';
 
   const addEvent = (eventType: EventType) => {
     let payload: any = {identifier: eventType, timestamp: new Date().getTime(), region};
@@ -45,7 +44,7 @@ export const useMetrics = () => {
         break;
       case 'exposed':
         break;
-      case 'otk':
+      case 'otk-no-date':
         payload = {...checkStatus(exposureStatus), ...payload};
         break;
       case 'otk-with-date':

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -20,7 +20,7 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
 export type EventType = 'installed' | 'onboarded' | 'exposed' | 'otk-no-date' | 'otk-with-date' | 'en-toggle';
 
 export const sendMetricEvent = (payload: any) => {
-  log.debug({message: 'metric', payload});
+  log.debug({category: 'metrics', message: payload.identifier, payload});
 };
 
 export const useMetrics = () => {

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -19,6 +19,10 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
 
 export type EventType = 'installed' | 'onboarded' | 'exposed' | 'onetimekey' | 'en-toggle';
 
+export const sendMetricEvent = (payload: any) => {
+  log.debug({message: 'metric', payload});
+};
+
 export const useMetrics = () => {
   const exposureStatus = useExposureStatus();
   const {region, userStopped} = useStorage();
@@ -48,7 +52,7 @@ export const useMetrics = () => {
         break;
     }
 
-    log.debug({message: 'metric', payload});
+    sendMetricEvent(payload);
   };
 
   return addEvent;

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -50,7 +50,7 @@ interface EnToggleMetric extends Metric {
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
 
 // note this can used direct i.e. outside of the React hook
-export const sendMetricEvent = (payload: Payload, metricsService: any) => {
+export const sendMetricEvent = (payload: Payload, metricsService: MetricsService) => {
   const {timestamp, identifier, region, ...data} = payload;
   metricsService.sendMetrics(timestamp, identifier, region, data);
 };

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-case-declarations */
 import {log} from 'shared/logging/config';
 import {
   useExposureStatus,
@@ -64,32 +65,33 @@ export const useMetrics = () => {
 
   const addEvent = (eventType: EventTypeMetric) => {
     const initialPayload: Metric = {identifier: eventType, timestamp: getCurrentDate().getTime(), region};
-    let payload: Payload = {...initialPayload};
 
     switch (eventType) {
       case EventTypeMetric.Installed:
+      case EventTypeMetric.Exposed:
+        const metric: Metric = {...initialPayload};
+        sendMetricEvent(metric);
         break;
       case EventTypeMetric.Onboarded:
-        payload = {
+        const onboardedMetric: OnboardedMetric = {
           ...initialPayload,
           pushnotification: notificationStatus,
           frameworkenabled: systemStatus === SystemStatus.Active,
         };
-        break;
-      case EventTypeMetric.Exposed:
+        sendMetricEvent(onboardedMetric);
         break;
       case EventTypeMetric.OtkNoDate:
-        payload = {...checkStatus(exposureStatus), ...initialPayload};
-        break;
       case EventTypeMetric.OtkWithDate:
-        payload = {...checkStatus(exposureStatus), ...initialPayload};
+        const otkMetric: OTKMetric = {...checkStatus(exposureStatus), ...initialPayload};
+        sendMetricEvent(otkMetric);
         break;
       case EventTypeMetric.EnToggle:
-        payload = userStopped ? {...initialPayload, state: false} : {...initialPayload, state: true};
+        const enToggleMetric: EnToggleMetric = userStopped
+          ? {...initialPayload, state: false}
+          : {...initialPayload, state: true};
+        sendMetricEvent(enToggleMetric);
         break;
     }
-
-    sendMetricEvent(payload);
   };
 
   return addEvent;

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -17,7 +17,7 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   return {exposed: false};
 };
 
-export type EventType = 'installed' | 'onboarded' | 'exposed' | 'onetimekey' | 'en-toggle';
+export type EventType = 'installed' | 'onboarded' | 'exposed' | 'otk' | 'otk-with-date' | 'en-toggle';
 
 export const sendMetricEvent = (payload: any) => {
   log.debug({message: 'metric', payload});
@@ -44,8 +44,11 @@ export const useMetrics = () => {
         break;
       case 'exposed':
         break;
-      case 'onetimekey':
-        payload = {...checkStatus(exposureStatus), ...payload, symptomonsent: ''};
+      case 'otk':
+        payload = {...checkStatus(exposureStatus), ...payload};
+        break;
+      case 'otk-with-date':
+        payload = {...checkStatus(exposureStatus), ...payload};
         break;
       case 'en-toggle':
         payload = userStopped ? {...payload, state: 'off'} : {...payload, state: 'on'};

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable no-case-declarations */
 import {log} from 'shared/logging/config';
+import {APP_VERSION_CODE, LOGGLY_URL} from 'env';
+import {useMemo} from 'react';
 import {
   useExposureStatus,
   ExposureStatusType,
@@ -9,8 +11,8 @@ import {
 } from 'services/ExposureNotificationService';
 import {useStorage} from 'services/StorageService';
 import {useNotificationPermissionStatus} from 'screens/home/components/NotificationPermissionStatus';
-import {LOGGLY_URL} from 'env';
 import {getCurrentDate} from 'shared/date-fns';
+import {Platform} from 'react-native';
 
 const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   if (exposureStatus.type === ExposureStatusType.Exposed) {
@@ -50,11 +52,52 @@ interface EnToggleMetric extends Metric {
 
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
 
-// note this can used direct i.e. outside of the React hook
-export const sendMetricEvent = (payload: Payload) => {
-  if (LOGGLY_URL) {
-    log.debug({category: 'metrics', message: payload.identifier, payload});
+// this will be replaces with DefaultMetricsJsonSerializer #1371
+export class Logger {
+  private appVersion: number;
+  private appOs: string;
+
+  constructor(appVersion: number, appOs: string) {
+    console.log('===== new logger ======');
+    this.appVersion = appVersion;
+    this.appOs = appOs;
   }
+
+  log(payload: any) {
+    console.log(payload); // eslint-disable-line no-console
+
+    if (LOGGLY_URL) {
+      log.debug({
+        category: 'metrics',
+        message: payload.identifier,
+        payload: {appVersion: this.appVersion, appOs: this.appOs},
+      });
+    }
+  }
+}
+
+// this will be replaced with DefaultMetricsService #1371
+class MetricsService implements MetricsService {
+  static initialize(logger: Logger) {
+    console.log('===== MetricsService initialize ======');
+    return new MetricsService(logger);
+  }
+
+  private logger: any;
+
+  private constructor(logger: any) {
+    this.logger = logger;
+  }
+
+  sendMetrics(timestamp: number, identifier: string, region: string | undefined, data: {}): Promise<void> {
+    return this.logger.log({timestamp, identifier, region, data});
+  }
+}
+
+// note this can used direct i.e. outside of the React hook
+export const sendMetricEvent = (payload: Payload, metricsService: MetricsService) => {
+  const {timestamp, identifier, region, ...data} = payload;
+  metricsService.sendMetrics(timestamp, identifier, region, data);
 };
 
 export const useMetrics = () => {
@@ -63,6 +106,12 @@ export const useMetrics = () => {
   const [systemStatus] = useSystemStatus();
   const [notificationStatus] = useNotificationPermissionStatus();
 
+  const metricsService = useMemo(() => {
+    const metricsJsonSerializer = new Logger(APP_VERSION_CODE, Platform.OS);
+    const metricsService = MetricsService.initialize(metricsJsonSerializer);
+    return metricsService;
+  }, []);
+
   const addEvent = (eventType: EventTypeMetric) => {
     const initialPayload: Metric = {identifier: eventType, timestamp: getCurrentDate().getTime(), region};
 
@@ -70,7 +119,7 @@ export const useMetrics = () => {
       case EventTypeMetric.Installed:
       case EventTypeMetric.Exposed:
         const metric: Metric = {...initialPayload};
-        sendMetricEvent(metric);
+        sendMetricEvent(metric, metricsService);
         break;
       case EventTypeMetric.Onboarded:
         const onboardedMetric: OnboardedMetric = {
@@ -78,18 +127,18 @@ export const useMetrics = () => {
           pushnotification: notificationStatus,
           frameworkenabled: systemStatus === SystemStatus.Active,
         };
-        sendMetricEvent(onboardedMetric);
+        sendMetricEvent(onboardedMetric, metricsService);
         break;
       case EventTypeMetric.OtkNoDate:
       case EventTypeMetric.OtkWithDate:
         const otkMetric: OTKMetric = {...checkStatus(exposureStatus), ...initialPayload};
-        sendMetricEvent(otkMetric);
+        sendMetricEvent(otkMetric, metricsService);
         break;
       case EventTypeMetric.EnToggle:
         const enToggleMetric: EnToggleMetric = userStopped
           ? {...initialPayload, state: false}
           : {...initialPayload, state: true};
-        sendMetricEvent(enToggleMetric);
+        sendMetricEvent(enToggleMetric, metricsService);
         break;
     }
   };

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -10,6 +10,8 @@ import {useStorage} from 'services/StorageService';
 import {useNotificationPermissionStatus} from 'screens/home/components/NotificationPermissionStatus';
 import {LOGGLY_URL} from 'env';
 
+import {getCurrentDate} from 'shared/date-fns';
+
 const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   if (exposureStatus.type === ExposureStatusType.Exposed) {
     return {exposed: true};
@@ -42,6 +44,7 @@ interface EnToggleMetric extends Metric {
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
 
 export const sendMetricEvent = (payload: Payload) => {
+  console.log(payload);
   if (LOGGLY_URL) {
     log.debug({category: 'metrics', message: payload.identifier, payload});
   }
@@ -54,7 +57,7 @@ export const useMetrics = () => {
   const [notificationStatus] = useNotificationPermissionStatus();
 
   const addEvent = (eventType: EventType) => {
-    const initialPayload: Metric = {identifier: eventType, timestamp: new Date().getTime(), region};
+    const initialPayload: Metric = {identifier: eventType, timestamp: getCurrentDate().getTime(), region};
     let payload: Payload = {...initialPayload};
 
     switch (eventType) {

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -7,7 +7,7 @@ import {
   useSystemStatus,
 } from 'services/ExposureNotificationService';
 import {useStorage} from 'services/StorageService';
-import {useNotificationPermissionStatus} from '../../src/screens/home/components/NotificationPermissionStatus';
+import {useNotificationPermissionStatus} from 'screens/home/components/NotificationPermissionStatus';
 
 const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   if (exposureStatus.type === ExposureStatusType.Exposed) {
@@ -17,7 +17,7 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   return {exposed: false};
 };
 
-type EventType = 'installed' | 'onboarded' | 'exposed' | 'onetimekey' | 'en-toggle';
+export type EventType = 'installed' | 'onboarded' | 'exposed' | 'onetimekey' | 'en-toggle';
 
 export const useMetrics = () => {
   const exposureStatus = useExposureStatus();

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -28,6 +28,7 @@ export const useMetrics = () => {
   const {region, userStopped} = useStorage();
   const [systemStatus] = useSystemStatus();
   const [notificationStatus] = useNotificationPermissionStatus();
+  // const notificationStatus = '';
 
   const addEvent = (eventType: EventType) => {
     let payload: any = {identifier: eventType, timestamp: new Date().getTime(), region};

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -39,7 +39,9 @@ interface EnToggleMetric extends Metric {
   state: boolean;
 }
 
-export const sendMetricEvent = (payload: any) => {
+type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
+
+export const sendMetricEvent = (payload: Payload) => {
   if (LOGGLY_URL) {
     log.debug({category: 'metrics', message: payload.identifier, payload});
   }
@@ -53,7 +55,7 @@ export const useMetrics = () => {
 
   const addEvent = (eventType: EventType) => {
     const initialPayload: Metric = {identifier: eventType, timestamp: new Date().getTime(), region};
-    let payload: Metric | OnboardedMetric | OTKMetric | EnToggleMetric = {...initialPayload};
+    let payload: Payload = {...initialPayload};
 
     switch (eventType) {
       case 'installed':

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -50,7 +50,7 @@ interface EnToggleMetric extends Metric {
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
 
 // note this can used direct i.e. outside of the React hook
-export const sendMetricEvent = (payload: Payload, metricsService: MetricsService) => {
+export const sendMetricEvent = (payload: Payload, metricsService: any) => {
   const {timestamp, identifier, region, ...data} = payload;
   metricsService.sendMetrics(timestamp, identifier, region, data);
 };

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -8,6 +8,7 @@ import {
 } from 'services/ExposureNotificationService';
 import {useStorage} from 'services/StorageService';
 import {useNotificationPermissionStatus} from 'screens/home/components/NotificationPermissionStatus';
+import {LOGGLY_URL} from 'env';
 
 const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   if (exposureStatus.type === ExposureStatusType.Exposed) {
@@ -20,7 +21,9 @@ const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
 export type EventType = 'installed' | 'onboarded' | 'exposed' | 'otk-no-date' | 'otk-with-date' | 'en-toggle';
 
 export const sendMetricEvent = (payload: any) => {
-  log.debug({category: 'metrics', message: payload.identifier, payload});
+  if (LOGGLY_URL) {
+    log.debug({category: 'metrics', message: payload.identifier, payload});
+  }
 };
 
 export const useMetrics = () => {

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -1,0 +1,40 @@
+import {log} from 'shared/logging/config';
+import {useExposureStatus, ExposureStatusType, ExposureStatus} from 'services/ExposureNotificationService';
+import {useStorage} from 'services/StorageService';
+
+const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
+  if (exposureStatus.type === ExposureStatusType.Exposed) {
+    return {exposed: true};
+  }
+
+  return {exposed: false};
+};
+
+type EventType = 'onboarded' | 'otk' | 'enToggle';
+
+export const useMetrics = () => {
+  const exposureStatus = useExposureStatus();
+  const {region, userStopped} = useStorage();
+
+  const addEvent = (eventType: EventType) => {
+    let payload: any = {timestamp: new Date().getTime(), region};
+
+    switch (eventType) {
+      case 'onboarded':
+        payload = {...payload};
+        break;
+      case 'otk':
+        payload = {...checkStatus(exposureStatus), ...payload};
+        break;
+      case 'enToggle':
+        payload = userStopped ? {...payload, en: 'off'} : {...payload, en: 'on'};
+        break;
+    }
+
+    console.log('===================================');
+
+    log.debug({message: 'metric', payload});
+  };
+
+  return addEvent;
+};


### PR DESCRIPTION
# Summary | Résumé

Initial work to add metrics hooks

This is the UI piece which will connect to https://github.com/cds-snc/covid-alert-app/pull/1371

Current logging is for dev mode only 
```
raw message
{"uuid":"S7GSNZ8T","platform":"android","msg":{"category":"metrics","message":"en-toggle","payload":{"appVersion":209,"appOs":"android","payload":{"timestamp":1611250306668,"identifier":"en-toggle","region":"ON","data":{"state":false}}}},"level":{"severity":5,"text":"debug"},"versionCode":209,"versionName":"1.1.7","currentStatus":"monitoring","lastCheckedMinutesAgo":"1"}
```

## Testing

Install the app 
Onboard 
Toggle EN on/off vs the drawer menu or home screen or info panel 

You should now be able to events for install, onboarded and multiple en toggle events depending on what you press


