### PR TITLE
Metrics adjustments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {BackendService} from 'services/BackendService';
 import {BackgroundScheduler} from 'services/BackgroundSchedulerService';
 import {ExposureNotificationService} from 'services/ExposureNotificationService';
 import {createBackgroundI18n} from 'locale';
+import {FilteredMetricsService} from 'services/MetricsService/FilteredMetricsService';
 
 import {name as appName} from '../app.json';
 
@@ -31,6 +32,7 @@ if (Platform.OS === 'android') {
       AsyncStorage,
       RNSecureKeyStore,
       ExposureNotification,
+      FilteredMetricsService.sharedInstance(),
     );
     await exposureNotificationService.updateExposureStatusInBackground();
   });
@@ -45,6 +47,7 @@ if (Platform.OS === 'android') {
       AsyncStorage,
       RNSecureKeyStore,
       ExposureNotification,
+      FilteredMetricsService.sharedInstance(),
     );
     if (await exposureNotificationService.shouldPerformExposureCheck()) {
       await exposureNotificationService.initiateExposureCheckHeadless();

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState, useEffect} from 'react';
+import React, {useCallback} from 'react';
 import {Linking} from 'react-native';
 import {BottomSheetBehavior, Box, Text} from 'components';
 import {useNavigation} from '@react-navigation/native';
@@ -7,7 +7,6 @@ import {captureException} from 'shared/log';
 import {useStorage} from 'services/StorageService';
 import {getExposedHelpMenuURL} from 'shared/RegionLogic';
 import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
-import {getLogUUID} from 'shared/logging/uuid';
 
 import {OnOffButton} from '../components/OnOffButton';
 import {InfoShareItem} from '../components/InfoShareItem';
@@ -17,14 +16,6 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
   const {region} = useStorage();
   const regionalI18n = useRegionalI18n();
   const navigation = useNavigation();
-
-  const [UUID, setUUID] = useState('');
-
-  useEffect(() => {
-    (async () => {
-      setUUID(await getLogUUID());
-    })();
-  }, []);
 
   const onPrivacy = useCallback(() => {
     Linking.openURL(i18n.translate('Info.PrivacyUrl')).catch(error => captureException('An error occurred', error));
@@ -111,9 +102,7 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
         />
       </Box>
       <Box paddingBottom="l">
-        <Text variant="smallText">
-          {versionNumber} - {UUID}
-        </Text>
+        <Text variant="smallText">{versionNumber}</Text>
       </Box>
     </>
   );

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState, useEffect} from 'react';
 import {Linking} from 'react-native';
 import {BottomSheetBehavior, Box, Text} from 'components';
 import {useNavigation} from '@react-navigation/native';
@@ -17,6 +17,14 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
   const {region} = useStorage();
   const regionalI18n = useRegionalI18n();
   const navigation = useNavigation();
+
+  const [UUID, setUUID] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      setUUID(await getLogUUID());
+    })();
+  }, []);
 
   const onPrivacy = useCallback(() => {
     Linking.openURL(i18n.translate('Info.PrivacyUrl')).catch(error => captureException('An error occurred', error));
@@ -104,7 +112,7 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
       </Box>
       <Box paddingBottom="l">
         <Text variant="smallText">
-          {versionNumber} {getLogUUID()}
+          {versionNumber} - {UUID}
         </Text>
       </Box>
     </>

--- a/src/screens/home/views/InfoShareView.tsx
+++ b/src/screens/home/views/InfoShareView.tsx
@@ -7,6 +7,7 @@ import {captureException} from 'shared/log';
 import {useStorage} from 'services/StorageService';
 import {getExposedHelpMenuURL} from 'shared/RegionLogic';
 import {APP_VERSION_NAME, APP_VERSION_CODE} from 'env';
+import {getLogUUID} from 'shared/logging/uuid';
 
 import {OnOffButton} from '../components/OnOffButton';
 import {InfoShareItem} from '../components/InfoShareItem';
@@ -102,7 +103,9 @@ export const InfoShareView = ({bottomSheetBehavior}: {bottomSheetBehavior: Botto
         />
       </Box>
       <Box paddingBottom="l">
-        <Text variant="smallText">{versionNumber}</Text>
+        <Text variant="smallText">
+          {versionNumber} {getLogUUID()}
+        </Text>
       </Box>
     </>
   );

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -19,6 +19,8 @@ import {getLogUUID, setLogUUID} from 'shared/logging/uuid';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useOutbreakService} from 'shared/OutbreakProvider';
 import {PollNotifications} from 'services/PollNotificationService';
+import {FilteredMetricsService} from 'services/MetricsService/FilteredMetricsService';
+import {log} from 'shared/logging/config';
 
 import {RadioButton} from './components/RadioButtons';
 import {MockProvider} from './MockProvider';
@@ -131,6 +133,15 @@ const Content = () => {
     await PollNotifications.checkForNotifications(i18n);
   }, [i18n]);
 
+  const onDebugMetrics = useCallback(async () => {
+    const payload = await FilteredMetricsService.sharedInstance().retrieveAllMetricsInStorage();
+    log.debug({
+      category: 'metrics',
+      message: 'backgoundTaskDuration',
+      payload,
+    });
+  }, []);
+
   const exposureNotificationService = useExposureNotificationService();
   const updateExposureStatus = useUpdateExposureStatus();
 
@@ -160,6 +171,10 @@ const Content = () => {
         >
           Demo menu
         </Text>
+      </Section>
+
+      <Section>
+        <Button text="Debug Metrics" onPress={onDebugMetrics} variant="bigFlat" />
       </Section>
       <Section>
         <Button

--- a/src/screens/testScreen/TestScreen.tsx
+++ b/src/screens/testScreen/TestScreen.tsx
@@ -137,7 +137,7 @@ const Content = () => {
     const payload = await FilteredMetricsService.sharedInstance().retrieveAllMetricsInStorage();
     log.debug({
       category: 'metrics',
-      message: 'backgoundTaskDuration',
+      message: 'debug metrics',
       payload,
     });
   }, []);

--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -3,6 +3,7 @@ import {AppRegistry, Platform} from 'react-native';
 import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL, TEST_MODE} from 'env';
 import AsyncStorage from '@react-native-community/async-storage';
 import RNSecureKeyStore from 'react-native-secure-key-store';
