### PR TITLE
Fixed the QR scanning screen mask for landscape

### DIFF
--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -47,7 +47,7 @@ export const QRCodeScanner = () => {
           style={styles.info}
           paddingVertical="s"
           paddingHorizontal="m"
-          height={orientation === 'landscape' ? 40 : '40%'}
+          height={orientation === 'landscape' ? 40 : '25%'}
         >
           <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
             {i18n.translate(`QRCode.Reader.Title`)}

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -7,12 +7,14 @@ import {useI18n} from 'locale';
 import {useNavigation} from '@react-navigation/native';
 import {log} from 'shared/logging/config';
 import {useOutbreakService} from 'services/OutbreakService';
+import {useOrientation} from 'shared/useOrientation';
 
 import {handleOpenURL} from '../utils';
 
 export const QRCodeScanner = () => {
   const navigation = useNavigation();
   const {addCheckIn} = useOutbreakService();
+  const {orientation} = useOrientation();
   const [scanned, setScanned] = useState<boolean>(false);
 
   const i18n = useI18n();
@@ -41,7 +43,7 @@ export const QRCodeScanner = () => {
           <Toolbar2 navText={i18n.translate('DataUpload.Close')} useWhiteText onIconClicked={close} showBackButton />
         </Box>
 
-        <Box style={styles.info} paddingTop="s" paddingHorizontal="m">
+        <Box style={styles.info} paddingTop="s" paddingHorizontal="m" height={orientation === 'landscape' ? 30 : '40%'}>
           <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
             {i18n.translate(`QRCode.Reader.Title`)}
           </Text>
@@ -64,7 +66,9 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
     width: '100%',
-    paddingBottom: '40%',
+    // paddingBottom: '50%',
+    // height: '40%',
+    // flex: 1,
   },
   toolbar: {
     backgroundColor: 'black',

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -43,7 +43,12 @@ export const QRCodeScanner = () => {
           <Toolbar2 navText={i18n.translate('DataUpload.Close')} useWhiteText onIconClicked={close} showBackButton />
         </Box>
 
-        <Box style={styles.info} paddingTop="s" paddingHorizontal="m" height={orientation === 'landscape' ? 30 : '40%'}>
+        <Box
+          style={styles.info}
+          paddingVertical="s"
+          paddingHorizontal="m"
+          height={orientation === 'landscape' ? 40 : '40%'}
+        >
           <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
             {i18n.translate(`QRCode.Reader.Title`)}
           </Text>
@@ -66,9 +71,6 @@ const styles = StyleSheet.create({
     left: 0,
     position: 'absolute',
     width: '100%',
-    // paddingBottom: '50%',
-    // height: '40%',
-    // flex: 1,
   },
   toolbar: {
     backgroundColor: 'black',


### PR DESCRIPTION
# Summary | Résumé

Landscape:
<img width="621" alt="Screen Shot 2021-04-29 at 4 07 07 PM" src="https://user-images.githubusercontent.com/5498428/116624334-017f9080-a905-11eb-8086-25d1ecc62ca9.png">

Portrait:
<img width="351" alt="Screen Shot 2021-04-29 at 4 06 44 PM" src="https://user-images.githubusercontent.com/5498428/116624348-080e0800-a905-11eb-945c-69d6b4193a61.png">
