### PR TITLE
Bug fix to ensure overlapping outbreak events do not result in more than one exposure per checkin

### DIFF
--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -10,6 +10,7 @@ import {unzip} from 'react-native-zip-archive';
 import {readFile} from 'react-native-fs';
 import {covidshield} from 'services/BackendService/covidshield';
 import {EventTypeMetric, FilteredMetricsService} from 'services/MetricsService';
+import {getRandomString} from 'shared/logging/uuid';
 
 import {Observable} from '../../shared/Observable';
 import {
@@ -31,6 +32,7 @@ export const HOURS_PER_PERIOD = 24;
 export const EXPOSURE_NOTIFICATION_CYCLE = 14;
 
 export interface OutbreakEvent {
+  id: string;
   locationId: string;
   // ms
   startTime: number;
@@ -212,6 +214,7 @@ export class OutbreakService {
   convertOutbreakEvents = (outbreakEvents: covidshield.OutbreakEvent[]): OutbreakEvent[] => {
     return outbreakEvents.map(event => {
       return {
+        id: getRandomString(8),
         locationId: event.locationId,
         endTime: 1000 * Number(event.endTime?.seconds),
         startTime: 1000 * Number(event.startTime?.seconds),

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -32,7 +32,9 @@ export const HOURS_PER_PERIOD = 24;
 export const EXPOSURE_NOTIFICATION_CYCLE = 14;
 
 export interface OutbreakEvent {
-  id: string;
+  // Don't use this for anything besides the dedup code.
+  // dedupeId will change each time we get new data from the server.
+  dedupeId: string;
   locationId: string;
   // ms
   startTime: number;
@@ -214,7 +216,7 @@ export class OutbreakService {
   convertOutbreakEvents = (outbreakEvents: covidshield.OutbreakEvent[]): OutbreakEvent[] => {
     return outbreakEvents.map(event => {
       return {
-        id: getRandomString(8),
+        dedupeId: getRandomString(8),
         locationId: event.locationId,
         endTime: 1000 * Number(event.endTime?.seconds),
         startTime: 1000 * Number(event.startTime?.seconds),

--- a/src/shared/logging/uuid.ts
+++ b/src/shared/logging/uuid.ts
@@ -2,7 +2,7 @@ import {DefaultStorageService, StorageDirectory} from 'services/StorageService';
 
 let currentUUID = '';
 
-const getRandomString = (size: number) => {
+export const getRandomString = (size: number) => {
   const chars = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'];
 
   return [...Array(size)].map(_ => chars[(Math.random() * chars.length) | 0]).join('');

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -110,7 +110,7 @@ describe('getMatchedOutbreakHistoryItems', () => {
   });
 
   it('returns not exposed if isIgnored or expired', () => {
-    const history = {
+    const history: OutbreakHistoryItem = {
       outbreakId: '123-1612180800000',
       isExpired: false,
       isIgnored: false,
@@ -121,6 +121,7 @@ describe('getMatchedOutbreakHistoryItems', () => {
       outbreakEndTimestamp: 1612195200000,
       checkInTimestamp: 1612180800000,
       notificationTimestamp: 1613758680944,
+      severity: 3,
     };
 
     expect(isExposedToOutbreak([history])).toStrictEqual(true);
@@ -324,6 +325,7 @@ describe('outbreakHistory functions', () => {
         outbreakEndTimestamp: 1612195200000,
         checkInTimestamp: 1612180800001,
         notificationTimestamp: 1613758680944,
+        severity: 3,
       };
 
       const history = getMatchedOutbreakHistoryItems(checkIns, outbreaks);

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -364,21 +364,21 @@ describe('outbreakHistory functions', () => {
       timestamp: new Date(2021, 1, 11, 12).getTime(),
     };
     const outbreakEvent1: OutbreakEvent = {
-      id: 'outbreakEvent1',
+      dedupeId: 'outbreakEvent1',
       locationId,
       startTime: new Date(2021, 1, 10).getTime(),
       endTime: new Date(2021, 1, 11).getTime(),
       severity: 2,
     };
     const outbreakEvent2: OutbreakEvent = {
-      id: 'outbreakEvent2',
+      dedupeId: 'outbreakEvent2',
       locationId,
       startTime: new Date(2021, 1, 10).getTime(),
       endTime: new Date(2021, 1, 11).getTime(),
       severity: 3,
     };
     const outbreakEvent3: OutbreakEvent = {
-      id: 'outbreakEvent2',
+      dedupeId: 'outbreakEvent2',
       locationId,
       startTime: new Date(2021, 1, 11).getTime(),
       endTime: new Date(2021, 1, 12).getTime(),

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -1,6 +1,9 @@
+import {OutbreakEvent} from '../services/OutbreakService';
+
 import {
   CheckInData,
   createOutbreakHistoryItem,
+  deduplicateMatches,
   doTimeWindowsOverlap,
   getMatchedOutbreakHistoryItems,
   isExposedToOutbreak,
@@ -9,6 +12,7 @@ import {
   getNewOutbreakExposures,
   expireHistoryItems,
   OutbreakHistoryItem,
+  MatchData,
 } from './qr';
 
 const getTimes = (startTimestamp, durationInMinutes: number) => {
@@ -342,6 +346,72 @@ describe('outbreakHistory functions', () => {
           outbreakId: '123-1612180800001',
         }),
       );
+    });
+  });
+
+  describe('deduplicateMatches', () => {
+    const locationId = 'abc123';
+    const checkIn1: CheckInData = {
+      id: locationId,
+      name: 'Burgers',
+      address: '123 King St',
+      timestamp: new Date(2021, 1, 10, 12).getTime(),
+    };
+    const checkIn2: CheckInData = {
+      id: locationId,
+      name: 'Burgers',
+      address: '123 King St',
+      timestamp: new Date(2021, 1, 11, 12).getTime(),
+    };
+    const outbreakEvent1: OutbreakEvent = {
+      id: 'outbreakEvent1',
+      locationId,
+      startTime: new Date(2021, 1, 10).getTime(),
+      endTime: new Date(2021, 1, 11).getTime(),
+      severity: 2,
+    };
+    const outbreakEvent2: OutbreakEvent = {
+      id: 'outbreakEvent2',
+      locationId,
+      startTime: new Date(2021, 1, 10).getTime(),
+      endTime: new Date(2021, 1, 11).getTime(),
+      severity: 3,
+    };
+    const outbreakEvent3: OutbreakEvent = {
+      id: 'outbreakEvent2',
+      locationId,
+      startTime: new Date(2021, 1, 11).getTime(),
+      endTime: new Date(2021, 1, 12).getTime(),
+      severity: 3,
+    };
+
+    it('filters out duplicate matches with a lower severity', () => {
+      const match1: MatchData = {
+        timestamp: checkIn1.timestamp,
+        checkIn: checkIn1,
+        outbreakEvent: outbreakEvent1,
+      };
+      const match2: MatchData = {
+        timestamp: checkIn1.timestamp,
+        checkIn: checkIn1,
+        outbreakEvent: outbreakEvent2,
+      };
+
+      expect(deduplicateMatches([match1, match2])).toStrictEqual([match2]);
+    });
+
+    it('does not filter out non duplicate matches', () => {
+      const match1: MatchData = {
+        timestamp: checkIn1.timestamp,
+        checkIn: checkIn1,
+        outbreakEvent: outbreakEvent1,
+      };
+      const match2: MatchData = {
+        timestamp: checkIn2.timestamp,
+        checkIn: checkIn2,
+        outbreakEvent: outbreakEvent3,
+      };
+      expect(deduplicateMatches([match1, match2])).toStrictEqual([match1, match2]);
     });
   });
 

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -396,7 +396,6 @@ describe('outbreakHistory functions', () => {
         checkIn: checkIn1,
         outbreakEvent: outbreakEvent2,
       };
-
       expect(deduplicateMatches([match1, match2])).toStrictEqual([match2]);
     });
 

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -146,8 +146,7 @@ export const getMatchedOutbreakHistoryItems = (
 
   log.debug({message: 'outbreak matches', payload: {allMatches}});
 
-  const validOutbreakEventIds = getValidOutbreakEventIds(allMatches);
-  const deduplicatedMatches = allMatches.filter(match => validOutbreakEventIds.indexOf(match.outbreakEvent.id) > -1);
+  const deduplicatedMatches = deduplicateMatches(allMatches);
   return deduplicatedMatches.map(match => createOutbreakHistoryItem(match));
 };
 
@@ -256,7 +255,11 @@ export const getNewOutbreakExposures = (
   return newOutbreakExposures;
 };
 
-export const getValidOutbreakEventIds = (allMatches: MatchData[]) => {
+/**
+ * Look at all outbreak/checkin matches and remove duplicate matches
+ * so the same checkin never results in more than one exposure
+ */
+export const deduplicateMatches = (allMatches: MatchData[]) => {
   const deduplicationDict: MatchDeduplicationDict = {};
   for (const match of allMatches) {
     const timestampStr = match.timestamp.toString();
@@ -273,5 +276,6 @@ export const getValidOutbreakEventIds = (allMatches: MatchData[]) => {
     }
   }
   const validOutbreakEventIds = Object.values(deduplicationDict).map(item => item.outbreakEventId);
-  return validOutbreakEventIds;
+  const deduplicatedMatches = allMatches.filter(match => validOutbreakEventIds.indexOf(match.outbreakEvent.id) > -1);
+  return deduplicatedMatches;
 };

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -40,7 +40,7 @@ interface MatchCalculationData {
   checkIns: CheckInData[];
 }
 
-interface MatchData {
+export interface MatchData {
   timestamp: number;
   checkIn: CheckInData;
   outbreakEvent: OutbreakEvent;


### PR DESCRIPTION
# Summary | Résumé

When we get outbreak events from the server that overlap the same day for a single location, this can result in multiple exposures for the same check in. This is visible to the user in the recent exposure history. We should only count this as one exposure, and display the guidance for the most severe of the outbreak events the user matched with. If there were overlapping outbreak events with the same severity, it doesn't matter which one we choose to keep so I am arbitrarily keeping the one with the latest `endTime`.