### PR TITLE
Exposure history screen fixes

### DIFF
--- a/src/screens/exposureHistory/views/ExposureList.tsx
+++ b/src/screens/exposureHistory/views/ExposureList.tsx
@@ -6,6 +6,18 @@ import {useNavigation} from '@react-navigation/native';
 import {Box, Text, Icon} from 'components';
 import {formatExposedDate} from 'shared/date-fns';
 
+const getRadiusStyle = (index: number, listLength: number) => {
+  if (listLength === 1) {
+    return styles.fullRadius;
+  }
+  if (index === 0) {
+    return styles.radiusTop;
+  }
+  if (index === listLength - 1) {
+    return styles.radiusBottom;
+  }
+};
+
 export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: CombinedExposureHistoryData[]}) => {
   const i18n = useI18n();
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
@@ -17,21 +29,13 @@ export const ExposureList = ({exposureHistoryData}: {exposureHistoryData: Combin
   exposureHistoryData.sort(function (first, second) {
     return second.notificationTimestamp - first.notificationTimestamp;
   });
-  const getRadiusStyle = (index: number) => {
-    if (index === 0) {
-      return styles.radiusTop;
-    }
-    if (index === exposureHistoryData.length - 1) {
-      return styles.radiusBottom;
-    }
-  };
 
   return (
     <>
       {exposureHistoryData.map((item, index) => {
         return (
           <Box key={item.historyItem.id}>
-            <Box backgroundColor="gray5" style={getRadiusStyle(index)}>
+            <Box backgroundColor="gray5" style={getRadiusStyle(index, exposureHistoryData.length)}>
               <Box paddingHorizontal="m" style={[exposureHistoryData.length !== index + 1 && styles.bottomBorder]}>
                 <TouchableOpacity
                   style={styles.chevronIcon}
@@ -66,6 +70,9 @@ const styles = StyleSheet.create({
   bottomBorder: {
     borderBottomColor: '#8a8a8a',
     borderBottomWidth: 1,
+  },
+  fullRadius: {
+    borderRadius: 10,
   },
   radiusTop: {
     borderTopStartRadius: 10,

--- a/src/screens/exposureHistory/views/ProximityExposureContent.tsx
+++ b/src/screens/exposureHistory/views/ProximityExposureContent.tsx
@@ -5,6 +5,7 @@ import {HomeScreenTitle} from 'screens/home/components/HomeScreenTitle';
 import {ExposureDateView} from 'screens/home/views/ExposureDateView';
 import {useCachedStorage} from 'services/StorageService';
 import {isRegionActive} from 'shared/RegionLogic';
+import {ExposedHelpButton} from 'components/ExposedHelpButton';
 
 const ActiveContent = ({text}: {text: string}) => {
   if (text === '') {
@@ -35,6 +36,7 @@ export const ProximityExposureContent = ({timestamp}: {timestamp: number}) => {
       ) : (
         <Text marginBottom="m">{i18n.translate('Home.ExposureDetected.Body2')}</Text>
       )}
+      <ExposedHelpButton />
     </>
   );
 };

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -955,6 +955,7 @@ export class ExposureNotificationService {
     };
     displayExposureHistory.push(newHistoryItem);
     this.displayExposureHistory.set(displayExposureHistory);
+    this.saveDisplayExposureHistory();
   }
 
   public selectExposureSummary(nextSummary: ExposureSummary): {summary: ExposureSummary; isNext: boolean} {

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -148,12 +148,6 @@ export class ExposureNotificationService {
     this.exposureHistory.observe(history => {
       this.storageService.save(StorageDirectory.ExposureNotificationServiceExposureHistoryKey, history.join(','));
     });
-    this.displayExposureHistory.observe(history => {
-      this.storageService.save(
-        StorageDirectory.ExposureNotificationServiceDisplayExposureHistoryKey,
-        JSON.stringify(history),
-      );
-    });
 
     if (Platform.OS === 'android') {
       DeviceEventEmitter.removeAllListeners('initiateExposureCheckEvent');
@@ -293,6 +287,7 @@ export class ExposureNotificationService {
     try {
       await this.loadExposureStatus();
       await this.loadExposureHistory();
+      await this.loadDisplayExposureHistory();
       await this.updateExposureStatus();
       await this.processNotification();
       const qrEnabled = (await this.storageService.retrieve(StorageDirectory.GlobalQrEnabledKey)) === '1';
@@ -990,9 +985,11 @@ export class ExposureNotificationService {
   }
 
   public async saveDisplayExposureHistory() {
+    const displayExposureHistory = this.displayExposureHistory.get();
+    log.debug({category: 'debug', message: 'saving displayExposureHistory', payload: {displayExposureHistory}});
     await this.storageService.save(
       StorageDirectory.ExposureNotificationServiceDisplayExposureHistoryKey,
-      JSON.stringify(this.displayExposureHistory.get()),
+      JSON.stringify(displayExposureHistory),
     );
   }
 


### PR DESCRIPTION
# Summary | Résumé

Fixes for the following bugs on the Exposure history screen:
- when there is only one item on the history screen, it now has a radius on the bottom corners:
<img width="344" alt="Screen Shot 2021-05-19 at 10 14 29 AM" src="https://user-images.githubusercontent.com/5498428/118847482-0217a100-b88b-11eb-9b12-a050bf5a570c.png">

- the proximity "Recent Exposure Screen" now has the "find out if you need to be tested" button:
<img width="351" alt="Screen Shot 2021-05-19 at 10 11 50 AM" src="https://user-images.githubusercontent.com/5498428/118847108-a220fa80-b88a-11eb-9b58-2bc485a42596.png">
- I am now forcing the `displayExposureHistory` to be saved after a proximity exposure is detected, hopefully fixing the bug where this was disappearing