### PR TITLE
Fix button text size

### DIFF
--- a/src/shared/theme/default.ts
+++ b/src/shared/theme/default.ts
@@ -204,7 +204,7 @@ const theme = {
       height: 52,
       textColor: palette.black,
       fontFamily: 'notosans',
-      fontSize: 20,
+      fontSize: 18,
       borderBottomWidth: 4,
       borderBottomColor: palette.darkGrey,
       disabled: {


### PR DESCRIPTION

> “Prefer not to say” has larger size in app

<img width="400" alt="Screen Shot 2021-05-27 at 8 07 09 AM" src="https://user-images.githubusercontent.com/62242/119823239-92c13300-bec2-11eb-8295-4be072d710fb.png">


