### PR TITLE
Severity Fix

### DIFF
--- a/src/screens/exposureHistory/ExposureHistoryScreen.tsx
+++ b/src/screens/exposureHistory/ExposureHistoryScreen.tsx
@@ -28,8 +28,6 @@ import {NoExposureHistoryScreen} from './views/NoExposureHistoryScreen';
 
 const severityText = ({severity, i18n}: {severity: OutbreakSeverity; i18n: I18n}) => {
   switch (severity) {
-    case OutbreakSeverity.GetTested:
-      return i18n.translate('QRCode.OutbreakExposed.GetTested.Title');
     case OutbreakSeverity.SelfIsolate:
       return i18n.translate('QRCode.OutbreakExposed.SelfIsolate.Title');
     case OutbreakSeverity.SelfMonitor:

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -53,8 +53,6 @@ export const OutbreakConditionalText = ({
   showNegativeTestButton?: boolean;
 }) => {
   switch (severity) {
-    case OutbreakSeverity.GetTested:
-      return <GetTestedText i18n={i18n} showNegativeTestButton={showNegativeTestButton} />;
     case OutbreakSeverity.SelfIsolate:
       return <IsolateText i18n={i18n} showNegativeTestButton={showNegativeTestButton} />;
     case OutbreakSeverity.SelfMonitor:

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {RoundedBox, Text, TextMultiline} from 'components';
 import {useI18n, I18n} from 'locale';
-import {useOutbreakService} from 'services/OutbreakService';
+import {useOutbreakService, getSortedOutbreakArrayByTimestamp} from 'services/OutbreakService';
 import {getNonIgnoredOutbreakHistory, OutbreakHistoryItem, OutbreakSeverity} from 'shared/qr';
 import {formatExposedDate} from 'shared/date-fns';
 import {TEST_MODE} from 'env';
@@ -14,10 +14,10 @@ import {NegativeOutbreakTestButton} from './ClearOutbreakExposureView';
 export const OutbreakExposedView = () => {
   const i18n = useI18n();
   const {outbreakHistory} = useOutbreakService();
-  const nonIgnoredOutbreakHistory = getNonIgnoredOutbreakHistory(outbreakHistory);
+  const nonIgnoredOutbreakHistory = getNonIgnoredOutbreakHistory(getSortedOutbreakArrayByTimestamp(outbreakHistory));
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
 
-  const historyItem: OutbreakHistoryItem = nonIgnoredOutbreakHistory[nonIgnoredOutbreakHistory.length - 1];
+  const historyItem: OutbreakHistoryItem = nonIgnoredOutbreakHistory[0];
   const severity = historyItem?.severity;
 
   const exposureDate = TEST_MODE

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -17,9 +17,9 @@ export const OutbreakExposedView = () => {
   const nonIgnoredOutbreakHistory = getNonIgnoredOutbreakHistory(outbreakHistory);
   const dateLocale = i18n.locale === 'fr' ? 'fr-CA' : 'en-CA';
 
-  const historyItem: OutbreakHistoryItem = nonIgnoredOutbreakHistory[0];
-
+  const historyItem: OutbreakHistoryItem = nonIgnoredOutbreakHistory[nonIgnoredOutbreakHistory.length - 1];
   const severity = historyItem?.severity;
+
   const exposureDate = TEST_MODE
     ? formatExposedDate(new Date(), dateLocale)
     : formatExposedDate(new Date(historyItem?.notificationTimestamp), dateLocale);

--- a/src/screens/home/views/OutbreakExposedView.tsx
+++ b/src/screens/home/views/OutbreakExposedView.tsx
@@ -84,15 +84,3 @@ const MonitorText = ({i18n}: {i18n: I18n}) => {
     </>
   );
 };
-
-const GetTestedText = ({i18n, showNegativeTestButton}: {i18n: I18n; showNegativeTestButton: boolean}) => {
-  return (
-    <>
-      <Text variant="bodyTitle" marginBottom="m" accessibilityRole="header">
-        {i18n.translate('QRCode.OutbreakExposed.GetTested.Title')}
-      </Text>
-      <TextMultiline marginBottom="m" text={i18n.translate('QRCode.OutbreakExposed.GetTested.Body')} />
-      {showNegativeTestButton ? <NegativeOutbreakTestButton /> : null}
-    </>
-  );
-};

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -250,7 +250,7 @@ export class OutbreakService {
               message: 'exposed',
             });
             FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ExposedToOutbreak});
-            this.processOutbreakNotification(this.getSeverity());
+            this.processOutbreakNotification(getSortedOutbreakArrayByTimestamp(outbreakHistory)[0].severity);
           }
         } catch (error) {
           log.error({category: 'qr-code', error});
@@ -380,15 +380,6 @@ export class OutbreakService {
     }
     return periodsToFetch;
   };
