### PR TITLE
Chore/send notification test

### DIFF
--- a/src/services/OutbreakService/OutbreakService.spec.ts
+++ b/src/services/OutbreakService/OutbreakService.spec.ts
@@ -436,7 +436,7 @@ describe('OutbreakService', () => {
     expect(outbreakHistory).toHaveLength(2);
   });
 
-  it('send notification if there is an outbreak', async () => {
+  it('sends a notification if there is an outbreak', async () => {
     jest.spyOn(service, 'extractOutbreakEventsFromZipFiles').mockImplementation(async () => {
       return service.convertOutbreakEvents([
         {
@@ -460,7 +460,7 @@ describe('OutbreakService', () => {
     expect(PushNotification.presentLocalNotification).toHaveBeenCalledTimes(1);
   });
 
-  it('does not send notification is outbreak history is empty', async () => {
+  it('does not send a notification is outbreak history is empty', async () => {
     jest.spyOn(service, 'extractOutbreakEventsFromZipFiles').mockImplementation(async () => {
       return service.convertOutbreakEvents([
         {

--- a/src/services/OutbreakService/OutbreakService.spec.ts
+++ b/src/services/OutbreakService/OutbreakService.spec.ts
@@ -401,14 +401,25 @@ describe('OutbreakService', () => {
           endTime: {seconds: toSeconds(addHours(checkIns[0].timestamp, 4))},
           severity: 1,
         },
+        {
+          locationId: checkIns[1].id,
+          startTime: {seconds: toSeconds(subtractHours(checkIns[1].timestamp, 2))},
+          endTime: {seconds: toSeconds(addHours(checkIns[1].timestamp, 4))},
+          severity: 1,
+        },
       ]);
     });
 
     await service.addCheckIn(checkIns[0]);
     await service.addCheckIn(checkIns[1]);
     await service.checkForOutbreaks();
-    // console.log('Push notif', PushNotification.presentLocalNotification);
+    let outbreakHistory = service.outbreakHistory.get();
+    console.log;
 
-    expect(PushNotification.presentLocalNotification).toHaveBeenCalled();
+    expect(PushNotification.presentLocalNotification).toHaveBeenCalledTimes(1);
+
+    MockDate.set('2021-02-16T12:00Z');
+    await service.checkForOutbreaks();
+    expect(PushNotification.presentLocalNotification).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Summary | Résumé

First test is to ensure we get a notification after outbreak check has occured.

Second test is once the outbreak history items have expired, so we don't expect to see any notifications sent.