### PR TITLE
Remove `LazyThreadSafetyMode.NONE` parameter when loading by lazy.

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/ExposureCheckSchedulerModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureCheckSchedulerModule.kt
@@ -23,7 +23,7 @@ class ExposureCheckSchedulerModule(private val context: ReactApplicationContext)
 
     override val coroutineContext: CoroutineContext get() = Dispatchers.Default
 
-    private val workManager: WorkManager by lazy(LazyThreadSafetyMode.NONE) {
+    private val workManager: WorkManager by lazy {
         WorkManager.getInstance(context.applicationContext)
     }
 

--- a/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/ExposureNotificationModule.kt
@@ -68,12 +68,12 @@ class ExposureNotificationModule(context: ReactApplicationContext) : ReactContex
     private var getTekResolutionCompleter: CompletableDeferred<Unit>? = null
     private var detectExposureResolutionCompleters = hashMapOf<Token, CompletableDeferred<Token>?>()
 
-    private val bluetoothAdapter: BluetoothAdapter? by lazy(LazyThreadSafetyMode.NONE) {
+    private val bluetoothAdapter: BluetoothAdapter? by lazy {
         val bluetoothManager = context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
         BluetoothAdapter.getDefaultAdapter() ?: bluetoothManager?.adapter
     }
 
-    private val locationManager: LocationManager? by lazy(LazyThreadSafetyMode.NONE) {
+    private val locationManager: LocationManager? by lazy {
         context.applicationContext.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
     }
 

--- a/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/PushNotificationModule.kt
@@ -30,11 +30,11 @@ private const val CHANNEL_DESC = "COVID Alert"
  */
 class PushNotificationModule(private val context: ReactApplicationContext) : ReactContextBaseJavaModule(context), CoroutineScope {
 
-    private val notificationManager: NotificationManager by lazy(LazyThreadSafetyMode.NONE) {
+    private val notificationManager: NotificationManager by lazy {
         context.applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
 
-    private val workManager: WorkManager by lazy(LazyThreadSafetyMode.NONE) {
+    private val workManager: WorkManager by lazy {
         WorkManager.getInstance(context.applicationContext)
     }
 


### PR DESCRIPTION
# Summary | Résumé

A small change in how lazy variables are loaded in Kotlin, removing the `LazyThreadSafetyMode.NONE` parameter, which will now use the default `LazyThreadSafetyMode. SYNCHRONIZED`.

I don't believe this will have any noticeable impact on the app, as there don't seem to be any use cases where these objects would be accessed by multiple threads, but this is the safer approach to handling these variables.

# Test instructions | Instructions pour tester la modification

Running the app on Android, and all normal behaviour should be executed.