### PR TITLE
Add the correct schema for detox ios tests.

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -5,7 +5,7 @@
     "ios": {
       "type": "ios.simulator",
       "binaryPath": "./ios/build/Build/Products/Debug-iphonesimulator/CovidShield.app",
-      "build": "xcodebuild -workspace ios/CovidShield.xcworkspace -scheme CovidShield -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
+      "build": "xcodebuild -workspace ios/CovidShield.xcworkspace -scheme Staging -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
       "device": {
         "type": "iPhone 8"
       }


### PR DESCRIPTION
# Summary | Résumé

See #1519.  Along the way, the iOS schemas were updated, breaking the run-ios yarn command. That was fixed, allowing the ios simulator to be run from yarn. However the ios test commands in `detoxrc.config` were unchanged and thus Detox ios tests still failed. This PR targets the correct schema for local ios Detox testing.

# Test instructions | Instructions pour tester la modification

Load the project, and execute any detox test like `detox test e2e/exploreDemoMenu.e2e.js --configuration=ios` The iOS simulator should launch and tests should complete succesfully.