### PR TITLE
Toggle what to do if your exposed menu button

### DIFF
--- a/src/screens/menu/MenuScreen.tsx
+++ b/src/screens/menu/MenuScreen.tsx
@@ -103,15 +103,17 @@ export const MenuScreen = () => {
               icon="icon-chevron"
             />
 
-            <InfoShareItem
-              text={i18n.translate('Home.ExposedHelpCTA')}
-              onPress={onExposedHelp}
-              icon={regionIcon}
-              accessibilityRole="link"
-              accessibilityHint={`${i18n.translate('Home.ExposedHelpCTA')} . ${i18n.translate(
-                'Home.ExternalLinkHint',
-              )}`}
-            />
+            {!qrEnabled && (
+              <InfoShareItem
+                text={i18n.translate('Home.ExposedHelpCTA')}
+                onPress={onExposedHelp}
+                icon={regionIcon}
+                accessibilityRole="link"
+                accessibilityHint={`${i18n.translate('Home.ExposedHelpCTA')} . ${i18n.translate(
+                  'Home.ExternalLinkHint',
+                )}`}
+              />
+            )}
           </Box>
 
           <Box marginTop="m" marginBottom="s">


### PR DESCRIPTION
Removes the `what to do if your exposed menu button` if QR Code functionality is turned on.

The links will be available via "your recent exposures"

<img width="500" alt="Screen Shot 2021-05-27 at 7 24 02 AM" src="https://user-images.githubusercontent.com/62242/119817927-8cc85380-bebc-11eb-9173-d2978cdd8047.png">
