### PR TITLE
Add guard for severity text

### DIFF
--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -14,7 +14,7 @@ export const OutbreakExposedView = () => {
   const {outbreakHistory} = useOutbreakService();
   const currentOutbreakHistory = getCurrentOutbreakHistory(outbreakHistory);
   const mostRecentHistoryItem = currentOutbreakHistory[0];
-  const severity = mostRecentHistoryItem.severity;
+  const severity = mostRecentHistoryItem?.severity;
 
   return (
     <BaseHomeView iconName="hand-caution-yellow" testID="outbreakExposure">


### PR DESCRIPTION
Given an app in an outbreak state pressing negative test + confirming was throwing an error given a property that wasn't available.

<img src="https://user-images.githubusercontent.com/62242/116609286-34745500-a902-11eb-8ada-448e75e425df.png" width="400"> 

