### PR TITLE
Fix type-o.

### DIFF
--- a/src/shared/logging/transports/loggly.ts
+++ b/src/shared/logging/transports/loggly.ts
@@ -11,7 +11,7 @@ const logglyTransport: transportFunctionType = async (msg, level, _options) => {
   const platform = Platform.OS;
   const versionCode = APP_VERSION_CODE;
   const versionName = APP_VERSION_NAME;
-  const enApiVerion = String(EN_API_VERSION) || 'not set';
+  const enApiVersion = String(EN_API_VERSION) || 'not set';
   let currentStatus = '';
   let lastCheckedMinutesAgo = '';
 
@@ -43,7 +43,7 @@ const logglyTransport: transportFunctionType = async (msg, level, _options) => {
         versionName,
         currentStatus,
         lastCheckedMinutesAgo,
-        enApiVerion,
+        enApiVersion,
       }),
     }).catch(error => {
       console.log(error); // eslint-disable-line no-console


### PR DESCRIPTION
# Summary | Résumé

A small type-o in the Loggly data. I don't believe this will cause any problems with existing logs that already have the incorrect spelling.

# Test instructions | Instructions pour tester la modification

This fix will show up in Loggly with `enApiVersion` correctly spelt.
