### PR TITLE
Fix TEST GROUP issue

### DIFF
--- a/fastlane/iOS.Fastfile
+++ b/fastlane/iOS.Fastfile
@@ -68,9 +68,7 @@ platform :ios do
     )
 
     # Upload to TestFlight
-    groups = ENV["TEST_GROUPS"].split(",")
     upload_to_testflight(
-      groups: groups,
       skip_submission: true,
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH]
     )


### PR DESCRIPTION
Fixes error when running latest iOS build

```
[13:26:21]: Error in your Fastfile at line 71
[13:26:21]:     69:         package_name: 'ca.gc.hcsc.canada.covidalert.dev'
[13:26:21]:     70:       )
[13:26:21]:  => 71:
[13:26:21]:     72:       versions = Array(primary_play_versions) + Array(secondary_play_versions)
[13:26:21]:     73:
```