### PR TITLE
Background tasks are aggregated per UTC day

### DIFF
--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -5,7 +5,7 @@ import {Platform} from 'react-native';
 import {Status} from 'screens/home/components/NotificationPermissionStatus';
 import {ExposureStatus, ExposureStatusType, SystemStatus} from 'services/ExposureNotificationService';
 import {Key} from 'services/StorageService';
-import {getHoursBetween, getCurrentDate, daysBetweenUTC} from 'shared/date-fns';
+import {getHoursBetween, getCurrentDate, daysBetweenUTC, getUTCMidnight} from 'shared/date-fns';
 import {log} from 'shared/logging/config';
 
 import {DefaultFilteredMetricsStateStorage, FilteredMetricsStateStorage} from './FilteredMetricsStateStorage';
@@ -176,10 +176,12 @@ export class FilteredMetricsService {
   private publishBackgroundCheckEventIfNecessary(): Promise<void> {
     const publishAndSave = (
       numberOfBackgroundCheckForPreviousDay: number,
+      day: number,
       newBackgroundCheckEvent: Date,
     ): Promise<void> => {
       return this.publishEvent(EventTypeMetric.BackgroundCheck, [
         ['count', String(numberOfBackgroundCheckForPreviousDay)],
+        ['utcDay', String(day)],
       ]).then(() => this.stateStorage.saveBackgroundCheckEvents([newBackgroundCheckEvent]));
     };
 
@@ -191,7 +193,7 @@ export class FilteredMetricsService {
         if (daysBetweenUTC(lastBackgroundCheckEvent, newBackgroundCheckEvent) === 0) {
           return this.stateStorage.saveBackgroundCheckEvents(events.concat(newBackgroundCheckEvent));
         } else {
-          return publishAndSave(events.length, newBackgroundCheckEvent);
+          return publishAndSave(events.length, getUTCMidnight(events[0]), newBackgroundCheckEvent);
         }
       } else {
         return this.stateStorage.saveBackgroundCheckEvents([newBackgroundCheckEvent]);

--- a/src/services/MetricsService/FilteredMetricsService.ts
+++ b/src/services/MetricsService/FilteredMetricsService.ts
@@ -5,7 +5,7 @@ import {Platform} from 'react-native';
 import {Status} from 'screens/home/components/NotificationPermissionStatus';
 import {ExposureStatus, ExposureStatusType, SystemStatus} from 'services/ExposureNotificationService';
 import {Key} from 'services/StorageService';
-import {getHoursBetween, getCurrentDate, datesAreOnSameDay} from 'shared/date-fns';
+import {getHoursBetween, getCurrentDate, daysBetweenUTC} from 'shared/date-fns';
 import {log} from 'shared/logging/config';
 
 import {DefaultFilteredMetricsStateStorage, FilteredMetricsStateStorage} from './FilteredMetricsStateStorage';
@@ -188,7 +188,7 @@ export class FilteredMetricsService {
     return this.stateStorage.getBackgroundCheckEvents().then(events => {
       if (events.length > 0) {
         const lastBackgroundCheckEvent = events[events.length - 1];
-        if (datesAreOnSameDay(lastBackgroundCheckEvent, newBackgroundCheckEvent)) {
+        if (daysBetweenUTC(lastBackgroundCheckEvent, newBackgroundCheckEvent) === 0) {
           return this.stateStorage.saveBackgroundCheckEvents(events.concat(newBackgroundCheckEvent));
         } else {
           return publishAndSave(events.length, newBackgroundCheckEvent);

--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -12,7 +12,6 @@ import {
   parseSavedTimestamps,
   getFirstThreeUniqueDates,
   getHoursBetween,
-  datesAreOnSameDay,
 } from './date-fns';
 
 /**
@@ -260,20 +259,6 @@ describe('date-fns', () => {
       const twoDaysFromNow = new Date(Number(now));
       twoDaysFromNow.setDate(now.getDate() + 2);
       expect(getHoursBetween(now, twoDaysFromNow)).toStrictEqual(48);
-    });
-  });
-
-  describe('datesAreOnSameDay', () => {
-    it('validates two dates are on same day', () => {
-      const now = new Date(Number(1612539273));
-      const plusFiveHours = new Date(now.getTime() + 5 * 60 * 60 * 1000);
-      expect(datesAreOnSameDay(now, plusFiveHours)).toStrictEqual(true);
-    });
-
-    it('validates two dates are not on same day', () => {
-      const now = new Date(Number(1612539273));
-      const plusTwentyFiveHours = new Date(now.getTime() + 25 * 60 * 60 * 1000);
-      expect(datesAreOnSameDay(now, plusTwentyFiveHours)).toStrictEqual(false);
     });
   });
 

--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -12,6 +12,7 @@ import {
   parseSavedTimestamps,
   getFirstThreeUniqueDates,
   getHoursBetween,
+  getUTCMidnight,
 } from './date-fns';
 
 /**
@@ -259,6 +260,17 @@ describe('date-fns', () => {
       const twoDaysFromNow = new Date(Number(now));
       twoDaysFromNow.setDate(now.getDate() + 2);
       expect(getHoursBetween(now, twoDaysFromNow)).toStrictEqual(48);
+    });
+  });
+
+  describe('getUTCMidnight', () => {
+    it.each([
+      [new Date('2021-01-01T12:00Z'), new Date('2021-01-01T00:00Z').getTime()],
+      [new Date('2021-01-01T01:00Z'), new Date('2021-01-01T00:00Z').getTime()],
+      [new Date('2021-01-01T23:59Z'), new Date('2021-01-01T00:00Z').getTime()],
+      [new Date('2021-01-02T01:00Z'), new Date('2021-01-02T00:00Z').getTime()],
+    ])('for %p, midnight has the timestamp %p', (date, midnight) => {
+      expect(getUTCMidnight(date)).toStrictEqual(midnight);
     });
   });
 

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -116,3 +116,8 @@ export const getFirstThreeUniqueDates = (formattedDates: string[]) => {
 export const parseSavedTimestamps = (savedTimestamps: string) => {
   return savedTimestamps.split(',').map(x => Number(x));
 };
+
+export const getUTCMidnight = (date: Date) => {
+  const midnight = new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  return midnight.getTime();
+}

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -118,6 +118,6 @@ export const parseSavedTimestamps = (savedTimestamps: string) => {
 };
 
 export const getUTCMidnight = (date: Date) => {
-  const midnight = new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const midnight = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
   return midnight.getTime();
-}
+};

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -42,14 +42,6 @@ export function daysBetweenUTC(date1: Date, date2: Date): number {
   return (startDate2.getTime() - startDate1.getTime()) / (1000 * 3600 * 24);
 }
 
-export function datesAreOnSameDay(date1: Date, date2: Date): boolean {
-  return (
-    date1.getFullYear() === date2.getFullYear() &&
-    date1.getMonth() === date2.getMonth() &&
-    date1.getDate() === date2.getDate()
-  );
-}
-
 export function getCurrentDate(): Date {
   return new Date();
 }


### PR DESCRIPTION
# Summary | Résumé

This will save the background tasks grouped by UTC day instead of by local day.