### PR TITLE
Added a new env variable QR_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ HMAC_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 TEST_MODE=true
 MOCK_SERVER=false
 
+QR_ENABLED=false
 QR_HOST=
 OUTBREAK_LOCATIONS_URL=
 

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -35,11 +35,11 @@ export const LOGGLY_URL = Config.LOGGLY_URL || false;
 
 export const LOG_LEVEL = Config.LOG_LEVEL || 'debug';
 
-export const QR_CODE_PUBLIC_KEY = Config.QR_CODE_PUBLIC_KEY;
-
 export const OUTBREAK_LOCATIONS_URL = Config.OUTBREAK_LOCATIONS_URL;
 
 export const QR_HOST = Config.QR_HOST || '';
+
+export const QR_ENABLED = Config.QR_ENABLED || false;
 
 export const METRICS_URL = Config.METRICS_URL || false;
 

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -39,7 +39,7 @@ export const OUTBREAK_LOCATIONS_URL = Config.OUTBREAK_LOCATIONS_URL;
 
 export const QR_HOST = Config.QR_HOST || '';
 
-export const QR_ENABLED = Config.QR_ENABLED || false;
+export const QR_ENABLED = Config.QR_ENABLED === 'true' || false;
 
 export const METRICS_URL = Config.METRICS_URL || false;
 

--- a/src/screens/home/views/OverlayView.tsx
+++ b/src/screens/home/views/OverlayView.tsx
@@ -17,7 +17,7 @@ import {ScrollView} from 'react-native-gesture-handler';
 import {useAccessibilityService} from 'services/AccessibilityService';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useStorage} from 'services/StorageService';
-import {QR_HOST} from 'env';
+import {QR_ENABLED} from 'env';
 
 import {PrimaryActionButton} from '../components/PrimaryActionButton';
 
@@ -319,7 +319,7 @@ export const OverlayView = ({status, notificationWarning, turnNotificationsOn, b
               </Box>
             )}
 
-            {QR_HOST !== '' && (
+            {QR_ENABLED && (
               <Box marginBottom="m" marginHorizontal="m">
                 <QRCode bottomSheetBehavior={bottomSheetBehavior} i18n={i18n} />
               </Box>

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -11,7 +11,7 @@ import {
   useReportDiagnosis,
   useUpdateExposureStatus,
 } from 'services/ExposureNotificationService';
-import {APP_VERSION_NAME, APP_VERSION_CODE, QR_HOST} from 'env';
+import {APP_VERSION_NAME, APP_VERSION_CODE, QR_ENABLED} from 'env';
 import {captureMessage} from 'shared/log';
 import {useNavigation} from '@react-navigation/native';
 import {ContagiousDateType} from 'shared/DataSharing';
@@ -162,7 +162,7 @@ const Content = () => {
       <Section>
         <Button text="Show sample notification" onPress={onShowSampleNotification} variant="bigFlat" />
       </Section>
-      {QR_HOST !== '' && (
+      {QR_ENABLED && (
         <>
           <Section>
             <Button text="Check for Outbreak Exposures" onPress={onCheckForOutbreak} variant="bigFlat" />


### PR DESCRIPTION
# Summary | Résumé

This is because `QR_HOST` will need to always be set, so it would be best not to use it to determine if the QR code scan button is displayed in the app.