### PR TITLE
Make sure Date.now() works in the tests

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -152,8 +152,10 @@ describe('ExposureNotificationService', () => {
   let service: ExposureNotificationService;
 
   const OriginalDate = global.Date;
+  const realDateNow = Date.now.bind(global.Date);
   const dateSpy = jest.spyOn(global, 'Date');
   const today = new OriginalDate('2020-05-18T04:10:00+0000');
+  global.Date.now = realDateNow;
 
   const testUpdateExposure = async (currentStatus: ExposureStatus, summaries: ExposureSummary[]) => {
     service.exposureStatus.append(currentStatus);
@@ -170,6 +172,7 @@ describe('ExposureNotificationService', () => {
       .calledWith(Key.OnboardedDatetime)
       .mockResolvedValue(today.getTime());
 
+    dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
     dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
   });
 


### PR DESCRIPTION
Our Date mocking in the `ExposureNotificationService` was over-writting the `Date.now()` function, preventing code using this function from running in the tests. Not sure when this was introduced - maybe it was this? https://github.com/cds-snc/covid-alert-app/blob/79c180ba37ff98b7604a214f76249752888fd526/src/services/PollNotificationService/PollNotificationService.ts#L97 