### PR TITLE
Homescreen z-index test

### DIFF
--- a/src/components/RoundedBox.tsx
+++ b/src/components/RoundedBox.tsx
@@ -13,7 +13,6 @@ export const RoundedBox = ({children, isFirstBox}: RoundedBoxProp) => {
       style={isFirstBox ? [styles.roundedBox, styles.firstBox] : styles.roundedBox}
       marginBottom="m"
       alignSelf="stretch"
-      paddingTop="l"
     >
       <Box paddingHorizontal="m" paddingVertical="m">
         {children}
@@ -29,6 +28,7 @@ const styles = StyleSheet.create({
   },
   firstBox: {
     marginTop: -32,
+    paddingTop: 32,
     zIndex: -1,
   },
 });

--- a/src/components/RoundedBox.tsx
+++ b/src/components/RoundedBox.tsx
@@ -1,6 +1,6 @@
 import {Box} from 'components';
 import React from 'react';
-import {StyleSheet, Platform} from 'react-native';
+import {StyleSheet} from 'react-native';
 
 interface RoundedBoxProp {
   children: React.ReactNode;

--- a/src/components/RoundedBox.tsx
+++ b/src/components/RoundedBox.tsx
@@ -13,7 +13,7 @@ export const RoundedBox = ({children, isFirstBox}: RoundedBoxProp) => {
       style={isFirstBox ? [styles.roundedBox, styles.firstBox] : styles.roundedBox}
       marginBottom="m"
       alignSelf="stretch"
-      paddingTop="xl"
+      paddingTop="l"
     >
       <Box paddingHorizontal="m" paddingVertical="m">
         {children}

--- a/src/components/RoundedBox.tsx
+++ b/src/components/RoundedBox.tsx
@@ -12,8 +12,8 @@ export const RoundedBox = ({children, isFirstBox}: RoundedBoxProp) => {
     <Box
       style={isFirstBox ? [styles.roundedBox, styles.firstBox] : styles.roundedBox}
       marginBottom="m"
-      marginTop="m"
       alignSelf="stretch"
+      paddingTop="xl"
     >
       <Box paddingHorizontal="m" paddingVertical="m">
         {children}
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
   },
   firstBox: {
-    marginTop: Platform.OS === 'ios' ? 5 : 20,
+    marginTop: -32,
     zIndex: -1,
   },
 });

--- a/src/screens/home/components/BaseHomeView.tsx
+++ b/src/screens/home/components/BaseHomeView.tsx
@@ -44,7 +44,7 @@ export const BaseHomeView = ({children, iconName, testID}: BaseHomeViewProps) =>
 };
 
 const styles = StyleSheet.create({
-  primaryIcon: {marginLeft: -35, marginBottom: 24},
+  primaryIcon: {marginLeft: -35, marginBottom: 32},
   scrollContainerWithAnimation: {
     marginTop: -100,
   },

--- a/src/screens/home/components/BaseHomeView.tsx
+++ b/src/screens/home/components/BaseHomeView.tsx
@@ -22,7 +22,7 @@ export const BaseHomeView = ({children, iconName, testID}: BaseHomeViewProps) =>
         contentContainerStyle={styles.scrollContainer}
       >
         <SafeAreaView edges={['left', 'right']}>
-          <Box width="100%" justifyContent="flex-start" marginBottom="-l">
+          <Box style={styles.zindex} width="100%" justifyContent="flex-start" marginBottom="-l">
             <Box style={{...styles.primaryIcon}}>
               <Icon name={iconName} height={120} width={150} />
             </Box>
@@ -44,7 +44,7 @@ export const BaseHomeView = ({children, iconName, testID}: BaseHomeViewProps) =>
 };
 
 const styles = StyleSheet.create({
-  primaryIcon: {marginLeft: -40, marginBottom: 30},
+  primaryIcon: {marginLeft: -35, marginBottom: 24},
   scrollContainerWithAnimation: {
     marginTop: -100,
   },
@@ -54,5 +54,8 @@ const styles = StyleSheet.create({
   scrollContainer: {
     maxWidth: 600,
     alignItems: 'flex-start',
+  },
+  zindex: {
+    zIndex: 1,
   },
 });

--- a/src/screens/home/views/NoExposureCoveredRegionView.tsx
+++ b/src/screens/home/views/NoExposureCoveredRegionView.tsx
@@ -4,7 +4,6 @@ import {useI18n} from 'locale';
 import {useStorage} from 'services/StorageService';
 import {hoursFromNow} from 'shared/date-fns';
 import {useAccessibilityAutoFocus} from 'shared/useAccessibilityAutoFocus';
-import {Platform} from 'react-native';
 
 import {AllSetView} from '../components/AllSetView';
 import {BaseHomeView} from '../components/BaseHomeView';
@@ -54,13 +53,9 @@ export const NoExposureCoveredRegionView = ({isBottomSheetExpanded}: {isBottomSh
   return (
     // note you can add an icon i.e. <BaseHomeView iconName="icon-offline>
     <BaseHomeView iconName="thumbs-up">
-      {Platform.OS === 'ios' ? (
+      <RoundedBox isFirstBox>
         <TextContent isBottomSheetExpanded={isBottomSheetExpanded} />
-      ) : (
-        <RoundedBox isFirstBox>
-          <TextContent isBottomSheetExpanded={isBottomSheetExpanded} />
-        </RoundedBox>
-      )}
+      </RoundedBox>
     </BaseHomeView>
   );
 };


### PR DESCRIPTION
# Summary | Résumé

Just a test using z-index to pull the shape on top of the first card. The negative margin is set on the rounded box, only if its the first one. Nothing else is added to the symbol, only a z-index to pull it to the foreground.

# Test instructions | Instructions pour tester la modification

Force different screens to test all layouts. 

# Help requested | Aide requise

This needs to be tested on android.

Other home screens without cards have been tested. This should not break them. 

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

Initially we were working on new designs to avoid having to overlap shapes. So we now have two options to decide from!

