### PR TITLE
Add maxFontSizeMultiplier for buttons 

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -111,7 +111,10 @@ export const Button = ({
             </Box>
           )}
 
-          <Text style={{...styles.content, color: textColor || buttonColor, fontWeight, fontFamily, fontSize}}>
+          <Text
+            maxFontSizeMultiplier={1.5}
+            style={{...styles.content, color: textColor || buttonColor, fontWeight, fontFamily, fontSize}}
+          >
             {text}
           </Text>
           <Box style={{...styles.chevronOffset}}>


### PR DESCRIPTION
This fixes some Toolbar issues but is applied to all buttons.

## Before

<img width="300" src="https://user-images.githubusercontent.com/62242/116697275-f8d49c00-a990-11eb-9679-ed0d060c0735.PNG"> <img width="300" src="https://user-images.githubusercontent.com/62242/116697287-fd00b980-a990-11eb-8af6-8c5b065ccc7a.png">

## After

<img width="300" src="https://user-images.githubusercontent.com/62242/116697519-451fdc00-a991-11eb-9ca8-1ba61cfa7563.png"> <img width="300" src="https://user-images.githubusercontent.com/62242/116697510-42bd8200-a991-11eb-9e77-c939dc503164.png">






