### PR TITLE
fixed issue with overlay menu

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -16,7 +16,6 @@ import {
 import {useStorage} from 'services/StorageService';
 import {RegionCase} from 'shared/Region';
 import {getRegionCase} from 'shared/RegionLogic';
-import {usePrevious} from 'shared/usePrevious';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useRegionalI18n} from 'locale';
 

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -216,13 +216,6 @@ export const HomeScreen = () => {
 
   const bottomSheetRef = useRef<BottomSheetBehavior>(null);
   const [isBottomSheetExpanded, setIsBottomSheetExpanded] = useState(false);
-  const currentStatus = useExposureStatus().type;
-  const previousStatus = usePrevious(currentStatus);
-  useLayoutEffect(() => {
-    if (previousStatus === ExposureStatusType.Monitoring && currentStatus === ExposureStatusType.Diagnosed) {
-      bottomSheetRef.current?.expand();
-    }
-  }, [currentStatus, previousStatus]);
   useLayoutEffect(() => {
     bottomSheetRef.current?.setOnStateChange(setIsBottomSheetExpanded);
   }, []);

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -220,7 +220,7 @@ export const HomeScreen = () => {
   const previousStatus = usePrevious(currentStatus);
   useLayoutEffect(() => {
     if (previousStatus === ExposureStatusType.Monitoring && currentStatus === ExposureStatusType.Diagnosed) {
-      bottomSheetRef.current?.collapse();
+      bottomSheetRef.current?.expand();
     }
   }, [currentStatus, previousStatus]);
   useLayoutEffect(() => {

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -117,7 +117,6 @@ const NotificationStatusOff = ({action, i18n}: {action: () => void; i18n: I18n})
 const ShareDiagnosisCode = ({
   i18n,
   isBottomSheetExpanded,
-  bottomSheetBehavior,
 }: {
   i18n: I18n;
   isBottomSheetExpanded: boolean;

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -174,7 +174,6 @@ const ShareDiagnosisCode = ({
         button={{
           text: i18n.translate('OverlayOpen.CodeNotShared.CTA'),
           action: () => {
-            bottomSheetBehavior.collapse();
             navigation.navigate('DataSharing', {screen: 'IntermediateScreen'});
           },
         }}


### PR DESCRIPTION
# Summary | Résumé

There was an issue with the overlay screen that led the menu being 'frozen', users would not be interact with any of the buttons on the menu. This was caused by conflicting bottom sheet booleans. In the `HomeScreen` , the `bottomSheetRef` was calling the `collapse()`, setting `bottomSheet.isExpanded` to false, however, the `isBottomSheetExpanded`, had a value of true. This is why the Overlay Menu was appearing, but could not be interacted with. Removed the function because it only effected the bottomSheet in diagnosed mode which led to the issue.