### PR TITLE
Autofocus titles in QR pages

### DIFF
--- a/src/screens/qr/CheckInHistoryScreen.tsx
+++ b/src/screens/qr/CheckInHistoryScreen.tsx
@@ -127,7 +127,7 @@ export const CheckInHistoryScreen = () => {
         <Toolbar title="" navIcon="icon-back-arrow" navText={i18n.translate('PlacesLog.Back')} onIconClicked={back} />
         <ScrollView style={styles.flex}>
           <Box paddingHorizontal="m">
-            <Text variant="bodyTitle" marginBottom="l" accessibilityRole="header">
+            <Text variant="bodyTitle" marginBottom="l" accessibilityRole="header" accessibilityAutoFocus>
               {i18n.translate('PlacesLog.Title')}
             </Text>
             <Text>{i18n.translate('PlacesLog.Body1')}</Text>

--- a/src/screens/qr/ExposureHistoryScreen.tsx
+++ b/src/screens/qr/ExposureHistoryScreen.tsx
@@ -142,7 +142,7 @@ export const ExposureHistoryScreen = () => {
         <Toolbar title="" navIcon="icon-back-arrow" navText={i18n.translate('PlacesLog.Back')} onIconClicked={back} />
         <ScrollView style={styles.flex}>
           <Box paddingHorizontal="m" paddingBottom="m">
-            <Text variant="bodyTitle" marginBottom="l" accessibilityRole="header">
+            <Text variant="bodyTitle" marginBottom="l" accessibilityRole="header" accessibilityAutoFocus>
               {i18n.translate('ExposureHistory.Title')}
             </Text>
             <Text>{i18n.translate('ExposureHistory.Body')}</Text>


### PR DESCRIPTION
# Summary | Résumé

This change makes these pages behave like all our other pages, where the title gets focus when the page is opened.