### PR TITLE
Help detect missing or empty translation strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bundle-ios": "yarn generate-translations && react-native bundle --dev false --platform ios --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",
     "codegen-protobuf": "pbjs -t static-module -o src/services/BackendService/covidshield/covidshield.js src/services/BackendService/covidshield/covidshield.proto && pbts -o src/services/BackendService/covidshield/covidshield.d.ts src/services/BackendService/covidshield/covidshield.js",
     "generate-translations": "node translations.js",
+    "detect-missing-translations": "node translation-keys.js",
     "generate-translations:regional": "node translations-regional.js",
     "generate-translations:android": "node translations-android.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/translation-keys.js
+++ b/translation-keys.js
@@ -1,0 +1,67 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const asyncForEach = async (arr, cb) => {
+  for (let index = 0; index < arr.length; index++) {
+    await cb(arr[index], index, arr);
+  }
+};
+
+const getRegionContent = async (activeLanguages, contentDirectory) => {
+  const data = {};
+
+  await asyncForEach(activeLanguages, async lang => {
+    const filePath = path.join(__dirname, contentDirectory, `${lang}.json`);
+    data[lang] = await fs.readFile(filePath, 'utf8');
+  });
+
+  return data;
+};
+
+const resolveObjectPath = (targetPath, obj) => {
+  return targetPath.split('.').reduce((prev, curr) => {
+    return prev ? prev[curr] : '';
+  }, obj);
+};
+
+/* eslint-disable */
+// original https://codegolf.stackexchange.com/questions/195476/extract-all-keys-from-an-object-json
+const parseKeys = (obj, str, cb) => {
+  !obj | ([obj] == obj) ||
+    Object.keys(obj).map(key => {
+      parseKeys(obj[key], (key = str ? str + [, key] : key), cb, cb(key));
+    });
+};
+/* eslint-enable */
+
+const parseFiles = (targetPath, languages, regionContent) => {
+  const en = JSON.parse(regionContent[languages[0]]);
+  const fr = JSON.parse(regionContent[languages[1]]);
+  let missing = '';
+
+  parseKeys(en, undefined, arr => {
+    const strPath = arr.split(',').join('.');
+    const enStr = resolveObjectPath(strPath, en);
+    const frStr = resolveObjectPath(strPath, fr);
+
+    if (typeof enStr === 'string' && enStr && !frStr) {
+      missing += ` - Missing FR string: "${strPath}" ${'\n'}`;
+    }
+  });
+
+  if (!missing) {
+    console.log(`${targetPath} ${languages}`, '✅'); // eslint-disable-line no-console
+    return;
+  }
+
+  console.log(`${targetPath} ${languages}`, '❌'); // eslint-disable-line no-console
+  console.log(missing); // eslint-disable-line no-console
+};
+
+const contentPaths = ['src/locale/translations', 'src/locale/translations/regional'];
+
+contentPaths.forEach(async targetPath => {
+  const languages = ['en', 'fr'];
+  const regionContent = await getRegionContent(languages, targetPath);
+  parseFiles(targetPath, languages, regionContent);
+});

--- a/translation-keys.js
+++ b/translation-keys.js
@@ -34,18 +34,25 @@ const parseKeys = (obj, str, cb) => {
 };
 /* eslint-enable */
 
-const parseFiles = (targetPath, languages, regionContent) => {
+const parseFiles = (targetPath, languages, regionContent, ignore) => {
   const en = JSON.parse(regionContent[languages[0]]);
   const fr = JSON.parse(regionContent[languages[1]]);
   let missing = '';
 
   parseKeys(en, undefined, arr => {
     const strPath = arr.split(',').join('.');
-    const enStr = resolveObjectPath(strPath, en);
-    const frStr = resolveObjectPath(strPath, fr);
 
-    if (typeof enStr === 'string' && enStr && !frStr) {
-      missing += ` - Missing FR string: "${strPath}" ${'\n'}`;
+    if (!ignore.includes(strPath)) {
+      const enStr = resolveObjectPath(strPath, en);
+      const frStr = resolveObjectPath(strPath, fr);
+
+      if (typeof enStr === 'string' && enStr && !frStr) {
+        missing += ` - Missing FR string: "${strPath}" ${'\n'}`;
+      }
+
+      if (typeof frStr === 'string' && frStr && !enStr) {
+        missing += ` - Missing EN string: "${strPath}" ${'\n'}`;
+      }
     }
   });
 
@@ -60,8 +67,14 @@ const parseFiles = (targetPath, languages, regionContent) => {
 
 const contentPaths = ['src/locale/translations', 'src/locale/translations/regional'];
 
+const ingoredKeys = [
+  'RegionPicker.ExposedHelpLinkNote.AB',
+  'RegionPicker.ExposedHelpLinkNote.BC',
+  'RegionPicker.ExposedHelpLinkNote.SK',
+];
+
 contentPaths.forEach(async targetPath => {
   const languages = ['en', 'fr'];
   const regionContent = await getRegionContent(languages, targetPath);
-  parseFiles(targetPath, languages, regionContent);
+  parseFiles(targetPath, languages, regionContent, ingoredKeys);
 });


### PR DESCRIPTION
Adds a new script to help detect missing or empty translation strings.

We've seen this happen a few times

Trello [#1005](https://trello.com/c/4RLx0UsI/1005-fix-missing-translation-errorsdatasharingstep2action)

Github [#1710](https://github.com/cds-snc/covid-alert-app/pull/1710#issuecomment-862547437) - the issue is in main and not the PR branch

### Testing

```
yarn detect-missing-translations
```

### Result

The resulting output will give you a list of files checked (pass / fail) and also a list of missing keys

<img width="800" alt="Screen Shot 2021-06-17 at 8 24 53 AM" src="https://user-images.githubusercontent.com/62242/122395952-81a99600-cf45-11eb-80f8-842ce5bb2ec3.png">

### Note

For empty strings that should exist in one of the translations files you can add them to 

`ingoredKeys` i.e RegionPicker.ExposedHelpLinkNote.SK exists in the FR file - 

<img width="499" alt="Screen Shot 2021-06-17 at 8 50 12 AM" src="https://user-images.githubusercontent.com/62242/122399718-0ea21e80-cf49-11eb-9c07-efb8858c7b9e.png">

Ref: String cleanup https://github.com/cds-snc/covid-alert-app/pull/1713


