### PR TITLE
Adds React Native Clean Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "run-android": "react-native run-android --variant debug",
     "run-ios": "react-native run-ios --scheme Staging",
     "start": "react-native start --reset-cache",
+    "clean": "react-native-clean-project",
     "test": "jest --coverage",
     "test:ios": "detox test --configuration=ios",
     "test:android": "detox test --configuration=android",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "prettier": "2.2.1",
     "prettier-eslint": "^12.0.0",
     "protobufjs": "^6.9.0",
+    "react-native-clean-project": "^3.6.3",
     "react-native-svg-transformer": "^0.14.3",
     "react-test-renderer": "17.0.2",
     "ts-jest": "26.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9454,6 +9454,11 @@ react-native-base64@^0.2.1:
   resolved "https://registry.yarnpkg.com/react-native-base64/-/react-native-base64-0.2.1.tgz#3d0e73a649c4c0129f7b7695d3912456aebae847"
   integrity sha512-eHgt/MA8y5ZF0aHfZ1aTPcIkDWxza9AaEk4GcpIX+ZYfZ04RcaNahO+527KR7J44/mD3efYfM23O2C1N44ByWA==
 
+react-native-clean-project@^3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-clean-project/-/react-native-clean-project-3.6.3.tgz#ad43b8e1491512f285b7f455ac56db3328b5a65f"
+  integrity sha512-sBbv+Zl05O9LfQqamLu2Crb//W/d8+l59TICF8nKxQ0nJsvear06a1CB2+FaO3rCrPNHiSjDDNXZ/D6muHTUkw==
+
 react-native-codegen@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/react-native-codegen/-/react-native-codegen-0.0.6.tgz#b3173faa879cf71bfade8d030f9c4698388f6909"


### PR DESCRIPTION
https://github.com/pmadruga/react-native-clean-project

Running the "clean" script (package.json) is interactive

<img width="477" alt="Screen Shot 2021-05-06 at 3 44 04 PM" src="https://user-images.githubusercontent.com/62242/117356714-1074be80-ae82-11eb-98ac-64eaface1cca.png">


See this list https://github.com/pmadruga/react-native-clean-project#content



I found this in the latest React Native release notes.

<img width="1103" alt="Screen Shot 2021-05-06 at 3 33 32 PM" src="https://user-images.githubusercontent.com/62242/117355422-8f68f780-ae80-11eb-9c95-67dd9a5ecee1.png">
