### PR TITLE
Explicitly remove EXTERNAL_STORAGE permissions from manifest file.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- Comment the next 3 lines to use the QR feature -->
     <!-- <uses-permission tools:node="remove" android:name="android.permission.CAMERA" /> -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove" />
+
 
     <application
         android:name="app.covidshield.MainApplication"


### PR DESCRIPTION
# Summary | Résumé

This is an Android only fix.

During the process of including `expo-barcode-scanner` in the app, additional unimodule dependencies were added as part of the Expo framework. These dependencies added permissions for ** android.permission.WRITE_EXTERNAL_STORAGE** and ** android.permission.READ_EXTERNAL_STORAGE**, which are not required for the app.

This PR removes those permissions without changing any functionality.

# Test instructions | Instructions pour tester la modification

Build the app, and test using the camera to capture a QR Code as normal. The camera should work, and there should be no requests for permissions for external storage. This is currently the way it works, so there's no change here.

To verify that the permissions are no longer in the `manifest` file, execute the following command from a computer that has `adb` installed:

> `adb shell dumpsys package ca.gc.hcsc.canada.covidalert.dev`

In the output, verify that the following 2 lines **do not appear**:

> `android.permission.WRITE_EXTERNAL_STORAGE: restricted=true`
> `android.permission.READ_EXTERNAL_STORAGE: restricted=true`