-
-  getSeverity = (): number => {
-    const outbreakHistory = this.outbreakHistory.get();
-    const severityArray = outbreakHistory.map(data => {
-      return data.severity;
-    });
-
-    return severityArray[severityArray.length - 1];
-  };
 }
 
 export const isDiagnosed = (status: string): boolean => {
@@ -397,3 +388,9 @@ export const isDiagnosed = (status: string): boolean => {
   }
   return false;
 };
+
+export const getSortedOutbreakArrayByTimestamp = (outbreakHistory: OutbreakHistoryItem[]): OutbreakHistoryItem[] => {
+const orderedTimestampArray = outbreakHistory.sort((first, second) => second.notificationTimestamp - first.notificationTimestamp)
+
+return orderedTimestampArray;
+}

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -250,7 +250,7 @@ export class OutbreakService {
               message: 'exposed',
             });
             FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.ExposedToOutbreak});
-            this.processOutbreakNotification();
+            this.processOutbreakNotification(this.getSeverity());
           }
         } catch (error) {
           log.error({category: 'qr-code', error});
@@ -349,7 +349,7 @@ export class OutbreakService {
     return this.convertOutbreakEvents(outbreakEvents);
   };
 
-  processOutbreakNotification = () => {
+  processOutbreakNotification = (severity: number) => {
     log.debug({
       category: 'qr-code',
       message: 'processOutbreakNotification',
@@ -357,7 +357,10 @@ export class OutbreakService {
 
     PushNotification.presentLocalNotification({
       alertTitle: this.i18n.translate('Notification.OutbreakMessageTitle'),
-      alertBody: this.i18n.translate('Notification.OutbreakMessageIsolate'),
+      alertBody:
+        severity === 1
+          ? this.i18n.translate('Notification.OutbreakMessageIsolate')
+          : this.i18n.translate('Notification.OutbreakMessageMonitor'),
       channelName: this.i18n.translate('Notification.AndroidChannelName'),
     });
   };
@@ -376,6 +379,15 @@ export class OutbreakService {
       runningPeriod -= 1;
     }
     return periodsToFetch;
+  };
+
+  getSeverity = (): number => {
+    const outbreakHistory = this.outbreakHistory.get();
+    const severityArray = outbreakHistory.map(data => {
+      return data.severity;
+    });
+
+    return severityArray[severityArray.length - 1];
   };
 }
 

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -390,7 +390,9 @@ export const isDiagnosed = (status: string): boolean => {
 };
 
 export const getSortedOutbreakArrayByTimestamp = (outbreakHistory: OutbreakHistoryItem[]): OutbreakHistoryItem[] => {
-const orderedTimestampArray = outbreakHistory.sort((first, second) => second.notificationTimestamp - first.notificationTimestamp)
+  const orderedTimestampArray = outbreakHistory.sort(
+    (first, second) => second.notificationTimestamp - first.notificationTimestamp,
+  );
 
-return orderedTimestampArray;
-}
+  return orderedTimestampArray;
+};

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -7,9 +7,9 @@ import {getCurrentDate, getHoursBetween} from './date-fns';
 export const OUTBREAK_EXPOSURE_DURATION_DAYS = 14;
 
 export enum OutbreakSeverity {
-  SelfMonitor = 1,
-  SelfIsolate = 2,
-  GetTested = 3,
+  SelfIsolate = 1,
+  SelfMonitor = 2,
+
 }
 
 export enum ExposureType {

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -9,7 +9,6 @@ export const OUTBREAK_EXPOSURE_DURATION_DAYS = 14;
 export enum OutbreakSeverity {
   SelfIsolate = 1,
   SelfMonitor = 2,
-
 }
 
 export enum ExposureType {


### PR DESCRIPTION
# Summary | Résumé

Issue with Outbreak severity which would give incorrect content and notification. The severity values were flipped around on our end.

Fixes:
- Fixed severity values to match with portal
- created a conditional to send the correct Push Notification based on which severity by pulling the most recent severity
- Fixed OutbreakExposedView to give the most recent history item by pulling the most recent history item in the event that a user has mutiple severities. 

