### PR TITLE
Fastlane: check that the translations file has been generated

### DIFF
--- a/fastlane/Android.Fastfile
+++ b/fastlane/Android.Fastfile
@@ -50,6 +50,9 @@ platform :android do
     # Load env file
     load_env_file(buildType:buildType)
 
+    # Check that translations have been generated
+    ensure_translations_generated
+
     # Check Version Code
     check_version_code_exists
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,3 +102,18 @@ lane :ensure_env_file_exists do |options|
   UI.user_error!("#{file} environment file is missing!") unless file_exists
   UI.success("Using environment file #{file}")
 end
+
+lane :ensure_translations_generated do
+  yarn(
+    command: "generate-translations"
+  )
+
+  translations_status = Actions.sh("git status ../src/locale/translations --porcelain")
+
+  repo_clean = translations_status.empty?
+
+  UI.user_error!("Ok, go commit that file!") unless prompt(
+    text: "The translations file appears to be dirty, and changes should be committed. Are you sure you want to continue?",
+    boolean: true
+  ) unless repo_clean
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -50,6 +50,11 @@ fastlane ensure_build_directory
 fastlane ensure_env_file_exists
 ```
 
+### ensure_translations_generated
+```
+fastlane ensure_translations_generated
+```
+
 
 ----
 

--- a/fastlane/iOS.Fastfile
+++ b/fastlane/iOS.Fastfile
@@ -40,6 +40,9 @@ platform :ios do
     # Check required env vars
     UI.user_error!("Missing XCODE_SCHEME environment variable") unless ENV['XCODE_SCHEME']
 
+    # Check that translations have been generated
+    ensure_translations_generated
+
     # Check Version Code
     check_version_code_exists
     set_version


### PR DESCRIPTION
# Summary | Résumé

Runs generate-translations before a build and will prompt the user if the generated file is 'dirty'. Usually, this file should be committed back to the repo, but the user has the option to continue anyway. If the user opts to continue, the build will contain the newly-generated translations.


https://user-images.githubusercontent.com/1187115/105534610-bf1e3600-5cbb-11eb-8db1-80eb4c09b936.mov


