### PR TITLE
Update state to refresh content on home screen.

### DIFF
--- a/src/screens/home/views/ClearOutbreakExposureView.tsx
+++ b/src/screens/home/views/ClearOutbreakExposureView.tsx
@@ -1,18 +1,21 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {ScrollView, Alert, StyleSheet} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {Text, Box, Button, ButtonSingleLine, Toolbar} from 'components';
 import {useNavigation} from '@react-navigation/native';
 import {useOutbreakService} from 'services/OutbreakService';
 import {useI18n} from 'locale';
+import {getCurrentDate} from 'shared/date-fns';
 
 export const ClearOutbreakExposureScreen = () => {
+  const [state, setState] = useState(ClearOutbreakExposureViewState);
   const navigation = useNavigation();
   const close = useCallback(() => navigation.goBack(), [navigation]);
   const {clearOutbreakHistory} = useOutbreakService();
   const onClearOutbreak = useCallback(async () => {
     clearOutbreakHistory();
-  }, [clearOutbreakHistory]);
+    setState({...state, exposureHistoryClearedDate: getCurrentDate()});
+  }, [clearOutbreakHistory, state]);
   const onClearOutbreakExposed = useCallback(() => {
     Alert.alert('Are you sure you want to clear outbreak exposure history?', undefined, [
       {
@@ -71,3 +74,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
 });
+
+const ClearOutbreakExposureViewState = {
+  exposureHistoryClearedDate: getCurrentDate(),
+};


### PR DESCRIPTION
# Summary | Résumé

This updates the state to force a re-render on the home screen.

# Test instructions | Instructions pour tester la modification

Scan a QR code that will trigger an Outbreak Exposure. From the home screen, select the button for "Negative Test".  Then select the button to clear the outbreak exposures, and return to home screen. You should now see the "You're all set" message.
