### PR TITLE
Detect & wrap bold text in strings

### DIFF
--- a/src/components/TextMultiline.tsx
+++ b/src/components/TextMultiline.tsx
@@ -5,15 +5,39 @@ import {Theme} from 'shared/theme/default';
 
 interface TextMultilineProps extends TextProps<Theme> {
   text: string;
+  detectBold?: boolean;
 }
 
-export const TextMultiline = ({text, ...props}: TextMultilineProps) => {
+export const boldText = (input: string) => {
+  const boldPattern = /\*\*(.*?)\*\*/gm;
+  const textSplit = input.split(boldPattern);
+
+  /* no match just return */
+  if (textSplit.length < 3) return input;
+
+  /* wrap Text element if it's "the middle" item i.e. index 1*/
+  return (
+    <>
+      {textSplit.map((t, index) =>
+        index === 1 ? (
+          <Text key={t} fontWeight="bold">
+            {t}
+          </Text>
+        ) : (
+          t
+        ),
+      )}
+    </>
+  );
+};
+
+export const TextMultiline = ({text, detectBold, ...props}: TextMultilineProps) => {
   const textSplit = text.split(/\n\n/g);
   return (
     <>
       {textSplit.map(t => (
         <Text key={t} {...props}>
-          {t}
+          {detectBold ? boldText(t) : t}
         </Text>
       ))}
     </>

--- a/src/screens/qr/onboarding/views/ItemView.tsx
+++ b/src/screens/qr/onboarding/views/ItemView.tsx
@@ -16,6 +16,8 @@ export const ItemView = ({item, image, isActive}: ItemViewProps) => {
   const i18n = useI18n();
   const autoFocusRef = useAccessibilityAutoFocus(isActive);
 
+  const text = i18n.translate(`QRCodeOnboarding.${item}`);
+
   return (
     <>
       <Box marginHorizontal="-m" marginTop="s" marginBottom="l" borderBottomWidth={2} borderBottomColor="gray5">
@@ -30,12 +32,7 @@ export const ItemView = ({item, image, isActive}: ItemViewProps) => {
       <Text variant="bodyTitle" color="overlayBodyText" marginBottom="l" accessible accessibilityRole="header">
         {i18n.translate(`QRCodeOnboarding.${item}Title`)}
       </Text>
-      <TextMultiline
-        text={i18n.translate(`QRCodeOnboarding.${item}`)}
-        variant="bodyText"
-        color="overlayBodyText"
-        marginBottom="l"
-      />
+      <TextMultiline detectBold text={text} variant="bodyText" color="overlayBodyText" marginBottom="l" />
     </>
   );
 };


### PR DESCRIPTION
There's a few places in the app that use `bold` text.

Previously we has to break the strings apart to handle bold text

Example:

<img width="200" src="https://user-images.githubusercontent.com/62242/115768840-d501cc80-a378-11eb-90ee-5edbb394ff24.png">

<img width="500" alt="Screen Shot 2021-04-22 at 2 40 00 PM" src="https://user-images.githubusercontent.com/62242/115768815-ca473780-a378-11eb-8d74-de5c1945a3fb.png">

This PR makes an update to allow wrapping text in `**your text**` to create bold text when using TextMultiline

```javascript 
<TextMultiline detectBold text={text} variant="bodyText" color="overlayBodyText" marginBottom="l" />
```

I added a property detectBold to avoid processing all text given bold isn't used very often.


 
## Testing

@omartehsin1 
QR code onboarding 

Update the text on this screen (use `**your text**` format in the en locale file) +  generate the translations

<img width="300" alt="Screen Shot 2021-04-22 at 2 37 03 PM" src="https://user-images.githubusercontent.com/62242/115769274-5a857c80-a379-11eb-9fcb-bd0259443741.png">
