### PR TITLE
Removed back button on QR intro screen, made close button consistent on qr-onboarding

### DIFF
--- a/src/screens/qr-onboarding/Tutorial.tsx
+++ b/src/screens/qr-onboarding/Tutorial.tsx
@@ -2,7 +2,7 @@ import React, {useState, useCallback, useRef} from 'react';
 import {ListRenderItem, StyleSheet, useWindowDimensions, View} from 'react-native';
 import Carousel from 'react-native-snap-carousel';
 import {useNavigation} from '@react-navigation/native';
-import {Box, Button, Toolbar, ProgressCircles} from 'components';
+import {Box, Button, ToolbarWithClose, ProgressCircles} from 'components';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useI18n} from 'locale';
 import {useAccessibilityService} from 'services/AccessibilityService';
@@ -53,13 +53,7 @@ export const QRCodeOnboardScreen = () => {
   return (
     <Box backgroundColor="overlayBackground" flex={1}>
       <SafeAreaView style={styles.flex}>
-        <Toolbar
-          title=""
-          navIcon="icon-back-arrow"
-          navText={i18n.translate('Tutorial.Close')}
-          navLabel={i18n.translate('Tutorial.Close')}
-          onIconClicked={close}
-        />
+        <ToolbarWithClose closeText={i18n.translate('Tutorial.Close')} onClose={close} showBackButton={false} />
         <View style={styles.flex}>
           <Carousel
             ref={carouselRef}

--- a/src/screens/qr/QRCodeIntroScreen.tsx
+++ b/src/screens/qr/QRCodeIntroScreen.tsx
@@ -23,7 +23,7 @@ export const QRCodeIntroScreen = () => {
     navigation.navigate('QRCodeReaderScreen');
   }, [navigation]);
   return (
-    <BaseQRCodeScreen>
+    <BaseQRCodeScreen showBackButton={false}>
       <Box paddingHorizontal="m">
         <Box marginBottom="s">
           <Image


### PR DESCRIPTION
# Summary | Résumé

Removed back button:
<img width="351" alt="Screen Shot 2021-05-11 at 10 26 07 AM" src="https://user-images.githubusercontent.com/5498428/117851256-5e534300-b243-11eb-917f-b1e5da8792e9.png">

Moved close button from left to right:
<img width="352" alt="Screen Shot 2021-05-11 at 10 27 08 AM" src="https://user-images.githubusercontent.com/5498428/117851342-72974000-b243-11eb-8b4b-9bf5c16e538e.png">
