### PR TITLE
Remove has viewed after camera perms

### DIFF
--- a/src/screens/qr/LearnAboutQRScreen.tsx
+++ b/src/screens/qr/LearnAboutQRScreen.tsx
@@ -13,7 +13,6 @@ export const LearnAboutQRScreen = ({updatePermissions}: {updatePermissions: () =
   const requestPermissions = useCallback(async () => {
     try {
       await BarCodeScanner.requestPermissionsAsync();
-      await setHasViewedQr(true);
       updatePermissions();
     } catch (err) {
       log.error({category: 'qr-code', message: err.message});


### PR DESCRIPTION
Fixes issue with QR code onboarding 

The app will now only set the `has viewed` after a successful scan