### PR TITLE
Add perm for upcoming QR feature

### DIFF
--- a/ios/CovidShield/Info.plist
+++ b/ios/CovidShield/Info.plist
@@ -62,6 +62,8 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>COVID Alert needs access to your camera so it can read the QR code.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Allow $(PRODUCT_NAME) to use the microphone</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Adding the microphone permission back - without this permission the code won't show the Camera prompt.  


```
"message":"An exception was thrown while calling `ExpoBarCodeScannerModule.requestPermissionsAsync` with arguments `(\n)`: This app is missing either 'NSCameraUsageDescription' or 'NSMicrophoneUsageDescription', so audio/video services will fail. Add both of these entries to your bundle's Info.pli..."}
```

See:
https://github.com/expo/expo/issues/11736