### PR TITLE
Updated content for future usage statistics

### DIFF
--- a/src/locale/translations/en.json
+++ b/src/locale/translations/en.json
@@ -7,9 +7,9 @@
     },
     "NoExposureDetected": {
       "WhatsNew": {
-        "Title": "New notifications show app is working",
-        "Body1": "If you got a notification that popped up and went away, it’s ok.",
-        "Body2": "The app now shows notifications while checking for exposures."
+        "Title": "",
+        "Body1": "",
+        "Body2": ""
       },
       "AllSetTitle": "You’re all set",
       "RegionCovered": {
@@ -189,7 +189,7 @@
       }
     },
     "ChangeRegion": "Change province or territory",
-    "Privacy": "How it protects your privacy",
+    "Privacy": "Privacy",
     "PrivacyUrl": "https://www.canada.ca/en/public-health/services/diseases/coronavirus-disease-covid-19/covid-alert/privacy-policy.html",
     "SettingsTitle": "Settings",
     "InformationTitle": "About COVID Alert"
@@ -320,7 +320,7 @@
         "3a": "3. Allow your phone to share ",
         "3b": "your random codes. These codes notify people you’ve been near."
       },
-      "Body1": "Nobody will get any information about you ",
+      "Body1": "Exposed people will not get any information about you",
       "Body2": "or the time you were near them. They will only get a notification that they were exposed recently.",
       "CTA": "Next",
       "NoCode": "Need a one-time key?"
@@ -446,7 +446,7 @@
     "Title": "Where do you live? (optional)",
     "SettingsTitle": "Province or territory",
     "Close": "Close",
-    "Body": "Choose your region to check if you can report a diagnosis through this app.\n\nYour region will never be shared with anyone.",
+    "Body": "Choose your region to check if you can report a diagnosis through this app.",
     "Skip": "Skip",
     "GetStarted": "Get started",
     "Optional": "* Optional",
@@ -473,7 +473,7 @@
   "RegionPickerNoPT": {
     "Exposed": {
       "Title": "Find your area’s advice",
-      "Body": "The steps you need to take when you’re exposed depend on the province or territory you live in. The app will not remember your choice."
+      "Body": "The steps you need to take when you’re exposed depend on the province or territory you live in."
     }
   },
   "A11yList": {


### PR DESCRIPTION
Updated content for coming usage statistics on the menu, province or territory selection screens and steps for sharing exposures if positive. Also removed the previous content about new notifications, but I'm not sure if something else needs to be done to delete the white card? Please review the figma page carefully to ensure I didn't miss anything. 

Tagging @EliseKa for French.

