### PR TITLE
Generate Kotlin locale strings from JSON

### DIFF
--- a/android/app/src/main/java/app/covidshield/MainApplication.java
+++ b/android/app/src/main/java/app/covidshield/MainApplication.java
@@ -17,12 +17,14 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import org.unimodules.adapters.react.ModuleRegistryAdapter;
 import org.unimodules.adapters.react.ReactModuleRegistryProvider;
 import org.unimodules.core.interfaces.SingletonModule;
 
 import app.covidshield.generated.BasePackageList;
+import android.util.Log;
 
 
 
@@ -65,6 +67,8 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     public void onCreate() {
         instance = this;
+        Log.d("locale", Locale.getDefault().getLanguage());
+        Log.d("locale", getResources().getString(R.string.app_name));
         super.onCreate();
         SoLoader.init(this, /* native exopackage */ false);
     }

--- a/android/app/src/main/java/app/covidshield/MainApplication.java
+++ b/android/app/src/main/java/app/covidshield/MainApplication.java
@@ -67,8 +67,6 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     public void onCreate() {
         instance = this;
-        Log.d("locale", Locale.getDefault().getLanguage());
-        Log.d("locale", getResources().getString(R.string.app_name));
         super.onCreate();
         SoLoader.init(this, /* native exopackage */ false);
     }

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Alerte COVID</string>
+	<string name="app_name">Alerte COVID</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">COVID Alert</string>
+	<string name="app_name">COVID Alert</string>
 </resources>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "codegen-protobuf": "pbjs -t static-module -o src/services/BackendService/covidshield/covidshield.js src/services/BackendService/covidshield/covidshield.proto && pbts -o src/services/BackendService/covidshield/covidshield.d.ts src/services/BackendService/covidshield/covidshield.js",
     "generate-translations": "node translations.js",
     "generate-translations:regional": "node translations-regional.js",
+    "generate-translations:android": "node translations-android.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "pod-install": "pushd ios; bundle exec pod install; popd",
     "run-android": "react-native run-android --variant debug",

--- a/translations-android.js
+++ b/translations-android.js
@@ -1,0 +1,59 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const contentDirectory = 'src/locale/translations';
+const outputFilename = 'strings.xml';
+const stringPaths = ['AppName', 'NoExposureDetected.RegionCovered.Title'];
+
+const resolveObjectPath = (stringPath, obj) => {
+  return stringPath.split('.').reduce((prev, curr) => {
+    return prev ? prev[curr] : '';
+  }, obj);
+};
+
+const camelCaseToUnderScore = str => {
+  return str
+    .split(/(?=[A-Z])/g)
+    .join('_')
+    .split('.')
+    .join('')
+    .toLowerCase();
+};
+
+const getLocaleContent = async lang => {
+  const filePath = path.join(__dirname, contentDirectory, `${lang}.json`);
+  const data = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(data);
+};
+
+const writeFile = options => {
+  const {content, filePath} = options;
+
+  let xml = '<resources>\n';
+
+  stringPaths.forEach(strPath => {
+    const str = resolveObjectPath(`Home.${strPath}`, content);
+    const name = camelCaseToUnderScore(strPath);
+    xml += `\t<string name="${name}">${str}</string>\n`;
+  });
+
+  xml += '</resources>';
+
+  fs.writeFile(filePath, xml, err => {
+    if (err) return console.log('error writing file', err); // eslint-disable-line no-console
+  });
+};
+
+const writeXml = async (lang = '') => {
+  const basePath = 'android/app/src/main/res/values';
+  const outputDirectory = lang === '' ? `${basePath}/` : `${basePath}-${lang}/`;
+  const content = await getLocaleContent(lang || 'en');
+  const filePath = path.join(__dirname, outputDirectory, outputFilename);
+  writeFile({content, filePath});
+};
+
+(async () => {
+  // defaults to en
+  await writeXml();
+  await writeXml('fr');
+})();

--- a/translations-android.js
+++ b/translations-android.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const contentDirectory = 'src/locale/translations';
 const outputFilename = 'strings.xml';
-const stringPaths = ['AppName', 'NoExposureDetected.RegionCovered.Title'];
+const stringPaths = ['AppName']; // add strings here i.e. 'NoExposureDetected.RegionCovered.Title'
 
 const resolveObjectPath = (stringPath, obj) => {
   return stringPath.split('.').reduce((prev, curr) => {

--- a/translations-android.js
+++ b/translations-android.js
@@ -3,7 +3,8 @@ const path = require('path');
 
 const contentDirectory = 'src/locale/translations';
 const outputFilename = 'strings.xml';
-const stringPaths = ['AppName']; // add strings here i.e. 'NoExposureDetected.RegionCovered.Title'
+// add strings here i.e. ['AppName', 'NoExposureDetected.RegionCovered.Title']
+const stringPaths = ['AppName'];
 
 const resolveObjectPath = (stringPath, obj) => {
   return stringPath.split('.').reduce((prev, curr) => {


### PR DESCRIPTION
# Summary | Résumé

Adds script to generate `Android` XML string translation files from existing JSON locale files

We need to access translated strings from React and Kotlin. The source for the translated string should be in a single spot i.e. en.json. The existing json format will not work within Kotlin.

Generate xml files from the JSON files with Android / Kotlin can read.

> [Trello](https://trello.com/c/2gWHLAqq/1213-figure-out-how-to-get-translation-strings-currently-in-react-native-over-to-kotlin)

### Testing

String "paths" for xml generation are added via the `stringPaths` variable in the script

i.e.
```javascript
const stringPaths = ['AppName', 'NoExposureDetected.RegionCovered.Title'];
```
Run
```bash
yarn generate-translations:android
```

*View the updated Android XML files*

![Screen Shot 2021-04-08 at 8 23 25 AM](https://user-images.githubusercontent.com/62242/114025971-b7464a80-9843-11eb-86b7-044c6d0bd821.png)


*View the log output*

**Change the language on your Phone**

2 logs have been added to the `MainApplication.java` onCreate

You can replace  the existing `getResources().getString(R.string.app_name)` with a new string i.e.   `getResources().getString(R.string.the_string_name_here)`

```
@Override
    public void onCreate() {
        ...
        Log.d("locale", Locale.getDefault().getLanguage());
        Log.d("locale", getResources().getString(R.string.app_name));
       ...
    }
```

![Screen Shot 2021-04-08 at 8 27 55 AM](https://user-images.githubusercontent.com/62242/114026642-76026a80-9844-11eb-80a4-46aced9b188b.png)