+import {FilteredMetricsService} from 'services/MetricsService/FilteredMetricsService';
 
 import ExposureCheckScheduler from '../../bridge/ExposureCheckScheduler';
 import {PeriodicWorkPayload} from '../../bridge/PushNotification';
@@ -130,6 +131,7 @@ const registerAndroidHeadlessPeriodicTask = (task: PeriodicTask) => {
         AsyncStorage,
         RNSecureKeyStore,
         ExposureNotification,
+        FilteredMetricsService.sharedInstance(),
       );
       registerPeriodicTask(async () => {
         await exposureNotificationService.updateExposureStatusInBackground();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -7,6 +7,8 @@ import {ExposureSummary} from '../../bridge/ExposureNotification';
 import PushNotification from '../../bridge/PushNotification';
 import {Key} from '../StorageService';
 import {PERIODIC_TASK_INTERVAL_IN_MINUTES} from '../BackgroundSchedulerService';
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {FilteredMetricsService} from '../MetricsService/FilteredMetricsService';
 
 import {
   ExposureNotificationService,
@@ -18,7 +20,7 @@ import {
 } from './ExposureNotificationService';
 
 jest.mock('react-native-permissions', () => {
-  return {checkNotifications: jest.fn(), requestNotifications: jest.fn()};
+  return {checkNotifications: jest.fn().mockReturnValue(Promise.reject()), requestNotifications: jest.fn()};
 });
 
 const ONE_DAY = 3600 * 24 * 1000;
@@ -80,6 +82,11 @@ const bridge: any = {
   getTemporaryExposureKeyHistory: jest.fn().mockResolvedValue({}),
   getStatus: jest.fn().mockResolvedValue('active'),
   getPendingExposureSummary: jest.fn().mockResolvedValue(undefined),
+};
+
+const filteredMetricsService: FilteredMetricsService = {
+  addEvent: jest.fn().mockReturnValue(Promise.resolve()),
+  sendDailyMetrics: jest.fn().mockReturnValue(Promise.resolve()),
 };
 
 const getSummary = ({
@@ -167,7 +174,7 @@ describe('ExposureNotificationService', () => {
   };
 
   beforeEach(() => {
-    service = new ExposureNotificationService(server, i18n, storage, secureStorage, bridge);
+    service = new ExposureNotificationService(server, i18n, storage, secureStorage, bridge, filteredMetricsService);
     Platform.OS = 'ios';
     service.systemStatus.set(SystemStatus.Active);
     when(storage.getItem)

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -305,7 +305,6 @@ export class ExposureNotificationService {
     }
 
     await this.filteredMetricsService.addEvent({type: EventTypeMetric.BackgroundCheck});
-    await this.filteredMetricsService.addEvent({type: EventTypeMetric.PushToServerFromBackground});
 
     const notificationStatus: Status = await checkNotifications()
       .then(({status}) => status)

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -275,10 +275,7 @@ export class ExposureNotificationService {
     await this.filteredMetricsService.addEvent({type: EventTypeMetric.ActiveUser});
 
     // @todo: maybe remove this gets called in updateExposureStatus
-    if (!(await this.shouldPerformExposureCheck())) {
-      logBackgroundTaskDuration('failure#1', getCurrentDate());
-      return;
-    }
+    if (!(await this.shouldPerformExposureCheck())) return;
 
     try {
       await this.loadExposureStatus();
@@ -301,7 +298,7 @@ export class ExposureNotificationService {
 
       logBackgroundTaskDuration('success', getCurrentDate());
     } catch (error) {
-      logBackgroundTaskDuration('failure#2', getCurrentDate());
+      logBackgroundTaskDuration('failure', getCurrentDate());
       log.error({category: 'exposure-check', message: 'updateExposureStatusInBackground', error});
     }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -272,6 +272,8 @@ export class ExposureNotificationService {
       });
     };
 
+    await this.filteredMetricsService.addEvent({type: EventTypeMetric.ActiveUser});
+
     // @todo: maybe remove this gets called in updateExposureStatus
     if (!(await this.shouldPerformExposureCheck())) {
       logBackgroundTaskDuration('failure#1', getCurrentDate());
@@ -284,8 +286,6 @@ export class ExposureNotificationService {
       await this.updateExposureStatus();
       await this.processNotification();
 
-      await this.filteredMetricsService.addEvent({type: EventTypeMetric.ActiveUser});
-
       if (QR_ENABLED) {
         OutbreakService.sharedInstance(this.i18n).checkForOutbreaks();
       }
@@ -296,6 +296,7 @@ export class ExposureNotificationService {
         message: 'updatedExposureStatusInBackground',
         payload: {exposureStatus},
       });
+
       PollNotifications.checkForNotifications(this.i18n);
 
       logBackgroundTaskDuration('success', getCurrentDate());
@@ -303,8 +304,6 @@ export class ExposureNotificationService {
       logBackgroundTaskDuration('failure#2', getCurrentDate());
       log.error({category: 'exposure-check', message: 'updateExposureStatusInBackground', error});
     }
-
-    await this.filteredMetricsService.addEvent({type: EventTypeMetric.BackgroundCheck});
 
     const notificationStatus: Status = await checkNotifications()
       .then(({status}) => status)
@@ -637,6 +636,9 @@ export class ExposureNotificationService {
       } else {
         exposureWindows = await this.exposureNotification.getExposureWindowsIos(exposureConfiguration, keysFileUrls);
       }
+
+      await this.filteredMetricsService.addEvent({type: EventTypeMetric.BackgroundCheck});
+
       log.debug({
         category: 'exposure-check',
         message: 'performExposureStatusUpdateV2',
@@ -805,6 +807,9 @@ export class ExposureNotificationService {
 
     try {
       const summaries = await this.exposureNotification.detectExposure(exposureConfiguration, keysFileUrls);
+
+      await this.filteredMetricsService.addEvent({type: EventTypeMetric.BackgroundCheck});
+
       log.debug({
         category: 'exposure-check',
         message: 'detectExposure',

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -51,6 +51,7 @@ export const ExposureNotificationServiceProvider = ({
         storage || AsyncStorage,
         secureStorage || RNSecureKeyStore,
         exposureNotification || ExposureNotification,
+        FilteredMetricsService.sharedInstance(),
       ),
     [backendInterface, exposureNotification, i18n, secureStorage, storage],
   );

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -73,8 +73,6 @@ export const ExposureNotificationServiceProvider = ({
       exposureNotificationService.updateExposure();
       await exposureNotificationService.updateExposureStatus();
 
-      await filteredMetricsService.addEvent({type: EventTypeMetric.PushToServerFromForeground});
-
       const notificationStatus: Status = await checkNotifications()
         .then(({status}) => status)
         .catch(() => 'unavailable');
@@ -93,20 +91,14 @@ export const ExposureNotificationServiceProvider = ({
     exposureNotificationService.updateExposure();
     exposureNotificationService.updateExposureStatus();
 
-    filteredMetricsService
-      .addEvent({type: EventTypeMetric.PushToServerFromForeground})
-      .then(() => {
-        // eslint-disable-next-line promise/no-nesting
-        checkNotifications()
-          .then(({status}) => status)
-          .catch(() => 'unavailable')
-          .then(notificationStatus => {
-            filteredMetricsService.sendDailyMetrics(
-              exposureNotificationService.systemStatus.get(),
-              notificationStatus as Status,
-            );
-          })
-          .catch(() => {});
+    checkNotifications()
+      .then(({status}) => status)
+      .catch(() => 'unavailable')
+      .then(notificationStatus => {
+        filteredMetricsService.sendDailyMetrics(
+          exposureNotificationService.systemStatus.get(),
+          notificationStatus as Status,
+        );
       })
       .catch(() => {});
 

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -72,10 +72,6 @@ export class FilteredMetricsService {
 
   static sharedInstance(): FilteredMetricsService {
     if (!this.instance) {
-      log.debug({
-        category: 'metrics',
-        message: 'FilteredMetricsService shared instance initialized',
-      });
       this.instance = new this();
     }
     return this.instance;

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -147,6 +147,12 @@ export class FilteredMetricsService {
     });
   }
 
+  retrieveAllMetricsInStorage(): Promise<Metric[]> {
+    return this.serialPromiseQueue.add(() => {
+      return this.metricsService.retrieveAllMetricsInStorage();
+    });
+  }
+
   private publishInstalledEventIfNecessary(): Promise<void> {
     const publishAndMark = (): Promise<void> => {
       return this.publishEvent(EventTypeMetric.Installed, [], true).then(() =>

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -80,7 +80,7 @@ export class FilteredMetricsService {
 
   private constructor() {
     this.metricsService = DefaultMetricsService.initialize(
-      new DefaultMetricsJsonSerializer(String(APP_VERSION_CODE), Platform.OS),
+      new DefaultMetricsJsonSerializer(String(APP_VERSION_CODE), Platform.OS, String(Platform.Version)),
     );
     this.stateStorage = new DefaultFilteredMetricsStateStorage(new DefaultSecureKeyValueStore());
     this.serialPromiseQueue = new PQueue({concurrency: 1});

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -59,12 +59,6 @@ export type EventWithContext =
     }
   | {
       type: EventTypeMetric.ActiveUser;
-    }
-  | {
-      type: EventTypeMetric.PushToServerFromForeground;
-    }
-  | {
-      type: EventTypeMetric.PushToServerFromBackground;
     };
 
 export class FilteredMetricsService {
@@ -122,10 +116,6 @@ export class FilteredMetricsService {
           return this.publishBackgroundCheckEventIfNecessary();
         case EventTypeMetric.ActiveUser:
           return this.publishActiveUserEventIfNecessary();
-        case EventTypeMetric.PushToServerFromForeground:
-          return this.publishEvent(EventTypeMetric.PushToServerFromForeground, []);
-        case EventTypeMetric.PushToServerFromBackground:
-          return this.publishEvent(EventTypeMetric.PushToServerFromBackground, []);
         default:
           break;
       }

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -24,6 +24,8 @@ export enum EventTypeMetric {
   ExposedClear = 'exposed-clear',
   BackgroundCheck = 'background-check',
   ActiveUser = 'active-user',
+  PushToServerFromForeground = 'foreground-push',
+  PushToServerFromBackground = 'background-push',
 }
 
 export type EventWithContext =
@@ -57,6 +59,12 @@ export type EventWithContext =
     }
   | {
       type: EventTypeMetric.ActiveUser;
+    }
+  | {
+      type: EventTypeMetric.PushToServerFromForeground;
+    }
+  | {
+      type: EventTypeMetric.PushToServerFromBackground;
     };
 
 export class FilteredMetricsService {
@@ -118,6 +126,10 @@ export class FilteredMetricsService {
           return this.publishBackgroundCheckEventIfNecessary();
         case EventTypeMetric.ActiveUser:
           return this.publishActiveUserEventIfNecessary();
+        case EventTypeMetric.PushToServerFromForeground:
+          return this.publishEvent(EventTypeMetric.PushToServerFromForeground, []);
+        case EventTypeMetric.PushToServerFromBackground:
+          return this.publishEvent(EventTypeMetric.PushToServerFromBackground, []);
         default:
           break;
       }

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -6,7 +6,6 @@ import {Status} from 'screens/home/components/NotificationPermissionStatus';
 import {ExposureStatus, ExposureStatusType, SystemStatus} from 'services/ExposureNotificationService';
 import {Key} from 'services/StorageService';
 import {getHoursBetween, getCurrentDate, daysBetweenUTC, getUTCMidnight} from 'shared/date-fns';
-import {log} from 'shared/logging/config';
 
 import {DefaultFilteredMetricsStateStorage, FilteredMetricsStateStorage} from './FilteredMetricsStateStorage';
 import {Metric} from './Metric';

--- a/src/services/MetricsService/InactiveMetricsService.ts
+++ b/src/services/MetricsService/InactiveMetricsService.ts
@@ -13,4 +13,8 @@ export class InactiveMetricsService implements MetricsService {
   sendDailyMetrics(): Promise<void> {
     return Promise.resolve();
   }
+
+  retrieveAllMetricsInStorage(): Promise<Metric[]> {
+    return Promise.resolve([]);
+  }
 }

--- a/src/services/MetricsService/MetricsJsonSerializer.ts
+++ b/src/services/MetricsService/MetricsJsonSerializer.ts
@@ -1,9 +1,7 @@
-import {getLogUUID} from 'shared/logging/uuid';
-
 import {Metric} from './Metric';
 
 export interface MetricsJsonSerializer {
-  serializeToJson(timestamp: number, metrics: Metric[]): Promise<string>;
+  serializeToJson(timestamp: number, metrics: Metric[]): string;
 }
 
 export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
@@ -17,7 +15,7 @@ export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
     this.osVersion = osVersion;
   }
 
-  serializeToJson(timestamp: number, metrics: Metric[]): Promise<string> {
+  serializeToJson(timestamp: number, metrics: Metric[]): string {
     function serializeDynamicPayload(map: [string, string][]): any {
       return Array.from(map).reduce((acc, [key, value]) => {
         // @ts-ignore
@@ -25,21 +23,19 @@ export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
         return acc;
       }, {});
     }
-    return getLogUUID().then(uuid => {
-      const jsonStructure = {
-        metricstimestamp: timestamp,
-        appversion: this.appVersion,
-        appos: this.appOs,
-        osversion: this.osVersion,
-        deviceuuid: uuid,
-        payload: metrics.map(metric => {
-          return {
-            ...{identifier: metric.identifier, region: metric.region, timestamp: metric.timestamp},
-            ...serializeDynamicPayload(metric.payload),
-          };
-        }),
-      };
-      return JSON.stringify(jsonStructure);
-    });
+
+    const jsonStructure = {
+      metricstimestamp: timestamp,
+      appversion: this.appVersion,
+      appos: this.appOs,
+      osversion: this.osVersion,
+      payload: metrics.map(metric => {
+        return {
+          ...{identifier: metric.identifier, region: metric.region, timestamp: metric.timestamp},
+          ...serializeDynamicPayload(metric.payload),
+        };
+      }),
+    };
+    return JSON.stringify(jsonStructure);
   }
 }

--- a/src/services/MetricsService/MetricsJsonSerializer.ts
+++ b/src/services/MetricsService/MetricsJsonSerializer.ts
@@ -1,7 +1,9 @@
+import {getLogUUID} from 'shared/logging/uuid';
+
 import {Metric} from './Metric';
 
 export interface MetricsJsonSerializer {
-  serializeToJson(timestamp: number, metrics: Metric[]): string;
+  serializeToJson(timestamp: number, metrics: Metric[]): Promise<string>;
 }
 
 export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
@@ -15,7 +17,7 @@ export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
     this.osVersion = osVersion;
   }
 
-  serializeToJson(timestamp: number, metrics: Metric[]): string {
+  serializeToJson(timestamp: number, metrics: Metric[]): Promise<string> {
     function serializeDynamicPayload(map: [string, string][]): any {
       return Array.from(map).reduce((acc, [key, value]) => {
         // @ts-ignore
@@ -23,19 +25,21 @@ export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
         return acc;
       }, {});
     }
-
-    const jsonStructure = {
-      metricstimestamp: timestamp,
-      appversion: this.appVersion,
-      appos: this.appOs,
-      osversion: this.osVersion,
-      payload: metrics.map(metric => {
-        return {
-          ...{identifier: metric.identifier, region: metric.region, timestamp: metric.timestamp},
-          ...serializeDynamicPayload(metric.payload),
-        };
-      }),
-    };
-    return JSON.stringify(jsonStructure);
+    return getLogUUID().then(uuid => {
+      const jsonStructure = {
+        metricstimestamp: timestamp,
+        appversion: this.appVersion,
+        appos: this.appOs,
+        osversion: this.osVersion,
+        deviceuuid: uuid,
+        payload: metrics.map(metric => {
+          return {
+            ...{identifier: metric.identifier, region: metric.region, timestamp: metric.timestamp},
+            ...serializeDynamicPayload(metric.payload),
+          };
+        }),
+      };
+      return JSON.stringify(jsonStructure);
+    });
   }
 }

--- a/src/services/MetricsService/MetricsJsonSerializer.ts
+++ b/src/services/MetricsService/MetricsJsonSerializer.ts
@@ -7,10 +7,12 @@ export interface MetricsJsonSerializer {
 export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
   private appVersion: string;
   private appOs: string;
+  private osVersion: string;
 
-  constructor(appVersion: string, appOs: string) {
+  constructor(appVersion: string, appOs: string, osVersion: string) {
     this.appVersion = appVersion;
     this.appOs = appOs;
+    this.osVersion = osVersion;
   }
 
   serializeToJson(timestamp: number, metrics: Metric[]): string {
@@ -26,6 +28,7 @@ export class DefaultMetricsJsonSerializer implements MetricsJsonSerializer {
       metricstimestamp: timestamp,
       appversion: this.appVersion,
       appos: this.appOs,
+      osversion: this.osVersion,
       payload: metrics.map(metric => {
         return {
           ...{identifier: metric.identifier, region: metric.region, timestamp: metric.timestamp},

--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -61,7 +61,7 @@ export class DefaultMetricsService implements MetricsService {
 
   private serialPromiseQueue: PQueue;
 
-  private constructor(
+  constructor(
     secureKeyValueStore: SecureKeyValueStore,
     metricsPublisher: MetricsPublisher,
     metricsProvider: MetricsProvider,

--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -14,7 +14,12 @@ import {InactiveMetricsService} from './InactiveMetricsService';
 
 const LastMetricTimestampSentToTheServerUniqueIdentifier = '3FFE2346-1910-4FD7-A23F-52D83CFF083A';
 const MetricsLastUploadedDateTime = 'C0663511-3718-4D85-B165-A38155DED2F3';
-export interface MetricsService {
+
+export interface MetricsServiceDebug {
+  retrieveAllMetricsInStorage(): Promise<Metric[]>;
+}
+
+export interface MetricsService extends MetricsServiceDebug {
   publishMetric(metric: Metric, forcePush?: boolean): Promise<void>;
   publishMetrics(metrics: Metric[], forcePush?: boolean): Promise<void>;
   sendDailyMetrics(): Promise<void>;
@@ -115,6 +120,12 @@ export class DefaultMetricsService implements MetricsService {
           return pushAndMarkLastUploadedDateTime();
         }
       });
+    });
+  }
+
+  retrieveAllMetricsInStorage(): Promise<Metric[]> {
+    return this.serialPromiseQueue.add(() => {
+      return this.metricsProvider.retrieveAll();
     });
   }
 

--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -131,24 +131,22 @@ export class DefaultMetricsService implements MetricsService {
 
   private triggerPush(): Promise<TriggerPushResult> {
     const pushAndClearMetrics = (metrics: Metric[]): Promise<TriggerPushResult> => {
-      return this.metricsJsonSerializer.serializeToJson(getCurrentDate().getTime(), metrics).then(jsonAsString => {
-        // eslint-disable-next-line promise/no-nesting
-        return Promise.all([this.metricsPusher.push(jsonAsString), Promise.resolve(metrics.pop())])
-          .then(([pushResult, lastPushedMetric]) => {
-            switch (pushResult) {
-              case MetricsPusherResult.Success:
-                return Promise.all([
-                  this.markLastMetricTimestampSentToTheServer(lastPushedMetric!.timestamp),
-                  this.metricsStorageCleaner.deleteUntilTimestamp(lastPushedMetric!.timestamp),
-                  Promise.resolve(TriggerPushResult.Success),
-                ]);
-              case MetricsPusherResult.Error:
-              default:
-                return Promise.all([Promise.resolve(), Promise.resolve(), Promise.resolve(TriggerPushResult.Error)]);
-            }
-          })
-          .then(([, , result]) => result);
-      });
+      const jsonAsString = this.metricsJsonSerializer.serializeToJson(getCurrentDate().getTime(), metrics);
+      return Promise.all([this.metricsPusher.push(jsonAsString), Promise.resolve(metrics.pop())])
+        .then(([pushResult, lastPushedMetric]) => {
+          switch (pushResult) {
+            case MetricsPusherResult.Success:
+              return Promise.all([
+                this.markLastMetricTimestampSentToTheServer(lastPushedMetric!.timestamp),
+                this.metricsStorageCleaner.deleteUntilTimestamp(lastPushedMetric!.timestamp),
+                Promise.resolve(TriggerPushResult.Success),
+              ]);
+            case MetricsPusherResult.Error:
+            default:
+              return Promise.all([Promise.resolve(), Promise.resolve(), Promise.resolve(TriggerPushResult.Error)]);
+          }
+        })
+        .then(([, , result]) => result);
     };
     return this.getLastMetricTimestampSentToTheServer()
       .then(lastTimestamp => {

--- a/src/services/MetricsService/MetricsStorage.ts
+++ b/src/services/MetricsService/MetricsStorage.ts
@@ -18,7 +18,7 @@ export interface MetricsStorageCleaner {
   deleteUntilTimestamp(timestamp: number): Promise<void>;
 }
 
-export class DefaultMetricsStorage implements MetricsStorageWriter, MetricsStorageReader {
+export class DefaultMetricsStorage implements MetricsStorageWriter, MetricsStorageReader, MetricsStorageCleaner {
   private keyValueStore: SecureKeyValueStore;
   private serialPromiseQueue: PQueue;
 

--- a/src/services/MetricsService/tests/MetricFactory.ts
+++ b/src/services/MetricsService/tests/MetricFactory.ts
@@ -12,9 +12,9 @@ export class MetricFactory {
 
   static createTestMetrics(): Metric[] {
     return [
-      this.createTestMetricWithEmptyPayload(),
-      this.createTestMetricWithCustomPayload(),
-      this.createTestMetricWithEmptyPayload(),
+      this.createTestMetricWithEmptyPayload(1611324024314),
+      this.createTestMetricWithCustomPayload(1611324024315),
+      this.createTestMetricWithEmptyPayload(1611324024316),
     ];
   }
 }

--- a/src/services/MetricsService/tests/MetricsJsonSerializer.spec.ts
+++ b/src/services/MetricsService/tests/MetricsJsonSerializer.spec.ts
@@ -7,9 +7,10 @@ describe('MetricsJsonSerializer', () => {
   it('can serialize metrics in JSON', async () => {
     const appVersion = '0.0.7';
     const appOs = 'iOS';
+    const osVersion = '12.5';
     const timestamp = 1611324024314;
 
-    const sut = new DefaultMetricsJsonSerializer(appVersion, appOs);
+    const sut = new DefaultMetricsJsonSerializer(appVersion, appOs, osVersion);
 
     const metric1 = new Metric(1611324021314, 'MyCustomMetric1', 'MyCustomRegion1', [
       ['MyPayloadKey1', 'MyPayloadValue1'],
@@ -24,7 +25,7 @@ describe('MetricsJsonSerializer', () => {
 
     expect(result).toMatch(
       // eslint-disable-next-line max-len
-      `{"metricstimestamp":1611324024314,"appversion":"0.0.7","appos":"iOS","payload":[{"identifier":"MyCustomMetric1","region":"MyCustomRegion1","timestamp":1611324021314,"MyPayloadKey1":"MyPayloadValue1"},{"identifier":"MyCustomMetric2","region":"MyCustomRegion2","timestamp":1611324022314},{"identifier":"MyCustomMetric3","region":"MyCustomRegion3","timestamp":1611324023314,"MyPayloadKey1":"MyPayloadValue1","MyPayloadKey2":"MyPayloadValue2","MyPayloadKey3":"MyPayloadValue3"}]}`,
+      `{"metricstimestamp":1611324024314,"appversion":"0.0.7","appos":"iOS","osversion":"12.5","payload":[{"identifier":"MyCustomMetric1","region":"MyCustomRegion1","timestamp":1611324021314,"MyPayloadKey1":"MyPayloadValue1"},{"identifier":"MyCustomMetric2","region":"MyCustomRegion2","timestamp":1611324022314},{"identifier":"MyCustomMetric3","region":"MyCustomRegion3","timestamp":1611324023314,"MyPayloadKey1":"MyPayloadValue1","MyPayloadKey2":"MyPayloadValue2","MyPayloadKey3":"MyPayloadValue3"}]}`,
     );
   });
 });

--- a/src/services/MetricsService/tests/MetricsService.spec.ts
+++ b/src/services/MetricsService/tests/MetricsService.spec.ts
@@ -1,0 +1,148 @@
+import {DefaultMetricsService, MetricsService} from '../MetricsService';
+import {MetricsPublisher, DefaultMetricsPublisher} from '../MetricsPublisher';
+import {DefaultMetricsStorage} from '../MetricsStorage';
+import {SecureKeyValueStore} from '../SecureKeyValueStorage';
+import {DefaultMetricsProvider, MetricsProvider} from '../MetricsProvider';
+import {DefaultMetricsJsonSerializer, MetricsJsonSerializer} from '../MetricsJsonSerializer';
+import {MetricsPusher, MetricsPusherResult} from '../MetricsPusher';
+import {Metric} from '../Metric';
+
+import {MetricFactory} from './MetricFactory';
+import {RNSecureKeyStoreMock} from './RNSecureKeyStoreMock';
+
+const metricsPusherMock: MetricsPusher = {
+  push: jest.fn().mockReturnValue(Promise.resolve(MetricsPusherResult.Success)),
+};
+
+describe('MetricsService', () => {
+  let sut: MetricsService;
+
+  let metricsStorage: DefaultMetricsStorage;
+  let metricsProvider: MetricsProvider;
+
+  beforeEach(() => {
+    const secureKeyValueStore: SecureKeyValueStore = new RNSecureKeyStoreMock();
+    metricsStorage = new DefaultMetricsStorage(secureKeyValueStore);
+    const metricsPublisher: MetricsPublisher = new DefaultMetricsPublisher(metricsStorage);
+    metricsProvider = new DefaultMetricsProvider(metricsStorage);
+    const metricsJsonSerializer: MetricsJsonSerializer = new DefaultMetricsJsonSerializer('1.0.0', 'ios', '12.5');
+    sut = new DefaultMetricsService(
+      secureKeyValueStore,
+      metricsPublisher,
+      metricsProvider,
+      metricsStorage,
+      metricsJsonSerializer,
+      metricsPusherMock,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('both metrics provider and metrics storage are in sync when returning all metrics', async () => {
+    const metrics = MetricFactory.createTestMetrics();
+    await sut.publishMetrics(metrics);
+
+    const metricsFromProvider = await metricsProvider.retrieveAll();
+    const metricsFromStorage = await metricsStorage.retrieve();
+
+    expect(metricsFromProvider).toStrictEqual(metrics);
+    expect(metricsFromStorage).toStrictEqual(metrics);
+  });
+
+  it('metrics provider returns metrics in the right order when requesting metrics after specific timestamp', async () => {
+    const metrics: Metric[] = [
+      MetricFactory.createTestMetricWithCustomPayload(1611324024314),
+      MetricFactory.createTestMetricWithCustomPayload(1611324024315),
+      MetricFactory.createTestMetricWithCustomPayload(1611324024316),
+      MetricFactory.createTestMetricWithCustomPayload(1611324024317),
+      MetricFactory.createTestMetricWithCustomPayload(1611324024318),
+    ];
+    await sut.publishMetrics(metrics);
+
+    const metricsFromProvider = await metricsProvider.retrieveLaterThanTimestamp(1611324024316);
+
+    expect(metricsFromProvider).toStrictEqual(metrics.slice(3));
+  });
+
+  it('metrics storage is getting cleared only if push to server was successful', async () => {
+    const metrics = MetricFactory.createTestMetrics();
+    await sut.publishMetrics(metrics);
+
+    const metricsBeforeTryingToPushToServer = await metricsStorage.retrieve();
+    expect(metricsBeforeTryingToPushToServer).toStrictEqual(metrics);
+
+    metricsPusherMock.push.mockReturnValue(Promise.resolve(MetricsPusherResult.Error));
+    await sut.sendDailyMetrics();
+
+    const metricsAfterTryingToPushToServerWithoutSuccess = await metricsStorage.retrieve();
+    expect(metricsAfterTryingToPushToServerWithoutSuccess).toStrictEqual(metrics);
+
+    metricsPusherMock.push.mockReturnValue(Promise.resolve(MetricsPusherResult.Success));
+    await sut.sendDailyMetrics();
+
+    const metricsAfterTryingToPushToServerWithSuccess = await metricsStorage.retrieve();
+    expect(metricsAfterTryingToPushToServerWithSuccess).toStrictEqual([]);
+  });
+
+  it('publish metrics triggers push to server if forcePush is true', async () => {
+    await sut.publishMetric(MetricFactory.createTestMetricWithCustomPayload());
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+
+    await sut.publishMetric(MetricFactory.createTestMetricWithCustomPayload(), true);
+    expect(metricsPusherMock.push).toHaveBeenCalledTimes(1);
+  });
+
+  it('send daily metrics only pushes metrics if we have at least one available in the queue', async () => {
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+
+    await sut.publishMetric(MetricFactory.createTestMetricWithCustomPayload());
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).toHaveBeenCalledTimes(1);
+
+    metricsPusherMock.push.mockClear();
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+  });
+
+  it('send daily metrics only pushes metrics to server when the day has changed', async () => {
+    const OriginalDate = global.Date;
+    const realDateNow = Date.now.bind(global.Date);
+    const realDateUTC = Date.UTC.bind(global.Date);
+    let today = new OriginalDate('2019-01-01T12:00:00.000Z');
+    const dateSpy = jest.spyOn(global, 'Date');
+    dateSpy.mockImplementation((...args: any[]) => (args.length > 0 ? new OriginalDate(...args) : today));
+    global.Date.now = realDateNow;
+    global.Date.UTC = realDateUTC;
+
+    await sut.publishMetric(MetricFactory.createTestMetricWithCustomPayload(1611324024315));
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).toHaveBeenCalledTimes(1);
+
+    await sut.publishMetric(MetricFactory.createTestMetricWithCustomPayload(1611324024316));
+    metricsPusherMock.push.mockClear();
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+
+    today = new OriginalDate('2019-01-01T20:00:00.000Z');
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+
+    today = new OriginalDate('2019-01-01T23:59:59.999Z');
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).not.toHaveBeenCalled();
+
+    today = new OriginalDate('2019-01-02T00:00:00.000Z');
+
+    await sut.sendDailyMetrics();
+    expect(metricsPusherMock.push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -25,6 +25,11 @@ export function minutesFromNow(date: Date) {
   return Math.round((currentTime - date.getTime()) / oneMinuteMs);
 }
 
+export function secondsBetween(date1: Date, date2: Date): number {
+  const oneSecondMs = 1000;
+  return (date2.getTime() - date1.getTime()) / oneSecondMs;
+}
+
 export function minutesBetween(date1: Date, date2: Date): number {
   const oneMinuteMs = 1000 * 60;
   return (date2.getTime() - date1.getTime()) / oneMinuteMs;


### PR DESCRIPTION
# Summary | Résumé

- Added additional osVersion info to metrics global payload
- Added some debug logs to check background task duration
- Plugged the push metrics to server (daily) in the foreground
- Added some unit tests for MetricsService
- Added an option to dump metrics from storage in Loggly from the Debug UI
- Refactored the way we publish active-user and the background-check events