### PR TITLE
QR code box styling

### DIFF
--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {StyleSheet} from 'react-native';
+import {StyleSheet, useWindowDimensions} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {BarCodeScanner, BarCodeScannerResult} from 'expo-barcode-scanner';
 import {Box, Text, ToolbarWithClose} from 'components';
@@ -46,40 +46,42 @@ export const QRCodeScanner = () => {
   };
   const close = useCallback(() => navigation.navigate('Home'), [navigation]);
 
+  const {width} = useWindowDimensions();
+
   return (
-    <BarCodeScanner onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned} style={styles.barcodeScanner}>
+    <>
       <Box style={styles.top} />
+      <Box marginBottom="m" style={styles.toolbar}>
+        <ToolbarWithClose closeText={i18n.translate('DataUpload.Close')} useWhiteText onClose={close} showBackButton />
+      </Box>
 
       <SafeAreaView style={styles.flex}>
-        <Box style={styles.boxLeft} />
-        <Box style={styles.boxRight} />
-        <Box marginBottom="m" style={styles.toolbar}>
-          <ToolbarWithClose
-            closeText={i18n.translate('DataUpload.Close')}
-            useWhiteText
-            onClose={close}
-            showBackButton
-          />
-        </Box>
-
-        <Box
-          style={styles.info}
-          paddingVertical="s"
-          paddingHorizontal="m"
-          height={orientation === 'landscape' ? 40 : '25%'}
+        <BarCodeScanner
+          onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
+          style={{...styles.barcodeScanner, height: width}}
         >
-          <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
-            {i18n.translate(`QRCode.Reader.Title`)}
-          </Text>
-        </Box>
+          <Box
+            style={styles.info}
+            paddingVertical="s"
+            paddingHorizontal="m"
+            height={orientation === 'landscape' ? 40 : '25%'}
+          >
+            <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
+              {i18n.translate(`QRCode.Reader.Title`)}
+            </Text>
+          </Box>
+        </BarCodeScanner>
       </SafeAreaView>
-    </BarCodeScanner>
+    </>
   );
 };
