### PR TITLE
Feature/proximity dates

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -80,7 +80,7 @@ export interface MainStackParamList extends Record<string, object | undefined> {
   Tutorial: undefined;
   QROnboard: undefined;
   RegionSelectExposedNoPT: {drawerMenu: boolean} | undefined;
-  RecentExposureScreen: {locationId?: string; timestamp: number; exposureType: ExposureType};
+  RecentExposureScreen: {timestamp: number; exposureType: ExposureType};
 }
 const LandingScreenWithNavBar = withDarkNav(LandingScreen);
 const HomeScreenWithNavBar = withDarkNav(HomeScreen);

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -80,7 +80,7 @@ export interface MainStackParamList extends Record<string, object | undefined> {
   Tutorial: undefined;
   QROnboard: undefined;
   RegionSelectExposedNoPT: {drawerMenu: boolean} | undefined;
-  RecentExposureScreen: {id: string; exposureType: ExposureType};
+  RecentExposureScreen: {locationId?: string; timestamp: number; exposureType: ExposureType};
 }
 const LandingScreenWithNavBar = withDarkNav(LandingScreen);
 const HomeScreenWithNavBar = withDarkNav(HomeScreen);

--- a/src/screens/exposureHistory/ExposureHistoryScreen.tsx
+++ b/src/screens/exposureHistory/ExposureHistoryScreen.tsx
@@ -38,7 +38,7 @@ const toOutbreakExposureHistoryData = ({
 }): CombinedExposureHistoryData[] => {
   return history.map(outbreak => {
     return {
-      id: outbreak.locationId,
+      locationId: outbreak.locationId,
       type: ExposureType.Outbreak,
       subtitle: severityText({severity: Number(outbreak.severity), i18n}),
       timestamp: outbreak.checkInTimestamp,
@@ -47,18 +47,17 @@ const toOutbreakExposureHistoryData = ({
 };
 
 const toProximityExposureHistoryData = ({
-  history,
+  proximityExposureTimestamps,
   i18n,
 }: {
-  history: number[];
+  proximityExposureTimestamps: number[];
   i18n: I18n;
 }): CombinedExposureHistoryData[] => {
-  return history.map(outbreak => {
+  return proximityExposureTimestamps.map(timestamp => {
     return {
-      id: outbreak,
       type: ExposureType.Proximity,
       subtitle: i18n.translate('QRCode.ProximityExposure'),
-      timestamp: outbreak,
+      timestamp,
     };
   });
 };
@@ -68,10 +67,10 @@ export const ExposureHistoryScreen = () => {
   const outbreaks = useOutbreakService();
   const [clearExposedStatus] = useClearExposedStatus();
   const currentOutbreakHistory = getCurrentOutbreakHistory(outbreaks.outbreakHistory);
-  const proximityExposure = useExposureHistory();
+  const proximityExposureTimestamps = useExposureHistory();
   const mergedArray = [
     ...toOutbreakExposureHistoryData({history: currentOutbreakHistory, i18n}),
-    ...toProximityExposureHistoryData({history: proximityExposure, i18n}),
+    ...toProximityExposureHistoryData({proximityExposureTimestamps, i18n}),
   ];
   const clearProximityExposure = useCallback(() => {
     clearExposedStatus();

--- a/src/screens/exposureHistory/ExposureHistoryScreen.tsx
+++ b/src/screens/exposureHistory/ExposureHistoryScreen.tsx
@@ -38,8 +38,7 @@ const toOutbreakExposureHistoryData = ({
 }): CombinedExposureHistoryData[] => {
   return history.map(outbreak => {
     return {
-      locationId: outbreak.locationId,
-      type: ExposureType.Outbreak,
+      exposureType: ExposureType.Outbreak,
       subtitle: severityText({severity: Number(outbreak.severity), i18n}),
       timestamp: outbreak.checkInTimestamp,
     };
@@ -55,7 +54,7 @@ const toProximityExposureHistoryData = ({
 }): CombinedExposureHistoryData[] => {
   return proximityExposureTimestamps.map(timestamp => {
     return {
-      type: ExposureType.Proximity,
+      exposureType: ExposureType.Proximity,
       subtitle: i18n.translate('QRCode.ProximityExposure'),
       timestamp,
     };

--- a/src/screens/exposureHistory/RecentExposureView.tsx
+++ b/src/screens/exposureHistory/RecentExposureView.tsx
@@ -15,11 +15,11 @@ type RecentExposureScreenProps = RouteProp<MainStackParamList, 'RecentExposureSc
 
 const ExposureView = () => {
   const route = useRoute<RecentExposureScreenProps>();
-  if (route.params?.locationId || route.params.exposureType === ExposureType.Outbreak) {
-    return <OutbreakExposedView locationId={route.params.locationId} />;
+  if (route.params.exposureType === ExposureType.Outbreak) {
+    return <OutbreakExposedView timestamp={route.params.timestamp} />;
   }
   if (route.params.exposureType === ExposureType.Proximity) {
-    return <ProximityExposureView />;
+    return <ProximityExposureView timestamp={route.params.timestamp} />;
   }
   return null;
 };

--- a/src/screens/exposureHistory/RecentExposureView.tsx
+++ b/src/screens/exposureHistory/RecentExposureView.tsx
@@ -15,12 +15,8 @@ type RecentExposureScreenProps = RouteProp<MainStackParamList, 'RecentExposureSc
 
 const ExposureView = () => {
   const route = useRoute<RecentExposureScreenProps>();
-  if (!route.params?.id || !route.params?.exposureType) {
-    return null;
-  }
-  const id = route.params.id;
-  if (route.params.exposureType === ExposureType.Outbreak) {
-    return <OutbreakExposedView id={id} />;
+  if (route.params?.locationId || route.params.exposureType === ExposureType.Outbreak) {
+    return <OutbreakExposedView locationId={route.params.locationId} />;
   }
   if (route.params.exposureType === ExposureType.Proximity) {
     return <ProximityExposureView />;

--- a/src/screens/exposureHistory/views/ExposureList.tsx
+++ b/src/screens/exposureHistory/views/ExposureList.tsx
@@ -11,8 +11,7 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
   const navigation = useNavigation();
   const onDetails = useCallback(
-    ({locationId, timestamp, exposureType}) =>
-      navigation.navigate('RecentExposureScreen', {locationId, timestamp, exposureType}),
+    ({timestamp, exposureType}) => navigation.navigate('RecentExposureScreen', {timestamp, exposureType}),
     [navigation],
   );
   exposureHistoryData.sort(function (first, second) {
@@ -29,14 +28,14 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
                 <TouchableOpacity
                   style={styles.chevronIcon}
                   onPress={() => {
-                    onDetails({locationId: item.locationId, timestamp: item.timestamp, exposureType: item.type});
+                    onDetails({timestamp: item.timestamp, exposureType: item.exposureType});
                   }}
                 >
                   <Box paddingVertical="m" style={styles.exposureList}>
                     <Box style={styles.typeIconBox}>
                       <Icon
                         size={20}
-                        name={item.type === ExposureType.Proximity ? 'exposure-proximity' : 'exposure-outbreak'}
+                        name={item.exposureType === ExposureType.Proximity ? 'exposure-proximity' : 'exposure-outbreak'}
                       />
                     </Box>
                     <Box style={styles.boxFlex}>

--- a/src/screens/exposureHistory/views/ExposureList.tsx
+++ b/src/screens/exposureHistory/views/ExposureList.tsx
@@ -11,7 +11,8 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
   const navigation = useNavigation();
   const onDetails = useCallback(
-    ({id, exposureType}) => navigation.navigate('RecentExposureScreen', {id, exposureType}),
+    ({locationId, timestamp, exposureType}) =>
+      navigation.navigate('RecentExposureScreen', {locationId, timestamp, exposureType}),
     [navigation],
   );
   exposureHistoryData.sort(function (first, second) {
@@ -28,7 +29,7 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
                 <TouchableOpacity
                   style={styles.chevronIcon}
                   onPress={() => {
-                    onDetails({id: `${item.id}-${item.timestamp}`, exposureType: item.type});
+                    onDetails({locationId: item.locationId, timestamp: item.timestamp, exposureType: item.type});
                   }}
                 >
                   <Box paddingVertical="m" style={styles.exposureList}>

--- a/src/screens/home/views/ExposureDateView.tsx
+++ b/src/screens/home/views/ExposureDateView.tsx
@@ -7,7 +7,7 @@ import {ForceScreen} from 'shared/ForceScreen';
 import {useCachedStorage} from 'services/StorageService';
 import {log} from 'shared/logging/config';
 
-export const ExposureDateView = () => {
+export const ExposureDateView = ({timestamp}: {timestamp?: number}) => {
   const i18n = useI18n();
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
   const {forceScreen} = useCachedStorage();
@@ -18,10 +18,13 @@ export const ExposureDateView = () => {
     if (forceScreen && forceScreen !== ForceScreen.None) {
       return [getCurrentDate()];
     }
+    if (timestamp) {
+      return [new Date(timestamp)];
+    }
     const _dates = exposureNotificationService.getExposureDetectedAt();
     log.debug({message: '_dates', payload: {_dates}});
     return _dates;
-  }, [exposureNotificationService, forceScreen]);
+  }, [exposureNotificationService, forceScreen, timestamp]);
 
   const formattedDates = dates.map(date => {
     return formatExposedDate(date, dateLocale);

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -10,7 +10,7 @@ import {HomeScreenTitle} from '../components/HomeScreenTitle';
 
 import {NegativeOutbreakTestButton} from './ClearOutbreakExposureView';
 
-export const OutbreakExposedView = ({id}: {id?: string}) => {
+export const OutbreakExposedView = ({locationId, timestamp}: {locationId?: string; timestamp?: number}) => {
   const i18n = useI18n();
   const {outbreakHistory} = useOutbreakService();
   const currentOutbreakHistory = getCurrentOutbreakHistory(outbreakHistory);
@@ -18,9 +18,9 @@ export const OutbreakExposedView = ({id}: {id?: string}) => {
 
   let historyItem: OutbreakHistoryItem = currentOutbreakHistory[0];
 
-  if (id) {
+  if (locationId && timestamp) {
     currentOutbreakHistory.forEach(item => {
-      if (item.outbreakId === id) {
+      if (item.locationId === locationId && item.checkInTimestamp === timestamp) {
         historyItem = item;
       }
     });
@@ -30,7 +30,7 @@ export const OutbreakExposedView = ({id}: {id?: string}) => {
   const exposureDate = formatExposedDate(new Date(historyItem?.checkInTimestamp), dateLocale);
   let props = {};
 
-  if (id) {
+  if (locationId && timestamp) {
     props = {header: false};
   }
 

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -10,7 +10,7 @@ import {HomeScreenTitle} from '../components/HomeScreenTitle';
 
 import {NegativeOutbreakTestButton} from './ClearOutbreakExposureView';
 
-export const OutbreakExposedView = ({locationId, timestamp}: {locationId?: string; timestamp?: number}) => {
+export const OutbreakExposedView = ({timestamp}: {timestamp?: number}) => {
   const i18n = useI18n();
   const {outbreakHistory} = useOutbreakService();
   const currentOutbreakHistory = getCurrentOutbreakHistory(outbreakHistory);
@@ -18,9 +18,9 @@ export const OutbreakExposedView = ({locationId, timestamp}: {locationId?: strin
 
   let historyItem: OutbreakHistoryItem = currentOutbreakHistory[0];
 
-  if (locationId && timestamp) {
+  if (timestamp) {
     currentOutbreakHistory.forEach(item => {
-      if (item.locationId === locationId && item.checkInTimestamp === timestamp) {
+      if (item.checkInTimestamp === timestamp) {
         historyItem = item;
       }
     });
@@ -30,7 +30,7 @@ export const OutbreakExposedView = ({locationId, timestamp}: {locationId?: strin
   const exposureDate = formatExposedDate(new Date(historyItem?.checkInTimestamp), dateLocale);
   let props = {};
 
-  if (locationId && timestamp) {
+  if (timestamp) {
     props = {header: false};
   }
 

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -28,11 +28,7 @@ export const OutbreakExposedView = ({timestamp}: {timestamp?: number}) => {
 
   const severity = historyItem?.severity;
   const exposureDate = formatExposedDate(new Date(historyItem?.checkInTimestamp), dateLocale);
-  let props = {};
-
-  if (timestamp) {
-    props = {header: false};
-  }
+  const props = timestamp ? {header: false} : {};
 
   return (
     <BaseHomeView iconName="hand-caution-yellow" testID="outbreakExposure" {...props}>

--- a/src/screens/home/views/ProximityExposureView.tsx
+++ b/src/screens/home/views/ProximityExposureView.tsx
@@ -19,7 +19,7 @@ const ActiveContent = ({text}: {text: string}) => {
   return <Text marginBottom="m">{text}</Text>;
 };
 
-const ExposureText = () => {
+const ExposureText = ({timestamp}: {timestamp?: number}) => {
   const {region} = useCachedStorage();
   const regionalI18n = useRegionalI18n();
   const regionActive = isRegionActive(region, regionalI18n.activeRegions);
@@ -32,7 +32,7 @@ const ExposureText = () => {
         <Text testID="bodyText" marginBottom="m">
           {i18n.translate('Home.ExposureDetected.Body1')}
         </Text>
-        <ExposureDateView />
+        <ExposureDateView timestamp={timestamp} />
       </RoundedBox>
 
       <RoundedBox isFirstBox={false}>
@@ -53,10 +53,10 @@ const ExposureText = () => {
   );
 };
 
-export const ProximityExposureView = () => {
+export const ProximityExposureView = ({timestamp}: {timestamp?: number}) => {
   return (
     <BaseHomeView iconName="hand-caution" testID="exposure">
-      <ExposureText />
+      <ExposureText timestamp={timestamp} />
     </BaseHomeView>
   );
 };

--- a/src/screens/home/views/ProximityExposureView.tsx
+++ b/src/screens/home/views/ProximityExposureView.tsx
@@ -54,8 +54,9 @@ const ExposureText = ({timestamp}: {timestamp?: number}) => {
 };
 
 export const ProximityExposureView = ({timestamp}: {timestamp?: number}) => {
+  const props = timestamp ? {header: false} : {};
   return (
-    <BaseHomeView iconName="hand-caution" testID="exposure">
+    <BaseHomeView iconName="hand-caution" testID="exposure" {...props}>
       <ExposureText timestamp={timestamp} />
     </BaseHomeView>
   );

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -61,9 +61,8 @@ export interface OutbreakHistoryItem {
 }
 
 export interface CombinedExposureHistoryData {
-  locationId?: string;
   timestamp: number;
-  type: ExposureType;
+  exposureType: ExposureType;
   subtitle: string;
 }
 

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -61,7 +61,7 @@ export interface OutbreakHistoryItem {
 }
 
 export interface CombinedExposureHistoryData {
-  id?: string | number;
+  locationId?: string;
   timestamp: number;
   type: ExposureType;
   subtitle: string;


### PR DESCRIPTION
# Summary | Résumé

Here's what I did:
- Only display one date in the RecentExposureScreen for proximity exposures
- Remove covid alert header from the RecentExposureScreen for proximity exposures
- Simplify the way lookup is done for the RecentExposureScreen. Instead of using a locationId and timestamp, just use a timestamp since this works both for proximity and outbreaks. For outbreaks the timestamp is the check in time, for proximity the timestamp is the notification time