### PR TITLE
Fix crash when reloading no visits screen after closing the app

### DIFF
--- a/src/screens/qr/CheckInHistoryScreen.tsx
+++ b/src/screens/qr/CheckInHistoryScreen.tsx
@@ -139,7 +139,7 @@ export const CheckInHistoryScreen = () => {
             </Text>
           </Box>
 
-          {checkInHistory.length === 0 ? (
+          {!checkInHistory.length || checkInHistory.length === 0 ? (
             <NoVisitsScreen />
           ) : (
             <>

--- a/src/screens/qr/utils.ts
+++ b/src/screens/qr/utils.ts
@@ -113,6 +113,9 @@ interface GroupedCheckInData {
 
 export const sortedCheckInArray = (checkIns: CheckInData[]) => {
   const sortedArray: GroupedCheckInData[] = [];
+
+  if (!checkIns.length) return [];
+
   const sortedCheckIn = checkIns.sort(function (first, second) {
     return second.timestamp - first.timestamp;
   });


### PR DESCRIPTION
In the last test release scanning a code and closing the app + going to your visits was crashing the app.

This was caused by a number vs an array coming back the value for checkins.

This PR adds some guards to prevent that.  

@jeberhardt separately we'll need to test if pulling visits from storage after closing the app is working properly.

<img width="174" alt="Screen Shot 2021-04-29 at 3 31 16 PM" src="https://user-images.githubusercontent.com/62242/116608120-d004c600-a900-11eb-9be1-134a15ffb3a9.png">
 