### PR TITLE
Design changes to outbreak exposed screen and exposure history screen

### DIFF
--- a/src/screens/exposureHistory/views/ExposureList.tsx
+++ b/src/screens/exposureHistory/views/ExposureList.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback} from 'react';
 import {StyleSheet, TouchableOpacity} from 'react-native';
 import {useI18n} from 'locale';
-import {CombinedExposureHistoryData, ExposureType} from 'shared/qr';
+import {CombinedExposureHistoryData} from 'shared/qr';
 import {useNavigation} from '@react-navigation/native';
 import {Box, Text, Icon} from 'components';
 import {formatExposedDate} from 'shared/date-fns';

--- a/src/screens/exposureHistory/views/ExposureList.tsx
+++ b/src/screens/exposureHistory/views/ExposureList.tsx
@@ -17,13 +17,21 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
   exposureHistoryData.sort(function (first, second) {
     return second.timestamp - first.timestamp;
   });
+  const getRadiusStyle = (index: number) => {
+    if (index === 0) {
+      return styles.radiusTop;
+    }
+    if (index === exposureHistoryData.length - 1) {
+      return styles.radiusBottom;
+    }
+  };
 
   return (
     <>
       {exposureHistoryData.map((item, index) => {
         return (
           <Box key={item.timestamp}>
-            <Box backgroundColor="gray5" style={styles.radius}>
+            <Box backgroundColor="gray5" style={getRadiusStyle(index)}>
               <Box paddingHorizontal="m" style={[exposureHistoryData.length !== index + 1 && styles.bottomBorder]}>
                 <TouchableOpacity
                   style={styles.chevronIcon}
@@ -32,17 +40,11 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
                   }}
                 >
                   <Box paddingVertical="m" style={styles.exposureList}>
-                    <Box style={styles.typeIconBox}>
-                      <Icon
-                        size={20}
-                        name={item.exposureType === ExposureType.Proximity ? 'exposure-proximity' : 'exposure-outbreak'}
-                      />
-                    </Box>
                     <Box style={styles.boxFlex}>
                       <Text fontWeight="bold">{formatExposedDate(new Date(item.timestamp), dateLocale)}</Text>
                       <Text>{item.subtitle}</Text>
                     </Box>
-                    <Box style={styles.chevronIconBox}>
+                    <Box style={styles.chevronIconBox} paddingRight="s">
                       <Icon size={30} name="icon-chevron" />
                     </Box>
                   </Box>
@@ -61,8 +63,13 @@ const styles = StyleSheet.create({
     borderBottomColor: '#8a8a8a',
     borderBottomWidth: 1,
   },
-  radius: {
-    borderRadius: 10,
+  radiusTop: {
+    borderTopStartRadius: 10,
+    borderTopEndRadius: 10,
+  },
+  radiusBottom: {
+    borderBottomStartRadius: 10,
+    borderBottomEndRadius: 10,
   },
   exposureList: {
     flexDirection: 'row',
@@ -74,7 +81,7 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   chevronIconBox: {
-    flex: 1,
+    flex: 0,
     justifyContent: 'center',
   },
   typeIconBox: {

--- a/src/screens/home/views/ClearOutbreakExposureView.tsx
+++ b/src/screens/home/views/ClearOutbreakExposureView.tsx
@@ -61,7 +61,7 @@ export const NegativeOutbreakTestButton = () => {
   return (
     <Box>
       <Box alignSelf="stretch">
-        <ButtonSingleLine iconName="icon-chevron" text={text} onPress={toClearOutbreakExposure} variant="scan25" />
+        <ButtonSingleLine iconName="icon-chevron" text={text} onPress={toClearOutbreakExposure} variant="exposure25" />
       </Box>
     </Box>
   );

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -31,7 +31,7 @@ export const OutbreakExposedView = ({timestamp}: {timestamp?: number}) => {
   const props = timestamp ? {header: false} : {};
 
   return (
-    <BaseHomeView iconName="hand-caution-yellow" testID="outbreakExposure" {...props}>
+    <BaseHomeView iconName="hand-caution" testID="outbreakExposure" {...props}>
       <RoundedBox isFirstBox>
         <HomeScreenTitle>{i18n.translate(`QRCode.OutbreakExposed.Title`)}</HomeScreenTitle>
         <Text marginBottom="m">{i18n.translate(`QRCode.OutbreakExposed.Body`)}</Text>

--- a/src/shared/theme/default.ts
+++ b/src/shared/theme/default.ts
@@ -28,7 +28,7 @@ export const palette = {
   green2: '#C9E7DE',
   info100: '#005B99',
   focus: '#44BBEE',
-  exposure25: '#DED8FB',
+  exposure25: '#C1BFFF',
   scan25: '#FEEFB8',
 
   greyCanada25: '#D0D7DE',


### PR DESCRIPTION
# Summary | Résumé

This does not include content updates, since they are over here: https://github.com/cds-snc/covid-alert-app/pull/1565

## Outbreak Exposed Screen:
Figma: https://www.figma.com/file/0pLawavG1fnBTXSYn4pdKZ/Exposure-notification?node-id=19406%3A74594

App:
<img width="350" alt="Screen Shot 2021-05-04 at 10 48 27 AM" src="https://user-images.githubusercontent.com/5498428/117039705-4f5e1500-acc6-11eb-83ad-159032812d93.png">
<img width="351" alt="Screen Shot 2021-05-04 at 10 48 36 AM" src="https://user-images.githubusercontent.com/5498428/117039749-5d139a80-acc6-11eb-99a7-b7529dd599b5.png">

Figma: https://www.figma.com/file/0pLawavG1fnBTXSYn4pdKZ/Exposure-notification?node-id=19456%3A74132

App:
<img width="351" alt="Screen Shot 2021-05-04 at 10 44 08 AM" src="https://user-images.githubusercontent.com/5498428/117039911-8a604880-acc6-11eb-959c-0e7020acc76b.png">
