### PR TITLE
Fix link to the E2E docs which was renamed from DETOX_DOC to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ yarn generate-translations
 ## Testing
 
 - [Manual Testing Plan](./TEST_PLAN.md)
-- [End to end testing with Detox](./e2e/DETOX_DOC.md)
+- [End to end testing with Detox](./e2e/README.md)
 
 ## Who built COVID Alert?
 


### PR DESCRIPTION
Minor change to the README.md to update a link. No other changes