### PR TITLE
Fixed bug in daysBetweenUTC, updated date mocking in ENService tests

### DIFF
--- a/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.spec.ts
@@ -153,9 +153,11 @@ describe('ExposureNotificationService', () => {
 
   const OriginalDate = global.Date;
   const realDateNow = Date.now.bind(global.Date);
+  const realDateUTC = Date.UTC.bind(global.Date);
   const dateSpy = jest.spyOn(global, 'Date');
   const today = new OriginalDate('2020-05-18T04:10:00+0000');
   global.Date.now = realDateNow;
+  global.Date.UTC = realDateUTC;
 
   const testUpdateExposure = async (currentStatus: ExposureStatus, summaries: ExposureSummary[]) => {
     service.exposureStatus.append(currentStatus);

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -37,8 +37,8 @@ export function daysBetween(date1: Date, date2: Date): number {
 }
 
 export function daysBetweenUTC(date1: Date, date2: Date): number {
-  const startDate1 = new Date(date1.getUTCFullYear(), date1.getUTCMonth(), date1.getUTCDate());
-  const startDate2 = new Date(date2.getUTCFullYear(), date2.getUTCMonth(), date2.getUTCDate());
+  const startDate1 = new Date(Date.UTC(date1.getUTCFullYear(), date1.getUTCMonth(), date1.getUTCDate()));
+  const startDate2 = new Date(Date.UTC(date2.getUTCFullYear(), date2.getUTCMonth(), date2.getUTCDate()));
   return (startDate2.getTime() - startDate1.getTime()) / (1000 * 3600 * 24);
 }
 


### PR DESCRIPTION
# Summary | Résumé

I found this while writing the `getUtcMidnight` function over here: https://github.com/cds-snc/covid-alert-app/pull/1437/files#diff-81628952bdd37b3b51d97a7b44516f3c7059f5ae32924347102d46e884a45ac8R120

Turns out we have a bug in `daysBetweenUTC`:  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC

Thinking about this some more - this bug did not cause this function to produce incorrect results, luckily, since we were creating both `startDate1` and `startDate2` in the local time. So the errors kind of cancelled out. So this patch is more about making the function make sense internally. 