### PR TITLE
Enabled pushToServerRightAway option for QR code related metrics

### DIFF
--- a/src/services/MetricsService/MetricsFilter.ts
+++ b/src/services/MetricsService/MetricsFilter.ts
@@ -138,13 +138,13 @@ export class DefaultMetricsFilter implements MetricsFilter {
         return Promise.resolve({
           eventType: EventTypeMetric.QrCodeSuccessfullyScanned,
           payload: [],
-          shouldBePushedToServerRightAway: false,
+          shouldBePushedToServerRightAway: true,
         });
       case EventTypeMetric.ExposedToOutbreak:
         return Promise.resolve({
           eventType: EventTypeMetric.ExposedToOutbreak,
           payload: [],
-          shouldBePushedToServerRightAway: false,
+          shouldBePushedToServerRightAway: true,
         });
       default:
         break;
@@ -210,7 +210,7 @@ export class DefaultMetricsFilter implements MetricsFilter {
         ['withDate', String(withDate)],
         ['isUserExposed', serializeIsUserExposed()],
       ],
-      shouldBePushedToServerRightAway: false,
+      shouldBePushedToServerRightAway: true,
     });
   }
 

--- a/src/services/MetricsService/tests/MetricsFilter.spec.ts
+++ b/src/services/MetricsService/tests/MetricsFilter.spec.ts
@@ -84,7 +84,7 @@ describe('MetricsFilter', () => {
         ['withDate', 'true'],
         ['isUserExposed', 'proximity,outbreak'],
       ],
-      shouldBePushedToServerRightAway: false,
+      shouldBePushedToServerRightAway: true,
     });
 
     const filteredEvent2 = await sut.filterEvent({
@@ -100,7 +100,7 @@ describe('MetricsFilter', () => {
         ['withDate', 'true'],
         ['isUserExposed', ''],
       ],
-      shouldBePushedToServerRightAway: false,
+      shouldBePushedToServerRightAway: true,
     });
 
     const filteredEvent3 = await sut.filterEvent({
@@ -116,7 +116,7 @@ describe('MetricsFilter', () => {
         ['withDate', 'true'],
         ['isUserExposed', 'outbreak'],
       ],
-      shouldBePushedToServerRightAway: false,
+      shouldBePushedToServerRightAway: true,
     });
 
     const filteredEvent4 = await sut.filterEvent({
@@ -132,7 +132,7 @@ describe('MetricsFilter', () => {
         ['withDate', 'true'],
         ['isUserExposed', 'proximity'],
       ],
-      shouldBePushedToServerRightAway: false,
+      shouldBePushedToServerRightAway: true,
     });
   });
 


### PR DESCRIPTION
# Summary | Résumé

- Enabled pushToServerRightAway option for QR code related metrics