### PR TITLE
Clear exposed metric

### DIFF
--- a/src/screens/home/views/ClearExposureView.tsx
+++ b/src/screens/home/views/ClearExposureView.tsx
@@ -4,11 +4,13 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {Text, Box, Button, ButtonSingleLine, Toolbar} from 'components';
 import {useNavigation} from '@react-navigation/native';
 import {useClearExposedStatus} from 'services/ExposureNotificationService';
+import {EventTypeMetric, useMetrics} from 'shared/metrics';
 import {useI18n} from 'locale';
 
 export const DismissAlertScreen = () => {
   const i18n = useI18n();
   const navigation = useNavigation();
+  const addEvent = useMetrics();
   const close = useCallback(() => navigation.goBack(), [navigation]);
   const [clearExposedStatus] = useClearExposedStatus();
 
@@ -23,12 +25,13 @@ export const DismissAlertScreen = () => {
         text: i18n.translate('Home.ExposureDetected.Dismiss.Confirm.Accept'),
         onPress: () => {
           clearExposedStatus();
+          addEvent(EventTypeMetric.ExposedClear);
           close();
         },
         style: 'default',
       },
     ]);
-  }, [clearExposedStatus, close, i18n]);
+  }, [addEvent, clearExposedStatus, close, i18n]);
 
   return (
     <Box backgroundColor="overlayBackground" flex={1}>

--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -11,6 +11,7 @@ import {
   formatExposedDate,
   parseSavedTimestamps,
   getFirstThreeUniqueDates,
+  getHoursBetween,
 } from './date-fns';
 
 /**
@@ -237,6 +238,30 @@ describe('date-fns', () => {
       ]);
     });
   });
+
+  describe('calculates hours', () => {
+    it('calculates short number of hours between', () => {
+      const now = getCurrentDate();
+      const hrs = 5 * 60 * 60 * 1000;
+      const plusFiveHours = new Date(now.getTime() + hrs);
+      expect(getHoursBetween(now, plusFiveHours)).toStrictEqual(5);
+    });
+
+    it('calculates negative hours', () => {
+      const now = getCurrentDate();
+      const hrs = -5 * 60 * 60 * 1000;
+      const minusFiveHours = new Date(now.getTime() + hrs);
+      expect(getHoursBetween(now, minusFiveHours)).toStrictEqual(-5);
+    });
+
+    it('calculates hours for 2 days in the future', () => {
+      const now = getCurrentDate();
+      const twoDaysFromNow = new Date(Number(now));
+      twoDaysFromNow.setDate(now.getDate() + 2);
+      expect(getHoursBetween(now, twoDaysFromNow)).toStrictEqual(48);
+    });
+  });
+
   // eslint-disable-next-line jest/no-commented-out-tests
   // it('returns 1 missing day for keys upload', () => {
   //   const today = new Date('Wed Jul 28 2020 00:00:00 GMT-0400');

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -61,8 +61,8 @@ export function getUploadDaysLeft(cycleEndsAt: number) {
 
 export function getHoursBetween(date1: Date, date2: Date): number {
   const oneHourMs = 1000 * 60 * 60;
-  const hrs = (date1.getTime() - date2.getTime()) / oneHourMs;
-  return hrs;
+  const hrs = (date2.getTime() - date1.getTime()) / oneHourMs;
+  return Math.round(hrs);
 }
 
 export function parseDateString(dateString: string) {

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -59,6 +59,12 @@ export function getUploadDaysLeft(cycleEndsAt: number) {
   return uploadDaysLeft;
 }
 
+export function getHoursBetween(date1: Date, date2: Date): number {
+  const oneHourMs = 1000 * 60 * 60;
+  const hrs = (date1.getTime() - date2.getTime()) / oneHourMs;
+  return hrs;
+}
+
 export function parseDateString(dateString: string) {
   if (!dateString) {
     return null;

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -9,7 +9,7 @@ import {
 import {useStorage} from 'services/StorageService';
 import {useMetricsContext} from 'shared/MetricsProvider';
 import {useNotificationPermissionStatus} from 'screens/home/components/NotificationPermissionStatus';
-import {getCurrentDate} from 'shared/date-fns';
+import {getCurrentDate, getHoursBetween} from 'shared/date-fns';
 
 const checkStatus = (exposureStatus: ExposureStatus): {exposed: boolean} => {
   if (exposureStatus.type === ExposureStatusType.Exposed) {
@@ -96,10 +96,15 @@ export const useMetrics = () => {
         sendMetricEvent(enToggleMetric, metrics.service);
         break;
       case EventTypeMetric.ExposedClear:
+        if (exposureStatus.type !== ExposureStatusType.Exposed) {
+          break;
+        }
+
         const clearExposedMetric: ClearExposedMetric = {
           ...initialPayload,
-          timeamount: getCurrentDate().getTime(),
+          timeamount: getHoursBetween(getCurrentDate(), new Date(exposureStatus.exposureDetectedAt)),
         };
+
         sendMetricEvent(clearExposedMetric, metrics.service);
         break;
     }

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -26,6 +26,7 @@ export enum EventTypeMetric {
   OtkNoDate = 'otk-no-date',
   OtkWithDate = 'otk-with-date',
   EnToggle = 'en-toggle',
+  ExposedClear = 'exposed-clear',
 }
 
 interface Metric {
@@ -45,6 +46,10 @@ interface OTKMetric extends Metric {
 
 interface EnToggleMetric extends Metric {
   state: boolean;
+}
+
+interface ClearExposedMetric extends Metric {
+  timeamount: number;
 }
 
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
@@ -89,6 +94,13 @@ export const useMetrics = () => {
           ? {...initialPayload, state: false}
           : {...initialPayload, state: true};
         sendMetricEvent(enToggleMetric, metrics.service);
+        break;
+      case EventTypeMetric.ExposedClear:
+        const clearExposedMetric: ClearExposedMetric = {
+          ...initialPayload,
+          timeamount: getCurrentDate().getTime(),
+        };
+        sendMetricEvent(clearExposedMetric, metrics.service);
         break;
     }
   };

--- a/src/shared/metrics.tsx
+++ b/src/shared/metrics.tsx
@@ -49,7 +49,7 @@ interface EnToggleMetric extends Metric {
 }
 
 interface ClearExposedMetric extends Metric {
-  timeamount: number;
+  hoursSinceExposureDetectedAt: number;
 }
 
 type Payload = Metric | OnboardedMetric | OTKMetric | EnToggleMetric;
@@ -102,7 +102,7 @@ export const useMetrics = () => {
 
         const clearExposedMetric: ClearExposedMetric = {
           ...initialPayload,
-          timeamount: getHoursBetween(getCurrentDate(), new Date(exposureStatus.exposureDetectedAt)),
+          hoursSinceExposureDetectedAt: getHoursBetween(getCurrentDate(), new Date(exposureStatus.exposureDetectedAt)),
         };
 
         sendMetricEvent(clearExposedMetric, metrics.service);


### PR DESCRIPTION
Add clear exposed metric

Follow up for https://github.com/cds-snc/covid-alert-app/pull/1373

Adds utility function to calculate hours between exposed to clearing

```
getHoursBetween(...)
```