### PR TITLE
Dynamic back button for QR Code Scanner toolbar

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -525,12 +525,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXBarCodeScanner: 38e025a8d508f40a96c44dc87bd4f8765f8002cd
   EXPermissions: 17d4846ad1880f6891c74ae58ca1acb43e47ed47
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 2a59be1c614979e9ea801a28227667b4618abf8c
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  FBReactNativeSpec: 9b7bebeb96ad1cec965025af43dd825a55a75c72
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   Permission-Notifications: d437cafc026900006d35981d35a2d694f883f44e
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -525,12 +525,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   EXBarCodeScanner: 38e025a8d508f40a96c44dc87bd4f8765f8002cd
   EXPermissions: 17d4846ad1880f6891c74ae58ca1acb43e47ed47
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 9b7bebeb96ad1cec965025af43dd825a55a75c72
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  FBReactNativeSpec: 2a59be1c614979e9ea801a28227667b4618abf8c
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Permission-Notifications: d437cafc026900006d35981d35a2d694f883f44e
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -152,6 +152,11 @@ const DataSharingNavigator = () => {
 };
 
 const QRCodeStack = createStackNavigator();
+
+export interface QRCodeStackParamList extends Record<string, object | undefined> {
+  QRCodeReaderScreen: {fromScreen?: string};
+}
+
 const QRCodeNavigator = () => {
   const {hasViewedQrInstructions} = useCachedStorage();
   return (

--- a/src/screens/qr/QRCodeIntroScreen.tsx
+++ b/src/screens/qr/QRCodeIntroScreen.tsx
@@ -20,7 +20,7 @@ export const QRCodeIntroScreen = () => {
   const navigation = useNavigation();
   const i18n = useI18n();
   const toQRScreen = useCallback(async () => {
-    navigation.navigate('QRCodeReaderScreen');
+    navigation.navigate('QRCodeReaderScreen', {fromScreen: 'QRCodeIntroScreen'});
   }, [navigation]);
   return (
     <BaseQRCodeScreen showBackButton={false}>

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -34,8 +34,7 @@ export const QRCodeScanner = () => {
       const checkInData = await handleOpenURL({url: data});
       setScanned(true);
       addCheckIn(checkInData);
-      // ensure has view has been set to stop
-      // tutorial from showing again
+      // ensure hasViewedQrInstructions has been set to stop <LearnAboutQRScreen /> from showing again
       await setHasViewedQr(true);
 
       FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.QrCodeSuccessfullyScanned});

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -21,7 +21,7 @@ export const QRCodeScanner = () => {
   const {addCheckIn} = useOutbreakService();
   const {orientation} = useOrientation();
   const [scanned, setScanned] = useState<boolean>(false);
-  const {hasViewedQrInstructions} = useCachedStorage();
+  const {hasViewedQrInstructions, setHasViewedQr} = useCachedStorage();
 
   const route = useRoute<QRCodeReaderScreenProps>();
 
@@ -34,6 +34,9 @@ export const QRCodeScanner = () => {
       const checkInData = await handleOpenURL({url: data});
       setScanned(true);
       addCheckIn(checkInData);
+      // ensure has view has been set to stop
+      // tutorial from showing again
+      await setHasViewedQr(true);
 
       FilteredMetricsService.sharedInstance().addEvent({type: EventTypeMetric.QrCodeSuccessfullyScanned});
 

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -66,12 +66,7 @@ export const QRCodeScanner = () => {
       <StatusBar barStyle="light-content" />
       <SafeAreaView style={styles.flex}>
         <Box style={styles.toolbar}>
-          <ToolbarWithClose
-            closeText={i18n.translate('DataUpload.Close')}
-            useWhiteText
-            onClose={close}
-            showBackButton
-          />
+          <ToolbarWithClose closeText={i18n.translate('DataUpload.Close')} useWhiteText onClose={close} />
         </Box>
 
         {orientation === 'portrait' ? (

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -4,14 +4,17 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import {BarCodeScanner, BarCodeScannerResult} from 'expo-barcode-scanner';
 import {Box, Text, ToolbarWithClose} from 'components';
 import {useI18n} from 'locale';
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useRoute, RouteProp} from '@react-navigation/native';
 import {log} from 'shared/logging/config';
 import {useOutbreakService} from 'services/OutbreakService';
 import {useOrientation} from 'shared/useOrientation';
 import {EventTypeMetric, FilteredMetricsService} from 'services/MetricsService';
 import {useCachedStorage} from 'services/StorageService';
+import {QRCodeStackParamList} from 'navigation/MainNavigator';
 
 import {handleOpenURL} from '../utils';
+
+type QRCodeReaderScreenProps = RouteProp<QRCodeStackParamList, 'QRCodeReaderScreen'>;
 
 export const QRCodeScanner = () => {
   const navigation = useNavigation();
@@ -19,6 +22,10 @@ export const QRCodeScanner = () => {
   const {orientation} = useOrientation();
   const [scanned, setScanned] = useState<boolean>(false);
   const {hasViewedQrInstructions} = useCachedStorage();
+
+  const route = useRoute<QRCodeReaderScreenProps>();
+
+  const fromScreen = route.params?.fromScreen;
 
   const i18n = useI18n();
   const handleBarCodeScanned = async (scanningResult: BarCodeScannerResult) => {
@@ -61,8 +68,12 @@ export const QRCodeScanner = () => {
     return () => {
       AppState.removeEventListener('change', onAppStateChange);
     };
-  }, []);
-  const toolBarProps = hasViewedQrInstructions === true ? {showBackButton: false} : {showBackButton: true};
+  }, [navigation]);
+
+  const toolBarProps =
+    hasViewedQrInstructions === true && fromScreen !== 'QRCodeIntroScreen'
+      ? {showBackButton: false}
+      : {showBackButton: true};
 
   return (
     <>

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -62,7 +62,7 @@ export const QRCodeScanner = () => {
       AppState.removeEventListener('change', onAppStateChange);
     };
   }, []);
-  const toolBarProps = hasViewedQrInstructions ? {} : {showBackButton: true};
+  const toolBarProps = hasViewedQrInstructions === true ? {showBackButton: false} : {showBackButton: true};
 
   return (
     <>

--- a/src/screens/qr/views/QRCodeScanner.tsx
+++ b/src/screens/qr/views/QRCodeScanner.tsx
@@ -9,6 +9,7 @@ import {log} from 'shared/logging/config';
 import {useOutbreakService} from 'services/OutbreakService';
 import {useOrientation} from 'shared/useOrientation';
 import {EventTypeMetric, FilteredMetricsService} from 'services/MetricsService';
+import {useCachedStorage} from 'services/StorageService';
 
 import {handleOpenURL} from '../utils';
 
@@ -17,6 +18,7 @@ export const QRCodeScanner = () => {
   const {addCheckIn} = useOutbreakService();
   const {orientation} = useOrientation();
   const [scanned, setScanned] = useState<boolean>(false);
+  const {hasViewedQrInstructions} = useCachedStorage();
 
   const i18n = useI18n();
   const handleBarCodeScanned = async (scanningResult: BarCodeScannerResult) => {
@@ -60,13 +62,19 @@ export const QRCodeScanner = () => {
       AppState.removeEventListener('change', onAppStateChange);
     };
   }, []);
+  const toolBarProps = hasViewedQrInstructions ? {} : {showBackButton: true};
 
   return (
     <>
       <StatusBar barStyle="light-content" />
       <SafeAreaView style={styles.flex}>
         <Box style={styles.toolbar}>
-          <ToolbarWithClose closeText={i18n.translate('DataUpload.Close')} useWhiteText onClose={close} />
+          <ToolbarWithClose
+            closeText={i18n.translate('DataUpload.Close')}
+            useWhiteText
+            onClose={close}
+            {...toolBarProps}
+          />
         </Box>
 
         {orientation === 'portrait' ? (


### PR DESCRIPTION
This PR makes the back button on the QR Code Scanner Toolbar dynamic vs always showing


First visit:
```
Add a visit -> Qr Code Instructions -> QR Code Scanner with back button
```

Additional visits:
```
Add a visit button ->  QR Code Scanner without back button
```

<hr>

Two variables are used to determine showing or hiding.

1. `fromScreen` which has been added to the route to detect if the previous screen was the instructions screen

2. `hasViewedQrInstructions` note: this was previously in the code but had a bug

The previous code for setting hasViewedQrInstructions was only set after receiving camera permissions.  If for whatever reason the variable isn't set (possibly re-install or another scenario) the variable would never be set.  I added additional code to set the hasViewedQrInstructions variable after a successful scan.


<img width="618" alt="Screen Shot 2021-06-03 at 5 17 11 PM" src="https://user-images.githubusercontent.com/62242/120713263-a73b9780-c48f-11eb-989f-d39791e7087e.png">
