### PR TITLE
Remove redunudant graphic

### DIFF
--- a/src/screens/qr/LearnAboutQRScreen.tsx
+++ b/src/screens/qr/LearnAboutQRScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react';
-import {Box, Text, Icon, Button} from 'components';
+import {Box, Text, Button} from 'components';
 import {BarCodeScanner} from 'expo-barcode-scanner';
 import {useI18n} from 'locale';
 import {log} from 'shared/logging/config';

--- a/src/screens/qr/LearnAboutQRScreen.tsx
+++ b/src/screens/qr/LearnAboutQRScreen.tsx
@@ -19,11 +19,11 @@ export const LearnAboutQRScreen = ({updatePermissions}: {updatePermissions: () =
   return (
     <BaseQRCodeScreen showBackButton>
       <Box paddingHorizontal="m">
-        <Text variant="bodyTitle" marginTop="l" accessibilityRole="header" accessibilityAutoFocus>
+        <Text variant="bodyTitle" marginBottom="l" accessibilityRole="header" accessibilityAutoFocus>
           {i18n.translate('QRCode.LearnAboutQRScan.Title')}
         </Text>
 
-        <Text marginVertical="s">{i18n.translate('QRCode.LearnAboutQRScan.Body1')}</Text>
+        <Text marginBottom="s">{i18n.translate('QRCode.LearnAboutQRScan.Body1')}</Text>
         <Text>{i18n.translate('QRCode.LearnAboutQRScan.Body2')}</Text>
         <Box marginTop="xl" marginBottom="l">
           <Button

--- a/src/screens/qr/LearnAboutQRScreen.tsx
+++ b/src/screens/qr/LearnAboutQRScreen.tsx
@@ -19,7 +19,6 @@ export const LearnAboutQRScreen = ({updatePermissions}: {updatePermissions: () =
   return (
     <BaseQRCodeScreen showBackButton>
       <Box paddingHorizontal="m">
-        <Icon height={120} width={150} name="no-visit-icon" />
         <Text variant="bodyTitle" marginTop="l" accessibilityRole="header" accessibilityAutoFocus>
           {i18n.translate('QRCode.LearnAboutQRScan.Title')}
         </Text>


### PR DESCRIPTION
# Summary | Résumé

1. This removes this redundant illustration and symbol that have the same meaning (therefore same alt text)
2. Adjusts the spacing to match other symbol-less screens. 
![image](https://user-images.githubusercontent.com/5230720/122240599-e60a1e00-ce8f-11eb-91e1-afa582f851b4.png)


# Test instructions | Instructions pour tester la modification

1. Enable QR flag and go through QR code set up. 
