### PR TITLE
Android Background check testing - set a longer delay for dev builds to test check for outbreak

### DIFF
--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -1,6 +1,6 @@
 import BackgroundFetch from 'react-native-background-fetch';
 import {AppRegistry, Platform} from 'react-native';
-import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL, TEST_MODE} from 'env';
+import {HMAC_KEY, RETRIEVE_URL, SUBMIT_URL} from 'env';
 import {FilteredMetricsService} from 'services/MetricsService';
 import ExposureNotification from 'bridge/ExposureNotification';
 import {publishDebugMetric} from 'bridge/DebugMetrics';
@@ -20,8 +20,10 @@ interface PeriodicTask {
   (): Promise<void>;
 }
 
-export const PERIODIC_TASK_INTERVAL_IN_MINUTES = TEST_MODE ? 15 : 240;
-export const PERIODIC_TASK_DELAY_IN_MINUTES = TEST_MODE ? 1 : PERIODIC_TASK_INTERVAL_IN_MINUTES + 5;
+// export const PERIODIC_TASK_INTERVAL_IN_MINUTES = TEST_MODE ? 15 : 240;
+// export const PERIODIC_TASK_DELAY_IN_MINUTES = TEST_MODE ? 1 : PERIODIC_TASK_INTERVAL_IN_MINUTES + 5;
+export const PERIODIC_TASK_INTERVAL_IN_MINUTES = 120;
+export const PERIODIC_TASK_DELAY_IN_MINUTES = PERIODIC_TASK_INTERVAL_IN_MINUTES + 5;
 
 const registerPeriodicTask = async (task: PeriodicTask, exposureNotificationService?: ExposureNotificationService) => {
   publishDebugMetric(0);

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -1,7 +1,6 @@
 import {Buffer} from 'buffer';
 
 import {Platform} from 'react-native';
-import {TEST_MODE} from 'env';
 import {StorageService, StorageDirectory, DefaultStorageService} from 'services/StorageService';
 import PushNotification from 'bridge/PushNotification';
 import {I18n} from 'locale';
@@ -29,7 +28,8 @@ import {log} from '../../shared/logging/config';
 
 import {getOutbreaksLastCheckedDateTime, markOutbreaksLastCheckedDateTime} from './OutbreakStorage';
 
-const MIN_OUTBREAKS_CHECK_MINUTES = TEST_MODE ? 15 : 240;
+// const MIN_OUTBREAKS_CHECK_MINUTES = TEST_MODE ? 15 : 240;
+const MIN_OUTBREAKS_CHECK_MINUTES = 120;
 
 export const HOURS_PER_PERIOD = 24;
 


### PR DESCRIPTION
This is for testing only - adding a longer delay (vs 15 min dev checks)