### PR TITLE
Feature/more debug metrics adjustments

### DIFF
--- a/android/app/src/main/java/app/covidshield/module/DebugMetricsModule.kt
+++ b/android/app/src/main/java/app/covidshield/module/DebugMetricsModule.kt
@@ -1,7 +1,9 @@
 package app.covidshield.module
 
 import app.covidshield.extensions.launch
+import app.covidshield.services.metrics.DebugMetricsHelper
 import app.covidshield.services.metrics.MetricsService
+import app.covidshield.services.metrics.UniqueDailyDebugMetricsHelper
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
@@ -18,7 +20,19 @@ class DebugMetricsModule(private val context: ReactApplicationContext) : ReactCo
     @ReactMethod
     fun publishDebugMetric(stepNumber: Double, message: String, promise: Promise) {
         promise.launch(this) {
+
             MetricsService.publishDebugMetric(stepNumber, context, message)
+
+            // This is the current final step we have and it is published from the React layer
+            if (stepNumber == 8.0) {
+                DebugMetricsHelper.incrementSuccessfulDailyBackgroundChecks(context)
+
+                if (UniqueDailyDebugMetricsHelper.canPublishMetric("200.3", context)) {
+                    MetricsService.publishDebugMetric(200.3, context)
+                    UniqueDailyDebugMetricsHelper.markMetricAsPublished("200.3", context)
+                }
+            }
+
             promise.resolve(null)
         }
     }

--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckHeadlessTask.java
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckHeadlessTask.java
@@ -99,8 +99,14 @@ public class ExposureCheckHeadlessTask implements HeadlessJsTaskEventListener {
     }
 
     private void invokeStartTask(ReactContext reactContext, final HeadlessJsTaskConfig taskConfig) {
-        if (reactContext.getLifecycleState() == LifecycleState.RESUMED) {
-            MetricsService.publishDebugMetric(3.9, reactContext);
+
+        try {
+            if (reactContext.getLifecycleState() == LifecycleState.RESUMED) {
+                MetricsService.publishDebugMetric(3.9, reactContext);
+                return;
+            }
+        } catch (Exception exception) {
+            MetricsService.publishDebugMetric(109, reactContext, exception.getMessage());
             return;
         }
 

--- a/android/app/src/main/java/app/covidshield/services/metrics/MetricsService.kt
+++ b/android/app/src/main/java/app/covidshield/services/metrics/MetricsService.kt
@@ -54,9 +54,6 @@ object MetricsService {
             return jsonObject
         }
 
-        // This is the current final step we have and it is published from the React layer
-        if (stepNumber == 8.0) DebugMetricsHelper.incrementSuccessfulDailyBackgroundChecks(context)
-
         val lifecycleIdentifier = DebugMetricsHelper.getLifecycleIdentifier()
         val lifecycleDailyCount = DebugMetricsHelper.getLifecycleDailyCount(context)
         val successfulDailyBackgroundChecks = DebugMetricsHelper.getSuccessfulDailyBackgroundChecks(context)


### PR DESCRIPTION
# Summary | Résumé

- Added try/catch in ExposureCheckHeadlessTask with new debug metrics step 109
- Added new debug metrics 200.3 which will only be sent once per UTC day