### PR TITLE
Replacing `outbreakStatus` with `outbreakHistory`

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -19,7 +19,7 @@ import {getRegionCase} from 'shared/RegionLogic';
 import {usePrevious} from 'shared/usePrevious';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useRegionalI18n} from 'locale';
-import {OutbreakStatusType} from 'shared/qr';
+import {isExposed} from 'shared/qr';
 import {useOutbreakService} from 'shared/OutbreakProvider';
 
 import {useDeepLinks} from '../qr/utils';
@@ -66,7 +66,7 @@ const Content = ({isBottomSheetExpanded}: ContentProps) => {
   const regionCase = getRegionCase(region, regionalI18n.activeRegions);
   const exposureStatus = useExposureStatus();
   const [systemStatus] = useSystemStatus();
-  const {outbreakStatus} = useOutbreakService();
+  const {outbreakHistory} = useOutbreakService();
   const [, turnNotificationsOn] = useNotificationPermissionStatus();
   useEffect(() => {
     return turnNotificationsOn();
@@ -106,7 +106,7 @@ const Content = ({isBottomSheetExpanded}: ContentProps) => {
     }
   }
 
-  if (outbreakStatus.type === OutbreakStatusType.Exposed) {
+  if (isExposed(outbreakHistory)) {
     return <OutbreakExposedView isBottomSheetExpanded={isBottomSheetExpanded} />;
   }
 

--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -19,7 +19,7 @@ import {getRegionCase} from 'shared/RegionLogic';
 import {usePrevious} from 'shared/usePrevious';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useRegionalI18n} from 'locale';
-import {isExposed} from 'shared/qr';
+import {isExposedToOutbreak} from 'shared/qr';
 import {useOutbreakService} from 'shared/OutbreakProvider';
 
 import {useDeepLinks} from '../qr/utils';
@@ -106,7 +106,7 @@ const Content = ({isBottomSheetExpanded}: ContentProps) => {
     }
   }
 
-  if (isExposed(outbreakHistory)) {
+  if (isExposedToOutbreak(outbreakHistory)) {
     return <OutbreakExposedView isBottomSheetExpanded={isBottomSheetExpanded} />;
   }
 

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -105,14 +105,11 @@ const Content = () => {
   const navigation = useNavigation();
 
   const {reset} = useStorage();
-  const {checkForOutbreaks, setOutbreakStatus} = useOutbreakService();
+  const {checkForOutbreaks, clearOutbreakHistory} = useOutbreakService();
 
   const onClearOutbreak = useCallback(async () => {
-    setOutbreakStatus({
-      type: OutbreakStatusType.Monitoring,
-      lastChecked: getCurrentDate().getTime(),
-    });
-  }, [setOutbreakStatus]);
+    clearOutbreakHistory();
+  }, [clearOutbreakHistory]);
 
   const onCheckForOutbreak = useCallback(async () => {
     checkForOutbreaks();

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -17,9 +17,7 @@ import {useNavigation} from '@react-navigation/native';
 import {ContagiousDateType} from 'shared/DataSharing';
 import {getLogUUID, setLogUUID} from 'shared/logging/uuid';
 import {ForceScreen} from 'shared/ForceScreen';
-import {OutbreakStatusType} from 'shared/qr';
 import {useOutbreakService} from 'shared/OutbreakProvider';
-import {getCurrentDate} from 'shared/date-fns';
 import {PollNotifications} from 'services/PollNotificationService';
 
 import {RadioButton} from './components/RadioButtons';

--- a/src/services/StorageService/StorageService.ts
+++ b/src/services/StorageService/StorageService.ts
@@ -13,6 +13,7 @@ export enum Key {
   SkipAllSet = 'SkipAllSet',
   UserStopped = 'UserStopped',
   CheckInHistory = 'CheckInHistory',
+  OutbreakHistory = 'OutbreakHistory',
   OutbreakStatus = 'OutbreakStatus',
   HasViewedQrInstructions = 'HasViewedQRInstructions',
 }

--- a/src/services/StorageService/StorageService.ts
+++ b/src/services/StorageService/StorageService.ts
@@ -14,7 +14,6 @@ export enum Key {
   UserStopped = 'UserStopped',
   CheckInHistory = 'CheckInHistory',
   OutbreakHistory = 'OutbreakHistory',
-  OutbreakStatus = 'OutbreakStatus',
   HasViewedQrInstructions = 'HasViewedQRInstructions',
 }
 export class StorageService {

--- a/src/shared/OutbreakProvider.tsx
+++ b/src/shared/OutbreakProvider.tsx
@@ -115,16 +115,24 @@ export const useOutbreakService = () => {
     [outbreakService],
   );
 
+  const clearOutbreakHistory = useMemo(
+    () => () => {
+      outbreakService.setOutbreakHistory([]);
+    },
+    [outbreakService],
+  );
+
   useEffect(() => outbreakService.checkInHistory.observe(addCheckInInternal), [outbreakService.checkInHistory]);
 
   return useMemo(
     () => ({
       outbreakHistory,
+      clearOutbreakHistory,
       checkForOutbreaks,
       addCheckIn,
       removeCheckIn,
       checkInHistory,
     }),
-    [outbreakHistory, checkForOutbreaks, addCheckIn, removeCheckIn, checkInHistory],
+    [outbreakHistory, clearOutbreakHistory, checkForOutbreaks, addCheckIn, removeCheckIn, checkInHistory],
   );
 };

--- a/src/shared/OutbreakProvider.tsx
+++ b/src/shared/OutbreakProvider.tsx
@@ -5,7 +5,7 @@ import PushNotification from 'bridge/PushNotification';
 import {useI18nRef, I18n} from 'locale';
 
 import {Observable} from './Observable';
-import {CheckInData, getNewOutbreakHistory, getOutbreakEvents, isExposed, OutbreakHistoryItem} from './qr';
+import {CheckInData, getNewOutbreakHistory, getOutbreakEvents, isExposedToOutbreak, OutbreakHistoryItem} from './qr';
 import {createCancellableCallbackPromise} from './cancellablePromise';
 
 class OutbreakService implements OutbreakService {
@@ -57,7 +57,7 @@ class OutbreakService implements OutbreakService {
   };
 
   processOutbreakNotification = (outbreakHistory: OutbreakHistoryItem[]) => {
-    if (isExposed(outbreakHistory)) {
+    if (isExposedToOutbreak(outbreakHistory)) {
       PushNotification.presentLocalNotification({
         alertTitle: this.i18n.translate('Notification.OutbreakMessageTitle'),
         alertBody: this.i18n.translate('Notification.OutbreakMessageBody'),

--- a/src/shared/OutbreakProvider.tsx
+++ b/src/shared/OutbreakProvider.tsx
@@ -108,6 +108,7 @@ export class OutbreakService implements OutbreakService {
   getOutbreaksFromServer = async () => {
     const outbreakEvents = await getOutbreakEvents();
     const detectedOutbreakExposures = getNewOutbreakHistoryItems(this.checkInHistory.get(), outbreakEvents);
+    this.markOutbreaksLastCheckedDateTime(getCurrentDate());
     log.debug({payload: {detectedOutbreakExposures}});
     if (detectedOutbreakExposures.length === 0) {
       return;
@@ -120,7 +121,6 @@ export class OutbreakService implements OutbreakService {
     const outbreakHistory = this.outbreakHistory.get();
     log.debug({payload: {outbreakHistory}});
     this.processOutbreakNotification(outbreakHistory);
-    this.markOutbreaksLastCheckedDateTime(getCurrentDate());
   };
 
   processOutbreakNotification = (outbreakHistory: OutbreakHistoryItem[]) => {

--- a/src/shared/logging/uuid.ts
+++ b/src/shared/logging/uuid.ts
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 const UUID_KEY = 'UUID_KEY';
 let currentUUID = '';
 
-const getRandomString = (size: number) => {
+export const getRandomString = (size: number) => {
   const chars = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'];
 
   return [...Array(size)].map(_ => chars[(Math.random() * chars.length) | 0]).join('');

--- a/src/shared/logging/uuid.ts
+++ b/src/shared/logging/uuid.ts
@@ -3,7 +3,7 @@ import AsyncStorage from '@react-native-community/async-storage';
 const UUID_KEY = 'UUID_KEY';
 let currentUUID = '';
 
-export const getRandomString = (size: number) => {
+const getRandomString = (size: number) => {
   const chars = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'];
 
   return [...Array(size)].map(_ => chars[(Math.random() * chars.length) | 0]).join('');

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -1,11 +1,4 @@
-import {
-  CheckInData,
-  doTimeWindowsOverlap,
-  getNewOutbreakStatus,
-  OutbreakHistoryItem,
-  OutbreakStatusType,
-  TimeWindow,
-} from './qr';
+import {CheckInData, doTimeWindowsOverlap, getNewOutbreakStatus, OutbreakStatusType, TimeWindow} from './qr';
 
 describe('doTimeWindowsOverlap', () => {
   const dateStr = '2021-01-05';

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -1,4 +1,4 @@
-import {CheckInData, doTimeWindowsOverlap, getNewOutbreakHistory, isExposedToOutbreak, TimeWindow} from './qr';
+import {CheckInData, doTimeWindowsOverlap, getNewOutbreakHistoryItems, isExposedToOutbreak, TimeWindow} from './qr';
 
 describe('doTimeWindowsOverlap', () => {
   const dateStr = '2021-01-05';
@@ -27,7 +27,7 @@ describe('doTimeWindowsOverlap', () => {
   });
 });
 
-describe('getNewOutbreakHistory', () => {
+describe('getNewOutbreakHistoryItems', () => {
   const t1100 = new Date('2021-02-01T11:00Z').getTime();
   const t1200 = new Date('2021-02-01T12:00Z').getTime();
   const t1300 = new Date('2021-02-01T13:00Z').getTime();
@@ -41,7 +41,7 @@ describe('getNewOutbreakHistory', () => {
       {id: '1', timestamp: t1200, address: '', name: ''},
       {id: '3', timestamp: t1200, address: '', name: ''},
     ];
-    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    const newHistory = getNewOutbreakHistoryItems(checkInHistory, outbreakEvents);
     expect(isExposedToOutbreak(newHistory)).toStrictEqual(true);
   });
   it('returns monitoring if there is no match', () => {
@@ -49,7 +49,7 @@ describe('getNewOutbreakHistory', () => {
       {id: '3', timestamp: t1200, address: '', name: ''},
       {id: '4', timestamp: t1200, address: '', name: ''},
     ];
-    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    const newHistory = getNewOutbreakHistoryItems(checkInHistory, outbreakEvents);
     expect(isExposedToOutbreak(newHistory)).toStrictEqual(false);
   });
   it('returns monitoring if id matches but time does not', () => {
@@ -57,7 +57,7 @@ describe('getNewOutbreakHistory', () => {
       {id: '1', timestamp: t1400, address: '', name: ''},
       {id: '2', timestamp: t1400, address: '', name: ''},
     ];
-    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    const newHistory = getNewOutbreakHistoryItems(checkInHistory, outbreakEvents);
     expect(isExposedToOutbreak(newHistory)).toStrictEqual(false);
   });
 });

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -1,4 +1,11 @@
-import {CheckInData, doTimeWindowsOverlap, getNewOutbreakStatus, OutbreakStatusType, TimeWindow} from './qr';
+import {
+  CheckInData,
+  doTimeWindowsOverlap,
+  getNewOutbreakStatus,
+  OutbreakHistoryItem,
+  OutbreakStatusType,
+  TimeWindow,
+} from './qr';
 
 describe('doTimeWindowsOverlap', () => {
   const dateStr = '2021-01-05';
@@ -59,5 +66,25 @@ describe('getNewOutbreakStatus', () => {
     ];
     const newStatus = getNewOutbreakStatus(checkInHistory, outbreakEvents);
     expect(newStatus.type).toStrictEqual(OutbreakStatusType.Monitoring);
+  });
+});
+
+describe('outbreakHistory functions', () => {
+  describe('expireHistoryItems', () => {
+    it('expires items older than 14 days', () => {
+      expect(true).toStrictEqual(true);
+    });
+    it('does not expire items newer than 14 days', () => {
+      expect(true).toStrictEqual(true);
+    });
+  });
+
+  describe('ignoreHistoryItems', () => {
+    it('ignores items with ids that are passed in', () => {
+      expect(true).toStrictEqual(true);
+    });
+    it('does not ignore items with ids not passed in', () => {
+      expect(true).toStrictEqual(true);
+    });
   });
 });

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -1,4 +1,4 @@
-import {CheckInData, doTimeWindowsOverlap, getNewOutbreakStatus, OutbreakStatusType, TimeWindow} from './qr';
+import {CheckInData, doTimeWindowsOverlap, getNewOutbreakHistory, isExposedToOutbreak, TimeWindow} from './qr';
 
 describe('doTimeWindowsOverlap', () => {
   const dateStr = '2021-01-05';
@@ -27,7 +27,7 @@ describe('doTimeWindowsOverlap', () => {
   });
 });
 
-describe('getNewOutbreakStatus', () => {
+describe('getNewOutbreakHistory', () => {
   const t1100 = new Date('2021-02-01T11:00Z').getTime();
   const t1200 = new Date('2021-02-01T12:00Z').getTime();
   const t1300 = new Date('2021-02-01T13:00Z').getTime();
@@ -41,24 +41,24 @@ describe('getNewOutbreakStatus', () => {
       {id: '1', timestamp: t1200, address: '', name: ''},
       {id: '3', timestamp: t1200, address: '', name: ''},
     ];
-    const newStatus = getNewOutbreakStatus(checkInHistory, outbreakEvents);
-    expect(newStatus.type).toStrictEqual(OutbreakStatusType.Exposed);
+    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    expect(isExposedToOutbreak(newHistory)).toStrictEqual(true);
   });
   it('returns monitoring if there is no match', () => {
     const checkInHistory: CheckInData[] = [
       {id: '3', timestamp: t1200, address: '', name: ''},
       {id: '4', timestamp: t1200, address: '', name: ''},
     ];
-    const newStatus = getNewOutbreakStatus(checkInHistory, outbreakEvents);
-    expect(newStatus.type).toStrictEqual(OutbreakStatusType.Monitoring);
+    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    expect(isExposedToOutbreak(newHistory)).toStrictEqual(false);
   });
   it('returns monitoring if id matches but time does not', () => {
     const checkInHistory: CheckInData[] = [
       {id: '1', timestamp: t1400, address: '', name: ''},
       {id: '2', timestamp: t1400, address: '', name: ''},
     ];
-    const newStatus = getNewOutbreakStatus(checkInHistory, outbreakEvents);
-    expect(newStatus.type).toStrictEqual(OutbreakStatusType.Monitoring);
+    const newHistory = getNewOutbreakHistory(checkInHistory, outbreakEvents);
+    expect(isExposedToOutbreak(newHistory)).toStrictEqual(false);
   });
 });
 

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -36,7 +36,7 @@ interface MatchData {
   mostRecentCheckOut?: number;
 }
 
-interface OutbreakHistoryItem {
+export interface OutbreakHistoryItem {
   outbreakId: string /* unique to your checkin during the outbreak event */;
   isExpired: boolean /* after 14 days the outbreak expires */;
   isIgnored: boolean /* if user has a negative test result */;
@@ -64,7 +64,7 @@ export const expireHistoryItems = (outbreakHistory: OutbreakHistoryItem[]): Outb
 };
 
 /** returns a new outbreakHistory with the `isIgnored` property updated */
-export const updateIsIgnored = (
+export const ignoreHistoryItems = (
   outbreakIds: string[],
   outbreakHistory: OutbreakHistoryItem[],
 ): OutbreakHistoryItem[] => {

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -13,16 +13,6 @@ export interface CheckInData {
   timestamp: number;
 }
 
-export enum OutbreakStatusType {
-  Monitoring = 'monitoring',
-  Exposed = 'exposed',
-}
-
-export interface OutbreakStatus {
-  type: OutbreakStatusType;
-  lastChecked: number;
-}
-
 export interface TimeWindow {
   start: number;
   end: number;
@@ -96,8 +86,6 @@ export const isExposedToOutbreak = (outbreakHistory: OutbreakHistoryItem[]) => {
 
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
 
-export const initialOutbreakStatus = {type: OutbreakStatusType.Monitoring, lastChecked: 0};
-
 export const getOutbreakEvents = async (): Promise<covidshield.OutbreakEvent[]> => {
   const fetchedData = await fetch(OUTBREAK_LOCATIONS_URL, {
     method: 'GET',
@@ -131,14 +119,6 @@ export const getNewOutbreakHistoryItems = (
   log.debug({message: 'outbreak matches', payload: {matches}});
 
   return matches.map(match => createOutbreakHistoryItem(match));
-};
-
-export const createOutbreakStatus = ({exposed}: {exposed: boolean}) => {
-  const newOutbreakStatus: OutbreakStatus = {
-    type: exposed ? OutbreakStatusType.Exposed : OutbreakStatusType.Monitoring,
-    lastChecked: getCurrentDate().getTime(),
-  };
-  return newOutbreakStatus;
 };
 
 export const doTimeWindowsOverlap = (window1: TimeWindow, window2: TimeWindow) => {

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -1,10 +1,11 @@
 import {OUTBREAK_LOCATIONS_URL} from 'env';
 import {log} from 'shared/logging/config';
 import {covidshield} from 'services/BackendService/covidshield';
-import {EXPOSURE_NOTIFICATION_CYCLE} from 'services/ExposureNotificationService';
 
 import {getCurrentDate, getHoursBetween} from './date-fns';
 import {getRandomString} from './logging/uuid';
+
+export const OUTBREAK_EXPOSURE_DURATION_DAYS = 14;
 
 export interface CheckInData {
   id: string;
@@ -64,7 +65,7 @@ export const expireHistoryItems = (outbreakHistory: OutbreakHistoryItem[]): Outb
       return {...historyItem};
     }
     const hoursSinceCheckIn = getHoursBetween(new Date(historyItem.checkInTimestamp), getCurrentDate());
-    if (hoursSinceCheckIn > 24 * EXPOSURE_NOTIFICATION_CYCLE) {
+    if (hoursSinceCheckIn > 24 * OUTBREAK_EXPOSURE_DURATION_DAYS) {
       return {...historyItem, isExpired: true};
     }
     return {...historyItem};

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -33,10 +33,6 @@ interface MatchCalculationData {
   id: string;
   outbreakEvents: covidshield.OutbreakEvent[];
   checkInData: CheckInData[];
-  matchCount?: number;
-  matchedCheckIns?: CheckInData[];
-  matchedOutbreakEvents?: covidshield.OutbreakEvent[];
-  mostRecentCheckOut?: number;
 }
 
 interface MatchData {
@@ -111,7 +107,7 @@ export const getOutbreakEvents = async (): Promise<covidshield.OutbreakEvent[]> 
   return data.exposedLocations;
 };
 
-export const getNewOutbreakHistory = (
+export const getNewOutbreakHistoryItems = (
   checkInHistory: CheckInData[],
   outbreakEvents: covidshield.OutbreakEvent[],
 ): OutbreakHistoryItem[] => {

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -84,7 +84,7 @@ export const ignoreHistoryItems = (
   });
 };
 
-export const isExposed = (outbreakHistory: OutbreakHistoryItem[]) => {
+export const isExposedToOutbreak = (outbreakHistory: OutbreakHistoryItem[]) => {
   const currentOutbreakHistory = outbreakHistory.filter(outbreak => {
     if (outbreak.isExpired || outbreak.isIgnored) {
       return false;

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -19,14 +19,14 @@ export interface TimeWindow {
 }
 
 interface MatchCalculationData {
-  id: string;
+  locationId: string;
   outbreakEvents: covidshield.OutbreakEvent[];
-  checkInData: CheckInData[];
+  checkIns: CheckInData[];
 }
 
 interface MatchData {
   timestamp: number;
-  checkInData: CheckInData;
+  checkIn: CheckInData;
   outbreakEvent: covidshield.OutbreakEvent;
 }
 
@@ -151,9 +151,9 @@ export const getMatches = ({
 
   const _matchData = matchedOutbreakIds.map(id => {
     return {
-      id,
+      locationId: id,
       outbreakEvents: relevantOutbreakData.filter(data => data.locationId === id),
-      checkInData: relevantCheckInData.filter(data => data.id === id),
+      checkIns: relevantCheckInData.filter(data => data.id === id),
     };
   });
 
@@ -165,7 +165,7 @@ const flattened = (arr: any[]) => [].concat(...arr);
 
 const processMatchData = (matchCalucationData: MatchCalculationData) => {
   const matches: MatchData[] = [];
-  for (const checkIn of matchCalucationData.checkInData) {
+  for (const checkIn of matchCalucationData.checkIns) {
     for (const outbreak of matchCalucationData.outbreakEvents) {
       if (!outbreak.startTime || !outbreak.endTime) {
         continue;
@@ -181,7 +181,7 @@ const processMatchData = (matchCalucationData: MatchCalculationData) => {
       if (doTimeWindowsOverlap(window1, window2)) {
         const match: MatchData = {
           timestamp: checkIn.timestamp,
-          checkInData: checkIn,
+          checkIn,
           outbreakEvent: outbreak,
         };
         matches.push(match);
@@ -192,15 +192,15 @@ const processMatchData = (matchCalucationData: MatchCalculationData) => {
 };
 
 export const createOutbreakHistoryItem = (matchData: MatchData): OutbreakHistoryItem => {
-  const locationId = matchData.checkInData.id;
-  const checkInTimestamp = matchData.checkInData.timestamp;
+  const locationId = matchData.checkIn.id;
+  const checkInTimestamp = matchData.checkIn.timestamp;
   const newItem: OutbreakHistoryItem = {
     outbreakId: `${locationId}-${checkInTimestamp}`,
     isExpired: false,
     isIgnored: false,
     locationId,
-    locationAddress: matchData.checkInData.address,
-    locationName: matchData.checkInData.name,
+    locationAddress: matchData.checkIn.address,
+    locationName: matchData.checkIn.name,
     outbreakStartTimestamp: Number(matchData.outbreakEvent.startTime),
     outbreakEndTimestamp: Number(matchData.outbreakEvent.endTime),
     checkInTimestamp,

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -1,9 +1,9 @@
 import {OUTBREAK_LOCATIONS_URL} from 'env';
 import {log} from 'shared/logging/config';
 import {covidshield} from 'services/BackendService/covidshield';
+import {EXPOSURE_NOTIFICATION_CYCLE} from 'services/ExposureNotificationService';
 
-import {getCurrentDate, hoursFromNow} from './date-fns';
-import { EXPOSURE_NOTIFICATION_CYCLE } from 'services/ExposureNotificationService';
+import {getCurrentDate, getHoursBetween} from './date-fns';
 
 export interface CheckInData {
   id: string;
@@ -55,7 +55,7 @@ export const expireHistoryItems = (outbreakHistory: OutbreakHistoryItem[]): Outb
     if (historyItem.isExpired) {
       return {...historyItem};
     }
-    const hoursSinceCheckIn = -1 * hoursFromNow(new Date(historyItem.checkInTimestamp));
+    const hoursSinceCheckIn = getHoursBetween(new Date(historyItem.checkInTimestamp), getCurrentDate());
     if (hoursSinceCheckIn > 24 * EXPOSURE_NOTIFICATION_CYCLE) {
       return {...historyItem, isExpired: true};
     }


### PR DESCRIPTION
# Summary | Résumé

Introducing the `OutbreakHistory` concept, replacing the `outbreakStatus`. Stubbed in tests.