### PR TITLE
Remove unused db.json

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,8 +1,0 @@
-{
-  "exposedLocations" : [
-    {"locationId": "150", "startTime": 1612396800000, "endTime": 1614816000000},
-    {"locationId":"2", "startTime": 1612396800000, "endTime": 1614816000000},
-    {"locationId":"3", "startTime": 1612396800000, "endTime": 1614816000000},
-    {"locationId":"4", "startTime": 1612396800000, "endTime": 1614816000000}
-  ]
-}


### PR DESCRIPTION
Removes db.json which was used for mocking outbreak data.  We're now using the staging server for this purpose and the payload type has changed.