### PR TITLE
Update close button (toolbar) for region picker

### DIFF
--- a/src/screens/regionPicker/RegionPickerSettings.tsx
+++ b/src/screens/regionPicker/RegionPickerSettings.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
 import {useNavigation} from '@react-navigation/native';
-import {Box, Toolbar, Text, TextMultiline} from 'components';
+import {Box, ToolbarWithClose, Text, TextMultiline} from 'components';
 import {ScrollView} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {useCachedStorage} from 'services/StorageService';
@@ -24,13 +24,7 @@ export const RegionPickerSettingsScreen = () => {
   return (
     <Box flex={1} backgroundColor="overlayBackground">
       <SafeAreaView style={regionStyles.flex}>
-        <Toolbar
-          title=""
-          navIcon="icon-back-arrow"
-          navText={i18n.translate('RegionPicker.Close')}
-          navLabel={i18n.translate('RegionPicker.Close')}
-          onIconClicked={close}
-        />
+        <ToolbarWithClose closeText={i18n.translate('RegionPicker.Close')} showBackButton={false} onClose={close} />
         <ScrollView style={regionStyles.flex} testID="RegionPickerSettings-ScrollView">
           <Text
             paddingHorizontal="m"


### PR DESCRIPTION
Updates region picker to move close button to right side

<img width="800" alt="Screen Shot 2021-05-27 at 9 55 54 AM" src="https://user-images.githubusercontent.com/62242/119838897-c6578980-bed1-11eb-9604-529c1358663e.png">

ref: https://github.com/cds-snc/covid-alert-app/issues/1314
