### PR TITLE
MainNavigator cleanup

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -64,23 +64,13 @@ const withDarkNavNonModal = (Component: React.ElementType) => {
   return ComponentWithDarkNav;
 };
 
-// const withLightNav = (Component: React.ElementType) => {
-//   const ComponentWithLightNav = (props: any) => (
-//     <SafeAreaProvider>
-//       <StatusBar barStyle="light-content" />
-//       <Component {...props} />
-//     </SafeAreaProvider>
-//   );
-//   return ComponentWithLightNav;
-// };
-
 export interface MainStackParamList extends Record<string, object | undefined> {
   Home: {timestamp?: number};
   Onboarding: undefined;
   Tutorial: undefined;
-  QROnboard: undefined;
+  QRcodeOnboard: undefined;
   RegionSelectExposedNoPT: {drawerMenu: boolean} | undefined;
-  ExposureHistoryScreen: {refreshAt?: number};
+  ExposureHistoryScreen: undefined;
   RecentExposureScreen: {exposureHistoryItem: CombinedExposureHistoryData};
   CheckInHistoryScreen: {closeRoute: string};
 }


### PR DESCRIPTION
Cleaning up some commented out code + a few references that have been removed or moved out of the main stack

i.e. ExposureHistoryStack

ExposureHistoryScreen has moved to the ExposureHistoryStack and is no longer using the `refreshAt` route prop

