### PR TITLE
Handle "easy mode: font sizes

### DIFF
--- a/src/screens/menu/views/MenuBar.tsx
+++ b/src/screens/menu/views/MenuBar.tsx
@@ -35,7 +35,7 @@ export const MenuBar = () => {
   return (
     <Box style={styles.content} paddingHorizontal="m">
       <Box style={styles.box}>
-        {pixelRatio > 1.25 ? (
+        {pixelRatio > 1.0 ? (
           <Box>
             {qrEnabled ? qrButtonBox : appStatus}
             {menuButtonBox}

--- a/src/screens/menu/views/MenuBar.tsx
+++ b/src/screens/menu/views/MenuBar.tsx
@@ -15,9 +15,10 @@ export const MenuBar = () => {
   const {qrEnabled} = useStorage();
   const [systemStatus] = useSystemStatus();
   const pixelRatio = PixelRatio.getFontScale();
+  const paddingBottom = pixelRatio > 1.0 ? 'none' : 'm';
 
   const appStatus = (
-    <Text paddingVertical="m">
+    <Text paddingTop="m" paddingBottom={paddingBottom}>
       <StatusHeaderView enabled={systemStatus === SystemStatus.Active} />
     </Text>
   );


### PR DESCRIPTION
Update to break to stacked nav if we're above anything above 1.0 for pixel ratio 

Logged ratio = 1.100000023841858


**"Easy Mode":**

<img src="https://user-images.githubusercontent.com/62242/111689875-ecdab380-8802-11eb-9338-3906522840b6.png" width="500">

<img src="https://user-images.githubusercontent.com/62242/111689880-ed734a00-8802-11eb-8294-5ca49141ca47.png" width="500">
<hr>

***Default*:**
<img src="https://user-images.githubusercontent.com/62242/111689877-ecdab380-8802-11eb-80e8-8ee16ae81fd1.png" width="500">


**Padding:**

<img src="https://user-images.githubusercontent.com/62242/111689874-ecdab380-8802-11eb-9086-3db24a0d8ed4.png" width="500">

<img src="https://user-images.githubusercontent.com/62242/111689873-ec421d00-8802-11eb-9a08-282eeedf5c65.png" width="500">





