### PR TITLE
Fastlane output log files

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,13 @@ lane :load_env_file do |options|
   env_file=".env.#{buildType}"
   ensure_env_file_exists(file: env_file)
 
+  env_data = File.read(File.expand_path "../#{env_file}")
+  UI.message("==============================================================")
+  UI.message("----- ENV FILE: #{File.expand_path "../#{env_file}"}")
+  UI.message("==============================================================")
+  UI.message(env_data)
+  UI.message("==============================================================")
+
   # Load the environment
   Dotenv.overload "../#{env_file}"
   ENV["ENVFILE"] = env_file

--- a/fastlane/iOS.Fastfile
+++ b/fastlane/iOS.Fastfile
@@ -41,6 +41,10 @@ platform :ios do
       yarn(
         command: 'run-ios:production'
       )
+    elsif options[:type] === 'staging'
+      yarn(
+        command: 'run-ios:staging'
+      )
     else
       yarn(
         command: 'run-ios'

--- a/fastlane/iOS.Fastfile
+++ b/fastlane/iOS.Fastfile
@@ -50,6 +50,14 @@ platform :ios do
     # Load env file
     load_env_file(buildType:buildType)
 
+    # Log iOS specific ENV variables
+    ios_env_data = File.read(File.expand_path "../ios/Generated.xcconfig")
+    UI.message("==============================================================")
+    UI.message("----- iOS ENV FILE: #{File.expand_path "../ios/Generated.xcconfig"}")
+    UI.message("==============================================================")
+    UI.message(ios_env_data)
+    UI.message("==============================================================")
+
     # Check required env vars
     UI.user_error!("Missing XCODE_SCHEME environment variable") unless ENV['XCODE_SCHEME']
 

--- a/fastlane/logs/.gitignore
+++ b/fastlane/logs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "onboard": "bundle exec fastlane onboard",
     "onboard:dev_only": "bundle exec fastlane onboard_dev",
     "get_latest_version": "bundle exec fastlane get_latest_version",
-    "deploy-android:staging": "bundle exec fastlane android build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-android-staging-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-android:production": "bundle exec fastlane android build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-android-production-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-ios:staging": "bundle exec fastlane ios build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-ios-staging-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-ios:production": "bundle exec fastlane ios build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-ios-production-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-ios:diawi": "bundle exec fastlane ios adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-ios-diawi-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-android:diawi": "bundle exec fastlane android adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-android-diawi-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
-    "deploy-ios:demo": "bundle exec fastlane ios build_and_deploy type:demo | tee -a ./fastlane/logs/fastlane-deploy-ios-demo-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log"
+    "deploy-android:staging": "bundle exec fastlane android build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-android-staging-$(cat .env.staging | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.staging | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-android:production": "bundle exec fastlane android build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-android-production-$(cat .env.production | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.production | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:staging": "bundle exec fastlane ios build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-ios-staging-$(cat .env.staging | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.staging | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:production": "bundle exec fastlane ios build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-ios-production-$(cat .env.production | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.production | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:diawi": "bundle exec fastlane ios adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-ios-diawi-$(cat .env.diawi | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.diawi | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-android:diawi": "bundle exec fastlane android adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-android-diawi-$(cat .env.diawi | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env.diawi | grep APP_VERSION_CODE | cut -d'=' -f2)-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:demo": "bundle exec fastlane ios build_and_deploy type:demo | tee -a ./fastlane/logs/fastlane-deploy-ios-demo--$(cat .env | grep APP_VERSION_NAME | cut -d'=' -f2)_$(cat .env | grep APP_VERSION_CODE | cut -d'=' -f2)$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "pod-install": "pushd ios; bundle exec pod install; popd",
     "run-android": "react-native run-android --variant debug",
+    "run-ios:staging": "ENVFILE=.env.staging react-native run-ios --scheme Staging",
     "run-ios:production": "ENVFILE=.env.production react-native run-ios --scheme Production",
     "run-ios": "react-native run-ios --scheme Staging --simulator='iPhone 8'",
     "start": "react-native start --reset-cache",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "onboard": "bundle exec fastlane onboard",
     "onboard:dev_only": "bundle exec fastlane onboard_dev",
     "get_latest_version": "bundle exec fastlane get_latest_version",
-    "deploy-android:staging": "bundle exec fastlane android build_and_deploy type:staging",
-    "deploy-android:production": "bundle exec fastlane android build_and_deploy type:production",
-    "deploy-ios:staging": "bundle exec fastlane ios build_and_deploy type:staging",
-    "deploy-ios:production": "bundle exec fastlane ios build_and_deploy type:production",
-    "deploy-ios:diawi": "bundle exec fastlane ios adhoc env:diawi",
-    "deploy-android:diawi": "bundle exec fastlane android adhoc env:diawi",
-    "deploy-ios:demo": "bundle exec fastlane ios build_and_deploy type:demo"
+    "deploy-android:staging": "bundle exec fastlane android build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-android-staging-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-android:production": "bundle exec fastlane android build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-android-production-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:staging": "bundle exec fastlane ios build_and_deploy type:staging | tee -a ./fastlane/logs/fastlane-deploy-ios-staging-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:production": "bundle exec fastlane ios build_and_deploy type:production | tee -a ./fastlane/logs/fastlane-deploy-ios-production-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:diawi": "bundle exec fastlane ios adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-ios-diawi-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-android:diawi": "bundle exec fastlane android adhoc env:diawi | tee -a ./fastlane/logs/fastlane-deploy-android-diawi-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log",
+    "deploy-ios:demo": "bundle exec fastlane ios build_and_deploy type:demo | tee -a ./fastlane/logs/fastlane-deploy-ios-demo-$(date +%Y%m%d-%H%M%S)-$(stat -f %Su /dev/console).log"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.9.0",


### PR DESCRIPTION
# Summary | Résumé

This will save the log files from a Fastlane build, to be used for potential future debugging.

Added the entire contents of the ENV file to the logs.

Included the datetime and username in the log filename, to know when it was built, and by whom.

Logs are stored in the `fastlane/logs` folder, but not uploaded to Github.