### PR TITLE
Update launch config for Android debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,15 +1,19 @@
 {
-  "version": "0.2.0",
+  "version": "0.2.1",
   "configurations": [
     {
-      "name": "Debug Jest Tests",
+      "name": "Debug Android",
+      "cwd": "${workspaceFolder}",
+      "type": "reactnativedirect",
+      "request": "attach",
+      "platform": "android"
+    },
+    {
+      "name": "Debug Jest Test",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": [
-        "-t",
-        "my test name"
-      ],
+      "args": ["-t", "my test name"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }


### PR DESCRIPTION
Updated launch config to support "React Native Tools" `VS Code` extension 

<img width="400" src="https://user-images.githubusercontent.com/62242/106146076-40564c80-6144-11eb-82b0-7a1d7d9e914b.png">

This allows debugging via breakpoints etc... for a running app.



https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native

