### PR TITLE
Toolbar is now fixed in place for QR scanning flow

### DIFF
--- a/src/screens/qr/components/BaseQRCodeScreen.tsx
+++ b/src/screens/qr/components/BaseQRCodeScreen.tsx
@@ -17,14 +17,14 @@ export const BaseQRCodeScreen = ({children, showBackButton}: BaseQRCodeScreenPro
   return (
     <Box backgroundColor="overlayBackground" flex={1}>
       <SafeAreaView style={styles.flex}>
+        <Box marginBottom="m">
+          <ToolbarWithClose
+            closeText={i18n.translate('DataUpload.Close')}
+            showBackButton={showBackButton}
+            onClose={close}
+          />
+        </Box>
         <ScrollView>
-          <Box marginBottom="m">
-            <ToolbarWithClose
-              closeText={i18n.translate('DataUpload.Close')}
-              showBackButton={showBackButton}
-              onClose={close}
-            />
-          </Box>
           <View style={styles.flex}>{children}</View>
         </ScrollView>
       </SafeAreaView>


### PR DESCRIPTION
# Summary | Résumé

I moved the toolbar outside of the ScrollView so that it is fixed at the top of the screen, like in the OTK entry screens:
<img width="351" alt="Screen Shot 2021-05-10 at 2 48 56 PM" src="https://user-images.githubusercontent.com/5498428/117723034-1da1ee00-b19f-11eb-8ff1-7a715aca385b.png">
