### PR TITLE
Remove legacy setHasViewed hook dependancy 

### DIFF
--- a/src/screens/qr/LearnAboutQRScreen.tsx
+++ b/src/screens/qr/LearnAboutQRScreen.tsx
@@ -3,13 +3,11 @@ import {Box, Text, Icon, Button} from 'components';
 import {BarCodeScanner} from 'expo-barcode-scanner';
 import {useI18n} from 'locale';
 import {log} from 'shared/logging/config';
-import {useCachedStorage} from 'services/StorageService';
 
 import {BaseQRCodeScreen} from './components/BaseQRCodeScreen';
 
 export const LearnAboutQRScreen = ({updatePermissions}: {updatePermissions: () => void}) => {
   const i18n = useI18n();
-  const {setHasViewedQr} = useCachedStorage();
   const requestPermissions = useCallback(async () => {
     try {
       await BarCodeScanner.requestPermissionsAsync();
@@ -17,7 +15,7 @@ export const LearnAboutQRScreen = ({updatePermissions}: {updatePermissions: () =
     } catch (err) {
       log.error({category: 'qr-code', message: err.message});
     }
-  }, [updatePermissions, setHasViewedQr]);
+  }, [updatePermissions]);
   return (
     <BaseQRCodeScreen showBackButton>
       <Box paddingHorizontal="m">


### PR DESCRIPTION
This was missed in a previous PR https://github.com/cds-snc/covid-alert-app/pull/1687