+
+/* {"bottom": 0, "left": 0, "position": "absolute", "right": 0, "top": 0} */
 
 const styles = StyleSheet.create({
   top: {
     position: 'absolute',
+    top: 0,
     height: 30,
     backgroundColor: 'black',
     width: '100%',
@@ -92,22 +94,25 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   toolbar: {
+    top: 30,
     backgroundColor: 'black',
   },
   flex: {
     flex: 1,
+    marginTop: 10,
+    backgroundColor: 'black',
   },
   barcodeScanner: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'black',
+    top: 30,
   },
   boxLeft: {
     top: 0,
     height: '100%',
     left: 0,
     position: 'absolute',
-    width: '4%',
-    paddingBottom: '40%',
+    width: '2%',
     backgroundColor: 'black',
   },
   boxRight: {
@@ -115,8 +120,7 @@ const styles = StyleSheet.create({
     height: '100%',
     right: 0,
     position: 'absolute',
-    width: '4%',
-    paddingBottom: '40%',
+    width: '2%',
     backgroundColor: 'black',
   },
 });

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -48,7 +48,7 @@ export const QRCodeScanner = () => {
 
   const {width} = useWindowDimensions();
 
-  const maskProps = orientation === 'portrait' ? {top: width} : {top: '85%', width: '100%', height: 50};
+  const maskProps = orientation === 'portrait' ? {top: width - 10} : {top: '85%', width: '100%', height: 50};
 
   return (
     <>

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -50,77 +50,51 @@ export const QRCodeScanner = () => {
 
   return (
     <>
-      <Box style={styles.top} />
-      <Box marginBottom="m" style={styles.toolbar}>
-        <ToolbarWithClose closeText={i18n.translate('DataUpload.Close')} useWhiteText onClose={close} showBackButton />
-      </Box>
-
       <SafeAreaView style={styles.flex}>
-        <BarCodeScanner
-          onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
-          style={{...styles.barcodeScanner, height: width}}
-        >
-          <Box
-            style={styles.info}
-            paddingVertical="s"
-            paddingHorizontal="m"
-            height={orientation === 'landscape' ? 40 : '25%'}
+        <Box style={styles.toolbar}>
+          <ToolbarWithClose
+            closeText={i18n.translate('DataUpload.Close')}
+            useWhiteText
+            onClose={close}
+            showBackButton
+          />
+        </Box>
+        <Box paddingVertical="m" paddingHorizontal="m" style={{...styles.scanWrapper}}>
+          <BarCodeScanner
+            onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
+            style={{...styles.barcodeScanner}}
           >
-            <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
-              {i18n.translate(`QRCode.Reader.Title`)}
-            </Text>
-          </Box>
-        </BarCodeScanner>
+            <Box style={{...styles.mask, top: orientation === 'portrait' ? width : '85%'}}>
+              <Box paddingTop="m">
+                <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
+                  {i18n.translate(`QRCode.Reader.Title`)}
+                </Text>
+              </Box>
+            </Box>
+          </BarCodeScanner>
+        </Box>
       </SafeAreaView>
     </>
   );
 };
 
-/* {"bottom": 0, "left": 0, "position": "absolute", "right": 0, "top": 0} */
-
 const styles = StyleSheet.create({
-  top: {
-    position: 'absolute',
-    top: 0,
-    height: 30,
-    backgroundColor: 'black',
-    width: '100%',
-  },
-  info: {
-    backgroundColor: 'black',
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-    width: '100%',
-  },
-  toolbar: {
-    top: 30,
-    backgroundColor: 'black',
-  },
   flex: {
     flex: 1,
-    marginTop: 10,
     backgroundColor: 'black',
+    alignContent: 'flex-start',
+  },
+  toolbar: {
+    top: 0,
+    backgroundColor: 'black',
+  },
+  scanWrapper: {
+    flex: 1,
   },
   barcodeScanner: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'black',
-    top: 30,
+    flex: 0.8,
+    backgroundColor: 'transparent',
   },
-  boxLeft: {
-    top: 0,
-    height: '100%',
-    left: 0,
-    position: 'absolute',
-    width: '2%',
-    backgroundColor: 'black',
-  },
-  boxRight: {
-    top: 0,
-    height: '100%',
-    right: 0,
-    position: 'absolute',
-    width: '2%',
-    backgroundColor: 'black',
-  },
+  /* top:value -> for portrait is offset by width of screen */
+  mask: {bottom: 0, left: 0, right: 0, position: 'absolute', backgroundColor: 'black'},
 });

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -144,6 +144,7 @@ const landscape = StyleSheet.create({
     marginTop: -10,
   },
   textWrap: {
+    flex: 1,
     marginTop: -8,
   },
 });

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -48,6 +48,8 @@ export const QRCodeScanner = () => {
 
   const {width} = useWindowDimensions();
 
+  const maskProps = orientation === 'portrait' ? {top: width} : {top: '85%', width: '100%', height: 50};
+
   return (
     <>
       <SafeAreaView style={styles.flex}>
@@ -59,12 +61,12 @@ export const QRCodeScanner = () => {
             showBackButton
           />
         </Box>
-        <Box paddingVertical="m" paddingHorizontal="m" style={{...styles.scanWrapper}}>
+        <Box paddingVertical="xs" paddingHorizontal="xs" style={{...styles.scanWrapper}}>
           <BarCodeScanner
             onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
             style={{...styles.barcodeScanner}}
           >
-            <Box style={{...styles.mask, top: orientation === 'portrait' ? width : '85%'}}>
+            <Box style={{...styles.mask, ...maskProps}}>
               <Box paddingTop="m">
                 <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
                   {i18n.translate(`QRCode.Reader.Title`)}
@@ -89,12 +91,13 @@ const styles = StyleSheet.create({
     backgroundColor: 'black',
   },
   scanWrapper: {
-    flex: 1,
+    flex: 0.8,
   },
   barcodeScanner: {
-    flex: 0.8,
+    flex: 1,
     backgroundColor: 'transparent',
   },
+
   /* top:value -> for portrait is offset by width of screen */
   mask: {bottom: 0, left: 0, right: 0, position: 'absolute', backgroundColor: 'black'},
 });

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -48,7 +48,7 @@ export const QRCodeScanner = () => {
 
   const {width} = useWindowDimensions();
 
-  const maskProps = orientation === 'portrait' ? {top: width - 10} : {top: '85%', width: '100%', height: 50};
+  const maskProps = orientation === 'portrait' ? {top: width - 10} : {};
 
   return (
     <>
@@ -61,20 +61,44 @@ export const QRCodeScanner = () => {
             showBackButton
           />
         </Box>
-        <Box paddingVertical="xs" paddingHorizontal="xs" style={{...styles.scanWrapper}}>
-          <BarCodeScanner
-            onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
-            style={{...styles.barcodeScanner}}
-          >
-            <Box style={{...styles.mask, ...maskProps}}>
-              <Box paddingTop="m">
-                <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
-                  {i18n.translate(`QRCode.Reader.Title`)}
-                </Text>
+
+        {orientation === 'portrait' ? (
+          <Box paddingVertical="xs" paddingHorizontal="xs" style={portrait.scanWrapper}>
+            <BarCodeScanner
+              onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
+              style={portrait.barcodeScanner}
+            >
+              <Box style={{...portrait.mask, ...maskProps}}>
+                <Box paddingTop="m">
+                  <Text variant="bodyText" accessibilityRole="header" accessibilityAutoFocus color="bodyTitleWhite">
+                    {i18n.translate(`QRCode.Reader.Title`)}
+                  </Text>
+                </Box>
               </Box>
+            </BarCodeScanner>
+          </Box>
+        ) : (
+          <Box paddingVertical="xs" paddingHorizontal="xs" style={landscape.scanWrapper}>
+            <BarCodeScanner
+              onBarCodeScanned={scanned ? () => {} : handleBarCodeScanned}
+              style={landscape.barcodeScanner}
+            >
+              <Box paddingVertical="xs" paddingHorizontal="xs" />
+            </BarCodeScanner>
+
+            <Box style={landscape.textWrap}>
+              <Text
+                variant="bodyText"
+                paddingHorizontal="m"
+                accessibilityRole="header"
+                accessibilityAutoFocus
+                color="bodyTitleWhite"
+              >
+                {i18n.translate(`QRCode.Reader.Title`)}
+              </Text>
             </Box>
-          </BarCodeScanner>
-        </Box>
+          </Box>
+        )}
       </SafeAreaView>
     </>
   );
@@ -90,6 +114,9 @@ const styles = StyleSheet.create({
     top: 0,
     backgroundColor: 'black',
   },
+});
+
+const portrait = StyleSheet.create({
   scanWrapper: {
     flex: 0.8,
   },
@@ -100,4 +127,23 @@ const styles = StyleSheet.create({
 
   /* top:value -> for portrait is offset by width of screen */
   mask: {bottom: 0, left: 0, right: 0, position: 'absolute', backgroundColor: 'black'},
+});
+
+const landscape = StyleSheet.create({
+  scanWrapper: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginTop: -10,
+  },
+  barcodeScanner: {
+    flex: 1,
+    flexDirection: 'column',
+    backgroundColor: 'transparent',
+    height: '100%',
+    marginTop: -10,
+  },
+  textWrap: {
+    marginTop: -8,
+  },
 });


### PR DESCRIPTION
This PR moves the Toolbar outside of the Scanner component and adjust the way the scanner view gets masked.

This ensures the Toolbar doesn't overlap the Camera view - see below 

The new mask setup also creates a square vs rectangle for the Camera view


See:
https://trello.com/c/EXAVYf4W/1280-ensure-qr-scanning-screen-works-on-all-screen-sizes


**How is this working?**

<img width="460" alt="Screen Shot 2021-05-28 at 8 46 22 AM" src="https://user-images.githubusercontent.com/62242/119987009-8ad0c400-bf92-11eb-9cb4-3eb9ea9227e2.png">

**Result:**

<img width="601" alt="Screen Shot 2021-05-28 at 8 55 06 AM" src="https://user-images.githubusercontent.com/62242/119987129-af2ca080-bf92-11eb-9894-fc6b54adf516.png">


**Example current (iPhone)**

Scan area is rectangular shape 

<img width="500" alt="Screen Shot 2021-05-28 at 8 46 22 AM" src="https://user-images.githubusercontent.com/62242/119989967-c8831c00-bf95-11eb-9954-422cd0493026.jpg">


**Toolbar Issues from Beta testing**

Pixel 4a
Toolbar gets cutoff
![pixel4a](https://user-images.githubusercontent.com/62242/119989318-0895cf00-bf95-11eb-9868-1ea1db14f60a.png)

iPhone 12
Toolbar overlap with extra space
![iphone_12_prro](https://user-images.githubusercontent.com/62242/119989334-0c295600-bf95-11eb-8caa-84e05a90f03e.png)



