### PR TITLE
Align yarn run-ios simulator config with Detox configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "pod-install": "pushd ios; bundle exec pod install; popd",
     "run-android": "react-native run-android --variant debug",
-    "run-ios": "react-native run-ios --scheme Staging",
+    "run-ios": "react-native run-ios --scheme Staging --simulator='iPhone 8'",
     "start": "react-native start --reset-cache",
     "test": "jest --coverage",
     "test:ios": "detox test --configuration=ios",


### PR DESCRIPTION
# Summary | Résumé

Having completed #1548, I figured we should probably standardize which iPhone simulators are used in the yarn configs.

We already use the config proposed by this PR in `.detoxrc.json` This PR aims to align the yarn configs with that.

# Reviewer checklist | Liste de vérification du réviseur

Run `yarn run-ios` and verify that it opens with an iPhone 8 ( written in simulator status bar)