### PR TITLE
Patch to fix disappearing exposure history

### DIFF
--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -5,6 +5,7 @@ import {useExposureNotificationService} from 'services/ExposureNotificationServi
 import {formatExposedDate, getCurrentDate, getFirstThreeUniqueDates} from 'shared/date-fns';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useStorage} from 'services/StorageService';
+import {log} from 'shared/logging/config';
 
 export const ExposureDateView = () => {
   const i18n = useI18n();
@@ -17,7 +18,9 @@ export const ExposureDateView = () => {
     if (forceScreen && forceScreen !== ForceScreen.None) {
       return [getCurrentDate()];
     }
-    return exposureNotificationService.getExposureDetectedAt();
+    const _dates = exposureNotificationService.getExposureDetectedAt();
+    log.debug({message: '_dates', payload: {_dates}});
+    return _dates;
   }, [exposureNotificationService, forceScreen]);
 
   const formattedDates = dates.map(date => {
@@ -25,6 +28,7 @@ export const ExposureDateView = () => {
   });
 
   const firstThreeUniqueDates = getFirstThreeUniqueDates(formattedDates);
+  log.debug({message: 'firstThreeUniqueDates', payload: {firstThreeUniqueDates}});
   return firstThreeUniqueDates ? (
     <Box marginBottom="m">
       <Text>{i18n.translate('Home.ExposureDetected.Notification.Received')}:</Text>

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -473,7 +473,7 @@ export class ExposureNotificationService {
           daysBetween(new Date(exposureStatus.summary.lastExposureTimestamp || today.getTime()), today) >=
           EXPOSURE_NOTIFICATION_CYCLE
         ) {
-          // clear exposure history
+          log.info({message: 'clearing exposure history'});
           this.exposureHistory.set([]);
           return {type: ExposureStatusType.Monitoring, lastChecked: exposureStatus.lastChecked};
         } else {
@@ -491,7 +491,7 @@ export class ExposureNotificationService {
       const summary = exposureStatus.summary;
       const summaries = exposureStatus.ignoredSummaries ? exposureStatus.ignoredSummaries : [];
       summaries.push(summary);
-      // clear exposure history
+      log.info({message: 'clearing exposure history'});
       this.exposureHistory.set([]);
       return this.finalize({type: ExposureStatusType.Monitoring, ignoredSummaries: summaries});
     }
@@ -689,7 +689,10 @@ export class ExposureNotificationService {
   };
 
   public getExposureDetectedAt(): Date[] {
+    // this.loadExposureHistory();
     const exposureStatus = this.exposureStatus.get();
+    log.info({message: 'getExposureDetectedAt', payload: {exposureStatus}});
+
     if (exposureStatus.type !== ExposureStatusType.Exposed) {
       return [];
     }

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -24,7 +24,6 @@ import {log} from 'shared/logging/config';
 import {DeviceEventEmitter, Platform} from 'react-native';
 import {ContagiousDateInfo, ContagiousDateType} from 'shared/DataSharing';
 import {EN_API_VERSION} from 'env';
-import {sendMetricEvent, EventTypeMetric} from 'shared/metrics';
 
 import {BackendInterface, SubmissionKeySet} from '../BackendService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
@@ -125,7 +124,6 @@ export class ExposureNotificationService {
   private i18n: I18n;
   private storage: PersistencyProvider;
   private secureStorage: SecurePersistencyProvider;
-  private metricService: any;
 
   constructor(
     backendInterface: BackendInterface,
@@ -133,7 +131,6 @@ export class ExposureNotificationService {
     storage: PersistencyProvider,
     secureStorage: SecurePersistencyProvider,
     exposureNotification: typeof ExposureNotification,
-    metricService?: any,
   ) {
     this.i18n = i18n;
     this.exposureNotification = exposureNotification;
@@ -143,7 +140,6 @@ export class ExposureNotificationService {
     this.backendInterface = backendInterface;
     this.storage = storage;
     this.secureStorage = secureStorage;
-    this.metricService = metricService;
     this.exposureStatus.observe(status => {
       this.storage.setItem(EXPOSURE_STATUS, JSON.stringify(status));
     });
@@ -689,7 +685,6 @@ export class ExposureNotificationService {
   };
 
   public getExposureDetectedAt(): Date[] {
-    // this.loadExposureHistory();
     const exposureStatus = this.exposureStatus.get();
     log.info({message: 'getExposureDetectedAt', payload: {exposureStatus}});
 
@@ -854,15 +849,6 @@ export class ExposureNotificationService {
     const exposureHistory = this.exposureHistory.get();
     exposureHistory.push(exposureDetectedAt);
     this.exposureHistory.set(exposureHistory);
-
-    sendMetricEvent(
-      {
-        identifier: EventTypeMetric.Exposed,
-        timestamp: getCurrentDate().getTime(),
-        region: (await this.storage.getItem(Key.Region)) || '',
-      },
-      this.metricService,
-    );
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -8,7 +8,6 @@ import SystemSetting from 'react-native-system-setting';
 import {ContagiousDateInfo} from 'shared/DataSharing';
 import {useStorage} from 'services/StorageService';
 import {log} from 'shared/logging/config';
-import {useMetricsContext} from 'shared/MetricsProvider';
 
 import {BackendInterface} from '../BackendService';
 import {BackgroundScheduler} from '../BackgroundSchedulerService';
@@ -41,7 +40,6 @@ export const ExposureNotificationServiceProvider = ({
 }: ExposureNotificationServiceProviderProps) => {
   const i18n = useI18nRef();
   const {setUserStopped} = useStorage();
-  const metrics = useMetricsContext();
   const exposureNotificationService = useMemo(
     () =>
       new ExposureNotificationService(
@@ -50,9 +48,8 @@ export const ExposureNotificationServiceProvider = ({
         storage || AsyncStorage,
         secureStorage || RNSecureKeyStore,
         exposureNotification || ExposureNotification,
-        metrics.service,
       ),
-    [backendInterface, exposureNotification, i18n, metrics.service, secureStorage, storage],
+    [backendInterface, exposureNotification, i18n, secureStorage, storage],
   );
 
   useEffect(() => {


### PR DESCRIPTION
# Summary | Résumé

Removing metrics from ExposureNotificationService temporarily since this is causing a new instance of the class to be created whenever bluetooth toggles on or off.