### PR TITLE
Add shared bold text function

### DIFF
--- a/src/components/TextMultiline.tsx
+++ b/src/components/TextMultiline.tsx
@@ -2,34 +2,12 @@ import React from 'react';
 import {Text} from 'components';
 import {TextProps} from '@shopify/restyle';
 import {Theme} from 'shared/theme/default';
+import {BoldText} from 'shared/BoldText';
 
 interface TextMultilineProps extends TextProps<Theme> {
   text: string;
   detectBold?: boolean;
 }
-
-export const boldText = (input: string) => {
-  const boldPattern = /\*\*(.*?)\*\*/gm;
-  const textSplit = input.split(boldPattern);
-
-  /* no match just return */
-  if (textSplit.length < 3) return input;
-
-  /* wrap Text element if it's "the middle" item i.e. index 1*/
-  return (
-    <>
-      {textSplit.map((t, index) =>
-        index === 1 ? (
-          <Text key={t} fontWeight="bold">
-            {t}
-          </Text>
-        ) : (
-          t
-        ),
-      )}
-    </>
-  );
-};
 
 export const TextMultiline = ({text, detectBold, ...props}: TextMultilineProps) => {
   const textSplit = text.split(/\n\n/g);
@@ -37,7 +15,7 @@ export const TextMultiline = ({text, detectBold, ...props}: TextMultilineProps) 
     <>
       {textSplit.map(t => (
         <Text key={t} {...props}>
-          {detectBold ? boldText(t) : t}
+          {detectBold ? BoldText(t) : t}
         </Text>
       ))}
     </>

--- a/src/shared/BoldText.tsx
+++ b/src/shared/BoldText.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {Text} from 'components';
+
+export const BoldText = (input: string) => {
+  const boldPattern = /\*\*(.*?)\*\*/gm;
+  const textSplit = input.split(boldPattern);
+
+  /* no match just return */
+  if (textSplit.length < 3) return input;
+
+  /* wrap Text element if it's "the middle" item i.e. index 1*/
+  return (
+    <>
+      {textSplit.map((t, index) =>
+        index === 1 ? (
+          <Text key={t} fontWeight="bold">
+            {t}
+          </Text>
+        ) : (
+          t
+        ),
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
This is a follow up PR 

This moves and renames the bold text function out so it can be used in other places i.e. 

```javascript
import {BoldText} from 'shared/BoldText';
export const SomeComponent = () => {
  const i18n = useI18n();
  return <Text marginTop="xl">{BoldText(i18n.translate(`QRCode.OutbreakExposed.Body`))}</Text>;
};
```

For testing ensure this doesn't break existing TextMultiline with detect bold functionality. 

cc: @omartehsin1 

Ref:
https://github.com/cds-snc/covid-alert-app/pull/1518