### PR TITLE
Test expire outbreaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "react-test-renderer": "17.0.2",
     "ts-jest": "26.5.4",
     "typescript": "^4.2.3",
-    "wait-for-expect": "^3.0.2"
+    "wait-for-expect": "^3.0.2",
+    "mockdate": "^3.0.5"
   }
 }

--- a/src/services/OutbreakService/OutbreakService.spec.ts
+++ b/src/services/OutbreakService/OutbreakService.spec.ts
@@ -1,9 +1,10 @@
+import MockDate from 'mockdate';
+
 // eslint-disable-next-line @shopify/strict-component-boundaries
 import {StorageServiceMock} from '../StorageService/tests/StorageServiceMock';
 
 import {OutbreakService} from './OutbreakService';
 import {checkIns, addHours, subtractHours} from './tests/utils';
-import MockDate from 'mockdate';
 
 const i18n: any = {
   translate: jest.fn().mockReturnValue('foo'),

--- a/src/services/OutbreakService/OutbreakService.spec.ts
+++ b/src/services/OutbreakService/OutbreakService.spec.ts
@@ -109,11 +109,8 @@ describe('OutbreakService', () => {
     expect(outbreakHistory).toHaveLength(1);
   });
 
-  //
-
   it('expires outbreaks', async () => {
     jest.spyOn(service, 'extractOutbreakEventsFromZipFiles').mockImplementation(async () => {
-      console.log('extractOutbreakEventsFromZipFiles', new Date().toString());
       return service.convertOutbreakEvents([
         {
           locationId: checkIns[0].id,
@@ -123,26 +120,22 @@ describe('OutbreakService', () => {
         },
       ]);
     });
-
+    MockDate.set('2021-02-01T12:00Z');
     await service.addCheckIn(checkIns[0]);
     await service.addCheckIn(checkIns[1]);
 
+    await service.checkForOutbreaks(true);
+    const outbreakHistory = service.outbreakHistory.get();
+    expect(outbreakHistory[0].isExpired).toStrictEqual(false);
+
+    MockDate.set('2021-02-15T13:00Z');
+    await service.checkForOutbreaks(true);
+
+    const outbreakHistoryExpired = service.outbreakHistory.get();
+
+    expect(outbreakHistoryExpired[0].isExpired).toStrictEqual(true);
+
     MockDate.set('2021-02-01T12:00Z');
-    console.log(new Date().toString());
-
-    await service.checkForOutbreaks(true);
-    const outbreakHistory1 = service.outbreakHistory.get();
-    console.log(outbreakHistory1);
-
-    MockDate.set('2021-04-01T12:00Z');
-    console.log(new Date().toString());
-
-    await service.checkForOutbreaks(true);
-
-    const outbreakHistory2 = service.outbreakHistory.get();
-    console.log(outbreakHistory2);
-
-    expect(outbreakHistory1).toHaveLength(1);
   });
 
   //

--- a/src/services/OutbreakService/OutbreakService.spec.ts
+++ b/src/services/OutbreakService/OutbreakService.spec.ts
@@ -121,21 +121,29 @@ describe('OutbreakService', () => {
         },
       ]);
     });
+
     MockDate.set('2021-02-01T12:00Z');
     await service.addCheckIn(checkIns[0]);
     await service.addCheckIn(checkIns[1]);
 
+    // set as exposed
     await service.checkForOutbreaks(true);
     const outbreakHistory = service.outbreakHistory.get();
     expect(outbreakHistory[0].isExpired).toStrictEqual(false);
 
+    // move ahead in time to ensure we're not marking as expired too soon
+    MockDate.set('2021-02-05T12:00Z');
+    const outbreakHistoryNotExpired = service.outbreakHistory.get();
+    expect(outbreakHistoryNotExpired[0].isExpired).toStrictEqual(false);
+
+    // move past the EXPOSURE_NOTIFICATION_CYCLE day mark
     MockDate.set('2021-02-15T13:00Z');
     await service.checkForOutbreaks(true);
 
     const outbreakHistoryExpired = service.outbreakHistory.get();
-
     expect(outbreakHistoryExpired[0].isExpired).toStrictEqual(true);
 
+    // reset back to default
     MockDate.set('2021-02-01T12:00Z');
   });
 

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -104,6 +104,19 @@ export class OutbreakService {
     );
   };
 
+  expireOutbreak = async (outbreakId: string) => {
+    this.outbreakHistory
+      .get()
+      .filter(outbreak => outbreak.id === outbreakId)
+      .forEach(outbreak => {
+        outbreak.isExpired = true;
+      });
+    await this.storageService.save(
+      StorageDirectory.OutbreakServiceOutbreakHistoryKey,
+      JSON.stringify(this.outbreakHistory.get()),
+    );
+  };
+
   ignoreOutbreak = async (outbreakId: string) => {
     this.outbreakHistory
       .get()
@@ -182,8 +195,8 @@ export class OutbreakService {
     const expireHistory = expireHistoryItems(outbreakHistory);
 
     expireHistory.forEach((historyItem: OutbreakHistoryItem) => {
-      if (historyItem.isIgnored) {
-        this.ignoreOutbreak(historyItem.id);
+      if (historyItem.isExpired) {
+        this.expireOutbreak(historyItem.id);
       }
     });
   };

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -90,6 +90,9 @@ export const expireHistoryItems = (outbreakHistory: OutbreakHistoryItem[]): Outb
       return {...historyItem};
     }
     const currentDate = getCurrentDate();
+
+    console.log('expireHistoryItems currentDate', currentDate);
+
     const hoursSinceCheckIn = getHoursBetween(new Date(historyItem.checkInTimestamp), currentDate);
 
     if (hoursSinceCheckIn > 24 * OUTBREAK_EXPOSURE_DURATION_DAYS) {

--- a/src/shared/qr.ts
+++ b/src/shared/qr.ts
@@ -91,13 +91,12 @@ export const expireHistoryItems = (outbreakHistory: OutbreakHistoryItem[]): Outb
     }
     const currentDate = getCurrentDate();
 
-    console.log('expireHistoryItems currentDate', currentDate);
-
     const hoursSinceCheckIn = getHoursBetween(new Date(historyItem.checkInTimestamp), currentDate);
 
     if (hoursSinceCheckIn > 24 * OUTBREAK_EXPOSURE_DURATION_DAYS) {
       return {...historyItem, isExpired: true};
     }
+
     return {...historyItem};
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8501,6 +8501,11 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 moment@^2.10.6:
   version "2.25.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.25.3.tgz#252ff41319cf41e47761a1a88cab30edfe9808c0"


### PR DESCRIPTION
- Adds new package for mocking dates
- Fixes bug where isIgnored was being set vs isExpired
- Adds test to create matched outbreak + move forward in time to ensure items get set as expired
