### PR TITLE
Do not display a period in the formatted exposed date if the month is not an abbreviation

### DIFF
--- a/src/shared/date-fns.spec.ts
+++ b/src/shared/date-fns.spec.ts
@@ -157,6 +157,7 @@ describe('date-fns', () => {
   describe('formatExposedDate', () => {
     it('returns formatted date for en and fr', () => {
       expect(formatExposedDate(new Date(1605814310000), 'en-CA')).toStrictEqual('Nov.\u00a019,\u00a02020');
+      expect(formatExposedDate(new Date(1620073771003), 'en-CA')).toStrictEqual('May\u00a03,\u00a02021');
       // the following test fails in CI for some reason
       // expect(formatExposedDate(new Date(1605814310000), 'fr-CA')).toStrictEqual('19\u00a0nov.\u00a02020');
     });

--- a/src/shared/date-fns.ts
+++ b/src/shared/date-fns.ts
@@ -85,15 +85,19 @@ export const formatExposedDate = (date: Date, locale: string) => {
     year: 'numeric',
   };
   const _formattedDate = date.toLocaleString(locale, dateFormatOptions);
+  const _formattedDateLong = date.toLocaleString(locale, {...dateFormatOptions, month: 'long'});
   const parts = _formattedDate.split(' ');
   const year = parts[2];
-
   // @note \u00a0 is a non breaking space so the date doesn't wrap
   // remove non-alpha chars from month
   if (locale === 'en-CA') {
-    const month = parts[0].replace(/\W/g, '');
+    const shortMonth = parts[0].replace(/\W/g, '');
+    const longMonth = _formattedDateLong.split(' ')[0].replace(/\W/g, '');
     const day = parts[1];
-    return `${month}.\u00a0${day}\u00a0${year}`;
+    if (longMonth === shortMonth) {
+      return `${shortMonth}\u00a0${day}\u00a0${year}`;
+    }
+    return `${shortMonth}.\u00a0${day}\u00a0${year}`;
   } else if (locale === 'fr-CA') {
     const month = parts[1].replace(/\W/g, '');
     const day = parts[0];


### PR DESCRIPTION
# Summary | Résumé

Before: 
<img width="332" alt="Screen Shot 2021-05-03 at 2 40 40 PM" src="https://user-images.githubusercontent.com/5498428/116932680-cd1b1580-ac1f-11eb-99a7-53c48d0896f8.png">

After:
<img width="329" alt="Screen Shot 2021-05-03 at 2 41 07 PM" src="https://user-images.githubusercontent.com/5498428/116932691-d1473300-ac1f-11eb-8727-29e7709c98e3.png">
