### PR TITLE
Remove outbreaks from storage after they expire

### DIFF
--- a/src/services/StorageService/tests/StorageServiceMock.ts
+++ b/src/services/StorageService/tests/StorageServiceMock.ts
@@ -9,11 +9,13 @@ export class StorageServiceMock implements StorageService {
 
   save(keyDefinition: KeyDefinition, value: string): Promise<void> {
     this.store.set(keyDefinition.keyIdentifier, value);
+
     return Promise.resolve();
   }
 
   retrieve(keyDefinition: KeyDefinition): Promise<string | null> {
     const result = this.store.get(keyDefinition.keyIdentifier);
+
     if (result) {
       return Promise.resolve(result);
     } else {

--- a/src/shared/qr.spec.ts
+++ b/src/shared/qr.spec.ts
@@ -62,7 +62,7 @@ describe('getMatchedOutbreakHistoryItems', () => {
       {id: '1', timestamp: t1200, address: '', name: ''},
       {id: '3', timestamp: t1200, address: '', name: ''},
     ];
-    const history = getMatchedOutbreakHistoryItems(checkInHistory, outbreakEvents);
+    const history = getMatchedOutbreakHistoryItems(checkInHistory, outbreakEvents, true);
     expect(isExposedToOutbreak(history)).toStrictEqual(true);
   });
 
@@ -205,7 +205,7 @@ describe('outbreakHistory functions', () => {
         },
       ];
 
-      const matchedHistory = getMatchedOutbreakHistoryItems(checkIns, outbreaks);
+      const matchedHistory = getMatchedOutbreakHistoryItems(checkIns, outbreaks, true);
 
       const history = expireHistoryItems(matchedHistory);
 


### PR DESCRIPTION
# Summary | Résumé

- Adds autoDeleteHistoryItemsAfterPeriod 

After adding code to remove outbreaks from storage after the 14 day cycle I found a bug where the outbreaks would be re-added after being removed because the match logic didn't account for items being past the expired date.

Adding the filter broke some existing tests given expired items would no longer be kept with the updated code.

For the purpose of this PR I added a parameter called keepExpired to help demonstrate that the updated code / filter works with the new and existing tests.

I'll create a followup PR to remove the keepExpired + remove those tests.  I think it's better to do it outside of this PR for clarity.

- Added a  `hasExpired `  utility function for re-use in multiple parts of the code

Notes: I've kept some logic for marking as expired which will act as a backup if anything goes wrong while storing the updated values i.e. expired items won't show in lists etc...

## Testing 

- Added some Jest tests
- You can also comment out the filter https://github.com/cds-snc/covid-alert-app/pull/1690/files#diff-c0e626a34422a9c5bb6f9b4736444caf9b48d36e213d003dd3173682b5a140fbR171 and see without it the "removed" item is still in the list (it's removed but gets re-added during the check for outbreaks call match logic)
