### PR TITLE
Feature/android debug metrics updates

### DIFF
--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
@@ -42,8 +42,8 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
         val enIsEnabled = exposureNotificationClient.isEnabled.await()
         val enStatus = exposureNotificationClient.status.await()
         if (!enIsEnabled || enStatus.contains(ExposureNotificationStatus.INACTIVATED)) {
-            MetricsService.publishDebugMetric(7.1, context)
             Log.d("background", "ExposureCheckNotificationWorker - ExposureNotification: Not enabled or not activated")
+            MetricsService.publishDebugMetric(7.1, context, "ExposureNotification: enIsEnabled = $enIsEnabled AND enStatus = ${enStatus.map { it.ordinal }}.")
             return Result.success()
         }
 

--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
@@ -52,8 +52,8 @@ class ExposureCheckSchedulerWorker (val context: Context, parameters: WorkerPara
                             completer.await()
                         }
                     }
-                } catch (_: TimeoutCancellationException) {
-                    MetricsService.publishDebugMetric(101.0, context);
+                } catch (exception: TimeoutCancellationException) {
+                    MetricsService.publishDebugMetric(101.0, context, exception.message ?: "Unknown");
                     log("doWork exception", mapOf("message" to "Timeout"))
                 } catch (exception: Exception) {
                     MetricsService.publishDebugMetric(102.0, context, exception.message ?: "Unknown");

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,9 +58,8 @@ if (Platform.OS === 'android') {
       ExposureNotification,
       FilteredMetricsService.sharedInstance(),
     );
-    if (await exposureNotificationService.shouldPerformExposureCheck()) {
-      await exposureNotificationService.initiateExposureCheckHeadless();
-    }
+
+    await exposureNotificationService.initiateExposureCheckHeadless();
   });
 }
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -167,8 +167,6 @@ export class ExposureNotificationService {
 
   initiateExposureCheck = async () => {
     if (Platform.OS !== 'android') return;
-    if (!(await this.shouldPerformExposureCheck())) return;
-
     const payload: NotificationPayload = {
       alertTitle: this.i18n.translate('Notification.ExposureChecksTitle'),
       alertBody: this.i18n.translate('Notification.ExposureChecksBody'),
@@ -274,9 +272,6 @@ export class ExposureNotificationService {
         durationInSeconds: backgroundTaskDurationInSeconds,
       });
     };
-
-    // @todo: maybe remove this gets called in updateExposureStatus
-    if (!(await this.shouldPerformExposureCheck())) return;
 
     try {
       await this.loadExposureStatus();

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -182,11 +182,15 @@ export class ExposureNotificationService {
   };
 
   executeExposureCheckEvent = async () => {
+    if (Platform.OS !== 'android') return;
     publishDebugMetric(7.3);
+    log.debug({category: 'background', message: 'executeExposureCheckEvent'});
+    await this.executeExposureCheck();
+  };
+
+  executeExposureCheck = async () => {
     await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
 
-    if (Platform.OS !== 'android') return;
-    log.debug({category: 'background', message: 'executeExposureCheckEvent'});
     try {
       await this.updateExposureStatusInBackground();
     } catch (error) {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -821,8 +821,6 @@ export class ExposureNotificationService {
 
     const {keysFileUrls, lastCheckedPeriod} = await this.getKeysFileUrls();
 
-    publishDebugMetric(6.1);
-
     try {
       const summaries = await this.exposureNotification.detectExposure(exposureConfiguration, keysFileUrls);
 

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -166,7 +166,6 @@ export class ExposureNotificationService {
   };
 
   initiateExposureCheck = async () => {
-    publishDebugMetric(5.0);
     if (Platform.OS !== 'android') return;
     if (!(await this.shouldPerformExposureCheck())) return;
 


### PR DESCRIPTION
# Summary | Résumé

Improving the debug metrics collection.

-- removing unnecessary `shouldPerformExposureCheck()` calls, since that function will always return **true** when the app is in the background.
-- removing Debug Metric for Step 6.1, as it's not needed.
-- adding extra information in 2 of the debug metric calls.

# Test instructions | Instructions pour tester la modification

Get the app into a state where a background check should perform. Note that the metrics are still uploaded and the exposure check performs properly. Be sure to test when the app is in the task switcher, and when it's been killed altogether.


