### PR TITLE
Feature/active user metric rework

### DIFF
--- a/android/app/src/main/java/app/covidshield/MainActivity.kt
+++ b/android/app/src/main/java/app/covidshield/MainActivity.kt
@@ -2,14 +2,31 @@ package app.covidshield
 
 import android.content.Intent
 import android.os.Bundle
+import app.covidshield.services.metrics.FilteredMetricsService
+import app.covidshield.services.metrics.MetricType
 import app.covidshield.utils.ActivityResultHelper
 import com.facebook.react.ReactActivity
+import kotlinx.coroutines.runBlocking
 import org.devio.rn.splashscreen.SplashScreen
 
 class MainActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         SplashScreen.show(this)
+
+        // Added a thread here to avoid android.os.networkonmainthreadexception due to us trying to push the metric to the server right away while still being on the main thread
+        val thread = Thread(Runnable {
+            try {
+                runBlocking {
+                    FilteredMetricsService.getInstance(applicationContext).addMetric(MetricType.ActiveUser, true)
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        })
+
+        thread.start()
+
         super.onCreate(null)
     }
 

--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
@@ -39,6 +39,8 @@ class ExposureCheckSchedulerWorker (val context: Context, parameters: WorkerPara
 
         val filteredMetricsService = FilteredMetricsService.getInstance(context)
 
+        filteredMetricsService.addMetric(MetricType.ActiveUser, true)
+
         filteredMetricsService.sendDailyMetrics()
 
         filteredMetricsService.addMetric(MetricType.ScheduledCheckStartedToday, true)

--- a/android/app/src/main/java/app/covidshield/services/metrics/FilteredMetricsService.kt
+++ b/android/app/src/main/java/app/covidshield/services/metrics/FilteredMetricsService.kt
@@ -2,6 +2,8 @@ package app.covidshield.services.metrics
 
 import android.content.Context
 import app.covidshield.BuildConfig
+import app.covidshield.services.storage.StorageDirectory
+import app.covidshield.services.storage.StorageService
 import app.covidshield.utils.DateUtils
 import app.covidshield.utils.SingletonHolder
 import kotlinx.coroutines.runBlocking
@@ -40,7 +42,8 @@ class DefaultFilteredMetricsService constructor(private val context: Context) : 
     override suspend fun addMetric(metricType: MetricType, oncePerUTCDay: Boolean) {
 
         suspend fun pushMetric() {
-            val metric = Metric(DateUtils.getCurrentLocalDate().time, metricType.identifier, "None", emptyMap())
+            val region = StorageService.getInstance(context).retrieve(StorageDirectory.Region) ?: "None"
+            val metric = Metric(DateUtils.getCurrentLocalDate().time, metricType.identifier, region, emptyMap())
             metricsService.publishMetric(metric, metricType.shouldBePushedToServerRightAway)
         }
 

--- a/android/app/src/main/java/app/covidshield/services/metrics/FilteredMetricsService.kt
+++ b/android/app/src/main/java/app/covidshield/services/metrics/FilteredMetricsService.kt
@@ -6,10 +6,11 @@ import app.covidshield.utils.DateUtils
 import app.covidshield.utils.SingletonHolder
 import kotlinx.coroutines.runBlocking
 
-enum class MetricType(val identifier: String) {
-    PackageUpdated("android-package-replaced"),
-    ScheduledCheckStartedToday("scheduled-check-started-today"),
-    ScheduledCheckSuccessfulToday("scheduled-check-successful-today")
+enum class MetricType(val identifier: String, val shouldBePushedToServerRightAway: Boolean) {
+    PackageUpdated("android-package-replaced", false),
+    ScheduledCheckStartedToday("scheduled-check-started-today", false),
+    ScheduledCheckSuccessfulToday("scheduled-check-successful-today", false),
+    ActiveUser("active-user", true)
 }
 
 interface FilteredMetricsService {
@@ -40,7 +41,7 @@ class DefaultFilteredMetricsService constructor(private val context: Context) : 
 
         suspend fun pushMetric() {
             val metric = Metric(DateUtils.getCurrentLocalDate().time, metricType.identifier, "None", emptyMap())
-            metricsService.publishMetric(metric)
+            metricsService.publishMetric(metric, metricType.shouldBePushedToServerRightAway)
         }
 
         if (oncePerUTCDay) {

--- a/android/app/src/main/java/app/covidshield/services/storage/StorageDirectory.kt
+++ b/android/app/src/main/java/app/covidshield/services/storage/StorageDirectory.kt
@@ -4,6 +4,7 @@ object StorageDirectory {
 
     // Shared between React and Kotlin
 
+    val Region: KeyDefinition = Unsecure("Region")
     val ExposureStatus: KeyDefinition = Unsecure("exposureStatus")
     val MetricsFilterStateStorageBackgroundCheckEventMarkerKey = Secure("AB398409-D8A9-4BC2-91F0-63E4CEFCD89A")
 

--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -121,8 +121,16 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     [[TSBackgroundFetch sharedInstance] didFinishLaunching];
   }
   
+  MetricsService *metricsService = [MetricsService sharedInstance];
+  
+  // Will be called when the app starts from either foreground or background
+  [metricsService publishMetric:ActiveUser];
+  
+  /* If we feel like this listener is not doing the job properly we can try a different solution:
+   "Immediately upon launch, you can check if applicationState equals UIApplicationStateBackground in order to determine whether your app was launched into the background."
+   */
   [[TSBackgroundFetch sharedInstance] addListener:@"scheduled-check-started-listener" callback:^(NSString *componentName) {
-    [[MetricsService sharedInstance] publishScheduledCheckMetricWithType:Start];
+    [metricsService publishMetric:ScheduledCheckStartedToday];
   }];
   
   // Define UNUserNotificationCenter

--- a/ios/CovidShield/AppDelegate.m
+++ b/ios/CovidShield/AppDelegate.m
@@ -124,13 +124,13 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   MetricsService *metricsService = [MetricsService sharedInstance];
   
   // Will be called when the app starts from either foreground or background
-  [metricsService publishMetric:ActiveUser];
+  [metricsService publishMetric:ActiveUser bridge:bridge];
   
   /* If we feel like this listener is not doing the job properly we can try a different solution:
    "Immediately upon launch, you can check if applicationState equals UIApplicationStateBackground in order to determine whether your app was launched into the background."
    */
   [[TSBackgroundFetch sharedInstance] addListener:@"scheduled-check-started-listener" callback:^(NSString *componentName) {
-    [metricsService publishMetric:ScheduledCheckStartedToday];
+    [metricsService publishMetric:ScheduledCheckStartedToday bridge:bridge];
   }];
   
   // Define UNUserNotificationCenter

--- a/ios/CovidShield/DebugMetrics.m
+++ b/ios/CovidShield/DebugMetrics.m
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE();
 RCT_REMAP_METHOD(publishDebugMetric, stepNumber:(double)stepNumber message:(NSString *)message withResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   if (stepNumber == 8.0) {
-    [[MetricsService sharedInstance] publishMetric:ScheduledCheckSuccessfulToday];
+    [[MetricsService sharedInstance] publishMetric:ScheduledCheckSuccessfulToday bridge:self.bridge];
   }
   
   resolve(nil);

--- a/ios/CovidShield/DebugMetrics.m
+++ b/ios/CovidShield/DebugMetrics.m
@@ -15,7 +15,7 @@ RCT_EXPORT_MODULE();
 RCT_REMAP_METHOD(publishDebugMetric, stepNumber:(double)stepNumber message:(NSString *)message withResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
   if (stepNumber == 8.0) {
-    [[MetricsService sharedInstance] publishScheduledCheckMetricWithType:End];
+    [[MetricsService sharedInstance] publishMetric:ScheduledCheckSuccessfulToday];
   }
   
   resolve(nil);

--- a/ios/MetricsService.h
+++ b/ios/MetricsService.h
@@ -7,9 +7,10 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, ScheduledCheckMetricType) {
-  Start,
-  End
+typedef NS_ENUM(NSUInteger, MetricType) {
+  ScheduledCheckStartedToday,
+  ScheduledCheckSuccessfulToday,
+  ActiveUser
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (void)publishScheduledCheckMetricWithType:(ScheduledCheckMetricType)type;
+- (void)publishMetric:(MetricType)type;
 
 @end
 

--- a/ios/MetricsService.h
+++ b/ios/MetricsService.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <React/RCTBridge.h>
 
 typedef NS_ENUM(NSUInteger, MetricType) {
   ScheduledCheckStartedToday,
@@ -19,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 
-- (void)publishMetric:(MetricType)type;
+- (void)publishMetric:(MetricType)type bridge:(RCTBridge *)bridge;
 
 @end
 

--- a/ios/MetricsService.m
+++ b/ios/MetricsService.m
@@ -10,6 +10,7 @@
 #import "MetricsPusher.h"
 #import <UIKit/UIDevice.h>
 #import "UniqueDailyMetricsHelper.h"
+#import <RNCAsyncStorage/RNCAsyncStorage.h>
 
 @interface MetricsService ()
 
@@ -45,15 +46,17 @@
   return self;
 }
 
-- (void)publishMetric:(MetricType)type
+- (void)publishMetric:(MetricType)type bridge:(RCTBridge *)bridge
 {
   NSString *identifier = [self identifierFromMetricType:type];
   
   if ([self.uniqueDailyMetricsHelper canPublishMetricWithIdentifier:identifier]) {
     
+    NSString *region = [self getRegionWithBridge:bridge];
+    
     NSNumber *timestamp = @((long long)([[NSDate date] timeIntervalSince1970] * 1000.0));
     
-    Metric *metric = [[Metric alloc] initWithTimestamp:timestamp identifier:identifier region:@"None"];
+    Metric *metric = [[Metric alloc] initWithTimestamp:timestamp identifier:identifier region:region];
     
     NSData *jsonPayload = [self.jsonSerializer serializeToJsonWithTimestamp:timestamp metric:metric];
     
@@ -76,6 +79,23 @@
     case ActiveUser:
       return @"active-user";
   }
+}
+
+- (NSString *)getRegionWithBridge:(RCTBridge *)bridge
+{
+  __block NSString *region = @"None";
+  
+  RNCAsyncStorage *asyncStorage = [bridge moduleForClass:[RNCAsyncStorage class]];
+  
+  dispatch_sync(asyncStorage.methodQueue, ^{
+    [asyncStorage multiGet:@[@"Region"] callback:^(NSArray *response) {
+        if (![response[0] isKindOfClass:[NSError class]] && ![response[1][0][1] isKindOfClass:[NSNull class]]) {
+          region = response[1][0][1];
+        }
+    }];
+  });
+  
+  return region;
 }
 
 @end

--- a/ios/MetricsService.m
+++ b/ios/MetricsService.m
@@ -45,9 +45,9 @@
   return self;
 }
 
-- (void)publishScheduledCheckMetricWithType:(ScheduledCheckMetricType)type
+- (void)publishMetric:(MetricType)type
 {
-  NSString *identifier = type == Start ? @"scheduled-check-started-today" : @"scheduled-check-successful-today";
+  NSString *identifier = [self identifierFromMetricType:type];
   
   if ([self.uniqueDailyMetricsHelper canPublishMetricWithIdentifier:identifier]) {
     
@@ -63,6 +63,18 @@
       }
     }];
     
+  }
+}
+
+- (NSString *)identifierFromMetricType:(MetricType)type
+{
+  switch (type) {
+    case ScheduledCheckStartedToday:
+      return @"scheduled-check-started-today";
+    case ScheduledCheckSuccessfulToday:
+      return @"scheduled-check-successful-today";
+    case ActiveUser:
+      return @"active-user";
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {BackendService} from 'services/BackendService';
 import {BackgroundScheduler} from 'services/BackgroundSchedulerService';
 import {ExposureNotificationService} from 'services/ExposureNotificationService';
 import {createBackgroundI18n} from 'locale';
-import {FilteredMetricsService, EventTypeMetric} from 'services/MetricsService';
+import {FilteredMetricsService} from 'services/MetricsService';
 import {publishDebugMetric} from 'bridge/DebugMetrics';
 
 import {DefaultStorageService} from './services/StorageService';
@@ -20,8 +20,6 @@ AppRegistry.registerComponent('CovidShield', () => App);
 
 if (Platform.OS === 'android') {
   BackgroundScheduler.registerAndroidHeadlessPeriodicTask(async () => {
-    await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
-
     const backendService = new BackendService(
       RETRIEVE_URL,
       SUBMIT_URL,
@@ -42,7 +40,6 @@ if (Platform.OS === 'android') {
 
   BackgroundScheduler.registerAndroidHeadlessExposureCheckPeriodicTask(async () => {
     publishDebugMetric(4.3);
-    await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
 
     const backendService = new BackendService(
       RETRIEVE_URL,

--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -1,7 +1,7 @@
 import BackgroundFetch from 'react-native-background-fetch';
 import {AppRegistry, Platform} from 'react-native';
 import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL, TEST_MODE} from 'env';
-import {FilteredMetricsService, EventTypeMetric} from 'services/MetricsService';
+import {FilteredMetricsService} from 'services/MetricsService';
 import ExposureNotification from 'bridge/ExposureNotification';
 import {publishDebugMetric} from 'bridge/DebugMetrics';
 
@@ -137,7 +137,6 @@ const registerAndroidHeadlessPeriodicTask = (task: PeriodicTask) => {
         FilteredMetricsService.sharedInstance(),
       );
       registerPeriodicTask(async () => {
-        await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
         await exposureNotificationService.updateExposureStatusInBackground();
       }, exposureNotificationService);
     } catch (error) {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -186,8 +186,6 @@ export class ExposureNotificationService {
   };
 
   executeExposureCheck = async () => {
-    await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
-
     try {
       await this.updateExposureStatusInBackground();
     } catch (error) {

--- a/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
+++ b/src/services/ExposureNotificationService/ExposureNotificationServiceProvider.tsx
@@ -47,7 +47,6 @@ export const ExposureNotificationServiceProvider = ({
 
   useEffect(() => {
     backgroundScheduler.registerPeriodicTask(async () => {
-      await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
       await exposureNotificationService.updateExposureStatusInBackground();
     }, exposureNotificationService);
   }, [backgroundScheduler, exposureNotificationService]);
@@ -63,7 +62,6 @@ export const ExposureNotificationServiceProvider = ({
       exposureNotificationService.updateExposure();
       await exposureNotificationService.updateExposureStatus();
 
-      await filteredMetricsService.addEvent({type: EventTypeMetric.ActiveUser});
       const notificationStatus: Status = await checkNotifications()
         .then(({status}) => status)
         .catch(() => 'unavailable');
@@ -74,7 +72,6 @@ export const ExposureNotificationServiceProvider = ({
       }
       // re-register the background tasks upon app launch
       backgroundScheduler.registerPeriodicTask(async () => {
-        await FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ActiveUser});
         await exposureNotificationService.updateExposureStatusInBackground();
       }, exposureNotificationService);
     };
@@ -83,20 +80,14 @@ export const ExposureNotificationServiceProvider = ({
     exposureNotificationService.updateExposure();
     exposureNotificationService.updateExposureStatus();
 
-    filteredMetricsService
-      .addEvent({type: EventTypeMetric.ActiveUser})
-      .then(() => {
-        // eslint-disable-next-line promise/no-nesting
-        checkNotifications()
-          .then(({status}) => status)
-          .catch(() => 'unavailable')
-          .then(notificationStatus => {
-            filteredMetricsService.sendDailyMetrics(
-              exposureNotificationService.systemStatus.get(),
-              notificationStatus as Status,
-            );
-          })
-          .catch(() => {});
+    checkNotifications()
+      .then(({status}) => status)
+      .catch(() => 'unavailable')
+      .then(notificationStatus => {
+        filteredMetricsService.sendDailyMetrics(
+          exposureNotificationService.systemStatus.get(),
+          notificationStatus as Status,
+        );
       })
       .catch(() => {});
 

--- a/src/services/MetricsService/MetricsFilterStateStorage.ts
+++ b/src/services/MetricsService/MetricsFilterStateStorage.ts
@@ -1,4 +1,3 @@
-import {getCurrentDate} from 'shared/date-fns';
 import {StorageService, StorageDirectory} from 'services/StorageService';
 
 export interface MetricsFilterStateStorage {
@@ -11,9 +10,6 @@ export interface MetricsFilterStateStorage {
 
   getBackgroundCheckEvents(): Promise<Date[]>;
   saveBackgroundCheckEvents(events: Date[]): Promise<void>;
-
-  getLastActiveUserEventSentDate(): Promise<Date | null>;
-  updateLastActiveUserSentDateToNow(): Promise<void>;
 }
 
 export class DefaultMetricsFilterStateStorage implements MetricsFilterStateStorage {
@@ -76,19 +72,6 @@ export class DefaultMetricsFilterStateStorage implements MetricsFilterStateStora
     return this.storageService.save(
       StorageDirectory.MetricsFilterStateStorageBackgroundCheckEventMarkerKey,
       eventsAsListOfTimestamps.join(','),
-    );
-  }
-
-  getLastActiveUserEventSentDate(): Promise<Date | null> {
-    return this.storageService
-      .retrieve(StorageDirectory.MetricsFilterStateStorageActiveUserEventMarkerKey)
-      .then(value => (value ? new Date(Number(value)) : null));
-  }
-
-  updateLastActiveUserSentDateToNow(): Promise<void> {
-    return this.storageService.save(
-      StorageDirectory.MetricsFilterStateStorageActiveUserEventMarkerKey,
-      `${getCurrentDate().getTime()}`,
     );
   }
 }

--- a/src/services/MetricsService/tests/FilteredMetricsService.spec.ts
+++ b/src/services/MetricsService/tests/FilteredMetricsService.spec.ts
@@ -52,32 +52,6 @@ describe('FilteredMetricsService', () => {
     jest.clearAllMocks();
   });
 
-  it('addEvent does not publish metric if filtered event is null', async () => {
-    metricsFilter.filterEvent.mockReturnValue(Promise.resolve(null));
-
-    await sut.addEvent({type: EventTypeMetric.ActiveUser});
-    expect(metricsService.publishMetric).not.toHaveBeenCalled();
-  });
-
-  it('addEvent publishes metric if filtered event is not null', async () => {
-    metricsFilter.filterEvent.mockReturnValue(
-      Promise.resolve({eventType: EventTypeMetric.ActiveUser, payload: [], shouldBePushedToServerRightAway: true}),
-    );
-
-    await sut.addEvent({type: EventTypeMetric.ActiveUser});
-    expect(metricsService.publishMetric).toHaveBeenCalled();
-  });
-
-  it('sendDailyMetrics publishes delayed metric if there is one and sends daily metrics', async () => {
-    metricsFilter.getDelayedOnboardedEventIfPublishable.mockReturnValue(
-      Promise.resolve({eventType: EventTypeMetric.ActiveUser, payload: [], shouldBePushedToServerRightAway: true}),
-    );
-
-    await sut.sendDailyMetrics('', '');
-    expect(metricsService.publishMetric).toHaveBeenCalled();
-    expect(metricsService.sendDailyMetrics).toHaveBeenCalled();
-  });
-
   it('sendDailyMetrics does not publish delayed metric if there is none and still sends daily metrics', async () => {
     metricsFilter.getDelayedOnboardedEventIfPublishable.mockReturnValue(Promise.resolve(null));
 

--- a/src/services/MetricsService/tests/MetricsFilter.spec.ts
+++ b/src/services/MetricsService/tests/MetricsFilter.spec.ts
@@ -167,21 +167,6 @@ describe('MetricsFilter', () => {
     expect(filteredEvent2).not.toBeNull();
   });
 
-  it('active-user event is only published once a day', async () => {
-    today = new OriginalDate('2019-01-01T12:00:00.000Z');
-
-    const filteredEvent1 = await sut.filterEvent({type: EventTypeMetric.ActiveUser});
-    expect(filteredEvent1).not.toBeNull();
-
-    const filteredEvent2 = await sut.filterEvent({type: EventTypeMetric.ActiveUser});
-    expect(filteredEvent2).toBeNull();
-
-    today = new OriginalDate('2019-01-02T00:00:00.000Z');
-
-    const filteredEvent3 = await sut.filterEvent({type: EventTypeMetric.ActiveUser});
-    expect(filteredEvent3).not.toBeNull();
-  });
-
   it('background-check event is only published once a day', async () => {
     // day 1
     today = new OriginalDate('2019-01-01T12:00:00.000Z');

--- a/src/services/StorageService/StorageDirectory.ts
+++ b/src/services/StorageService/StorageDirectory.ts
@@ -152,11 +152,6 @@ export class StorageDirectory {
     storageType: StorageType.Secure,
   };
 
-  static readonly MetricsFilterStateStorageActiveUserEventMarkerKey: KeyDefinition = {
-    keyIdentifier: 'B678D2BD-1596-4650-B28C-4606E34DC4CA',
-    storageType: StorageType.Secure,
-  };
-
   // BackendService.ts
   static readonly BackendServiceRegionContentKey: KeyDefinition = {
     keyIdentifier: '30F6F699-43F7-44A1-B138-89278C25A1AB',


### PR DESCRIPTION
# Summary | Résumé

- Moved `active-user` metric from React to Objective-C and Kotlin