### PR TITLE
android date picker fix

### DIFF
--- a/src/screens/datasharing/components/DatePicker.tsx
+++ b/src/screens/datasharing/components/DatePicker.tsx
@@ -60,6 +60,7 @@ const DatePickerInternal = ({dateOptions, pickerStyles, selectedDate, setDate}: 
       selectedValue={selectedDate}
       onValueChange={value => setDate(value.toString())}
       mode="dialog"
+      accessible={true}
     >
       {dateOptions.map(x => (
         <Picker.Item key={x.value} label={x.label} value={x.value} />

--- a/src/screens/datasharing/components/DatePicker.tsx
+++ b/src/screens/datasharing/components/DatePicker.tsx
@@ -60,7 +60,7 @@ const DatePickerInternal = ({dateOptions, pickerStyles, selectedDate, setDate}: 
       selectedValue={selectedDate}
       onValueChange={value => setDate(value.toString())}
       mode="dialog"
-      accessible={true}
+      accessible
     >
       {dateOptions.map(x => (
         <Picker.Item key={x.value} label={x.label} value={x.value} />


### PR DESCRIPTION
# Summary | Résumé

Fix for issue regarding this [bug](https://github.com/cds-snc/covid-alert-app/issues/1587). The date picker would not open up when in voiceover command. This pretty much prevented anyone using the voiceover accessibility feature from sharing exposures.

Quick fix was making the picker accessible