### PR TITLE
Outbreak screen now only over-rides the proximity exposed screen if it is more recent

### DIFF
--- a/src/screens/home/HomeScreen.tsx
+++ b/src/screens/home/HomeScreen.tsx
@@ -18,7 +18,7 @@ import {RegionCase} from 'shared/Region';
 import {getRegionCase} from 'shared/RegionLogic';
 import {ForceScreen} from 'shared/ForceScreen';
 import {useRegionalI18n} from 'locale';
-import {isExposedToOutbreak} from 'shared/qr';
+import {getCurrentOutbreakHistory, isExposedToOutbreak} from 'shared/qr';
 import {useOutbreakService} from 'services/OutbreakService';
 import {useNotificationPermissionStatus} from 'shared/NotificationPermissionStatus';
 
@@ -47,7 +47,7 @@ const UploadShareView = ({hasShared}: {hasShared?: boolean}) => {
 };
 
 const Content = () => {
-  const {region, userStopped} = useCachedStorage();
+  const {region, userStopped, qrEnabled} = useCachedStorage();
 
   const regionalI18n = useRegionalI18n();
   const regionCase = getRegionCase(region, regionalI18n.activeRegions);
@@ -95,10 +95,6 @@ const Content = () => {
     }
   }
 
-  if (isExposedToOutbreak(outbreakHistory)) {
-    return <OutbreakExposedView />;
-  }
-
   if (userStopped && systemStatus !== SystemStatus.Active) {
     return <ExposureNotificationsUserStoppedView />;
   }
@@ -112,6 +108,19 @@ const Content = () => {
       return <ExposureNotificationsDisabledView />;
     case SystemStatus.PlayServicesNotAvailable:
       return <FrameworkUnavailableView />;
+  }
+
+  if (qrEnabled && isExposedToOutbreak(outbreakHistory)) {
+    if (exposureStatus.type === ExposureStatusType.Monitoring) {
+      return <OutbreakExposedView />;
+    } else if (exposureStatus.type === ExposureStatusType.Exposed) {
+      const currentOutbreakHistory = getCurrentOutbreakHistory(outbreakHistory);
+      const outbreakTimestamp = currentOutbreakHistory[currentOutbreakHistory.length - 1].checkInTimestamp;
+      const proximityTimestamp = exposureStatus.summary.lastExposureTimestamp;
+      if (outbreakTimestamp > proximityTimestamp) {
+        return <OutbreakExposedView />;
+      }
+    }
   }
 
   switch (exposureStatus.type) {


### PR DESCRIPTION
# Summary | Résumé

I did a few things here:
- put the `OutbreakExposedView` behind the `qrEnabled` flag
- moved the priority of the `OutbreakExposedView` down to be the same as the proximity based exposed screen. This means that certain system statuses, and if the app is turned off, will take priority
- if we are already diagnosed, don't show the `OutbreakExposedView`
- if there is a proximity based exposure and an outbreak exposure, only show the outbreak exposure if it was more recent