### PR TITLE
Qr code menu button spacing

### DIFF
--- a/src/screens/menu/views/MenuBar.tsx
+++ b/src/screens/menu/views/MenuBar.tsx
@@ -52,7 +52,7 @@ export const MenuBar = () => {
             </Box>
           ) : (
             <>
-              <Box flex={1} marginRight="m">
+              <Box flex={qrEnabled ? 2 : 1} marginRight="m">
                 {qrEnabled ? <QrButton /> : appStatus}
               </Box>
 

--- a/src/screens/menu/views/MenuBar.tsx
+++ b/src/screens/menu/views/MenuBar.tsx
@@ -8,8 +8,12 @@ import {useCachedStorage} from 'services/StorageService';
 
 import {QrButton} from '../components/QrButton';
 import {MenuButton} from '../components/MenuButton';
+import {Dimensions} from 'react-native';
 
 import {StatusHeaderView} from './StatusHeaderView';
+const windowWidth = Dimensions.get('window').width;
+
+console.log('windowWidth', windowWidth);
 
 const borderRadius = 16;
 
@@ -17,8 +21,11 @@ export const MenuBar = () => {
   const {qrEnabled} = useCachedStorage();
   const [systemStatus] = useSystemStatus();
   const pixelRatio = PixelRatio.getFontScale();
+
+  PixelRatio.getPixelSizeForLayoutSize;
   const statusHeaderPadding = pixelRatio > 1.0 ? 'none' : 'm';
-  const menuButtonPadding = pixelRatio > 1.0 ? 'm' : 'none';
+  const menuButtonPadding = pixelRatio > 1.0 || (qrEnabled && windowWidth <= 320) ? 'm' : 'none';
+
   const {orientation} = useOrientation();
   const safeAreaPadding = orientation === 'landscape' ? -10 : -20;
 
@@ -39,7 +46,7 @@ export const MenuBar = () => {
       <SafeAreaView edges={['bottom']} mode="padding" style={{paddingBottom: safeAreaPadding}}>
         <Box style={styles.box}>
           {/* Stack the menu buttons or place in columns */}
-          {pixelRatio > 1.0 ? (
+          {pixelRatio > 1.0 || (qrEnabled && windowWidth <= 320) ? (
             <Box>
               {qrEnabled ? (
                 <Box paddingVertical="m">

--- a/src/screens/menu/views/MenuBar.tsx
+++ b/src/screens/menu/views/MenuBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {StyleSheet, PixelRatio} from 'react-native';
+import {StyleSheet, PixelRatio, Dimensions} from 'react-native';
 import {Box, Text} from 'components';
 import {SystemStatus, useSystemStatus} from 'services/ExposureNotificationService';
 import {SafeAreaView} from 'react-native-safe-area-context';
@@ -8,12 +8,10 @@ import {useCachedStorage} from 'services/StorageService';
 
 import {QrButton} from '../components/QrButton';
 import {MenuButton} from '../components/MenuButton';
-import {Dimensions} from 'react-native';
 
 import {StatusHeaderView} from './StatusHeaderView';
-const windowWidth = Dimensions.get('window').width;
 
-console.log('windowWidth', windowWidth);
+const windowWidth = Dimensions.get('window').width;
 
 const borderRadius = 16;
 
@@ -22,7 +20,6 @@ export const MenuBar = () => {
   const [systemStatus] = useSystemStatus();
   const pixelRatio = PixelRatio.getFontScale();
 
-  PixelRatio.getPixelSizeForLayoutSize;
   const statusHeaderPadding = pixelRatio > 1.0 ? 'none' : 'm';
   const menuButtonPadding = pixelRatio > 1.0 || (qrEnabled && windowWidth <= 320) ? 'm' : 'none';
 


### PR DESCRIPTION
Updates menu button spacing to give more space for QR code button.

<img width="500" src="https://user-images.githubusercontent.com/62242/115550390-ce3f6080-a277-11eb-8cf6-713e9f79f7b0.png">


Added a width check for small screens i.e. iPhone SE to stack to prevent the "menu" button text wrapping.  Without that check the text it's up being 

```
ME
NU
```
 
<img width="500" src="https://user-images.githubusercontent.com/62242/115553902-e9ac6a80-a27b-11eb-8832-f6f47edb5555.png">



