### PR TITLE
Font fix "notosans" vs "Noto Sans"

### DIFF
--- a/src/screens/onboarding/views/Anonymous.tsx
+++ b/src/screens/onboarding/views/Anonymous.tsx
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   bodyContent: {
-    fontFamily: 'Noto Sans',
+    fontFamily: 'notosans',
     fontSize: 18,
   },
 });

--- a/src/screens/onboarding/views/Permissions.tsx
+++ b/src/screens/onboarding/views/Permissions.tsx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   bodyContent: {
-    fontFamily: 'Noto Sans',
+    fontFamily: 'notosans',
     fontSize: 18,
   },
 });


### PR DESCRIPTION
Fixes font defaulting to Roboto for MarkDown component
https://www.youtube.com/watch?v=tbuE56wKJLk (video shows flipping between current code + fix)

Closes https://github.com/cds-snc/covid-alert-app/issues/1626