### PR TITLE
Patch/adjust metric upload interval

### DIFF
--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -1,7 +1,7 @@
 import {METRICS_API_KEY, METRICS_URL} from 'env';
 import PQueue from 'p-queue';
 import {log} from 'shared/logging/config';
-import {datesAreOnSameDay, daysBetweenUTC, getCurrentDate} from 'shared/date-fns';
+import {daysBetweenUTC, getCurrentDate} from 'shared/date-fns';
 
 import {Metric} from './Metric';
 import {MetricsJsonSerializer} from './MetricsJsonSerializer';

--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -113,13 +113,11 @@ export class DefaultMetricsService implements MetricsService {
         if (metricsLastUploadedDateTime) {
           const today = getCurrentDate();
           const minutesSinceLastUpload = minutesBetween(metricsLastUploadedDateTime, today);
-          // randomize the upload window, to stagger when phones are uploading the metrics
-          const randomMinutes = Math.floor(Math.random() * MIN_UPLOAD_MINUTES);
           log.debug({
             category: 'metrics',
-            message: `MinutesSinceLastUpload: ${minutesSinceLastUpload}, MinimumUploadMinutes: ${MIN_UPLOAD_MINUTES}, RandomMinutes: ${randomMinutes}`,
+            message: `MinutesSinceLastUpload: ${minutesSinceLastUpload}, MinimumUploadMinutes: ${MIN_UPLOAD_MINUTES}`,
           });
-          if (minutesSinceLastUpload > MIN_UPLOAD_MINUTES + randomMinutes) {
+          if (minutesSinceLastUpload > MIN_UPLOAD_MINUTES) {
             return pushAndMarkLastUploadedDateTime();
           }
         } else {

--- a/src/services/MetricsService/MetricsService.ts
+++ b/src/services/MetricsService/MetricsService.ts
@@ -1,7 +1,7 @@
 import {METRICS_API_KEY, METRICS_URL} from 'env';
 import PQueue from 'p-queue';
 import {log} from 'shared/logging/config';
-import {datesAreOnSameDay, getCurrentDate} from 'shared/date-fns';
+import {datesAreOnSameDay, daysBetweenUTC, getCurrentDate} from 'shared/date-fns';
 
 import {Metric} from './Metric';
 import {MetricsJsonSerializer} from './MetricsJsonSerializer';
@@ -108,7 +108,7 @@ export class DefaultMetricsService implements MetricsService {
       return this.getMetricsLastUploadedDateTime().then(metricsLastUploadedDateTime => {
         if (metricsLastUploadedDateTime) {
           const today = getCurrentDate();
-          if (datesAreOnSameDay(metricsLastUploadedDateTime, today) === false) {
+          if (daysBetweenUTC(metricsLastUploadedDateTime, today) > 0) {
             return pushAndMarkLastUploadedDateTime();
           }
         } else {


### PR DESCRIPTION
# Summary | Résumé

This will adjust how often the Metrics will be uploaded to the server. Instead of relying on an interval of minutes to be passed, it will upload the metrics as long as it hasn't already been uploaded for that day.