### PR TITLE
added proximity and outbreak tests

### DIFF
--- a/src/services/ExposureNotificationService/tests/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/tests/ExposureNotificationService.spec.ts
@@ -1314,6 +1314,7 @@ describe('ExposureNotificationService', () => {
 
     let outbreakHistory = outbreakService.outbreakHistory.get();
     expect(outbreakHistory).toHaveLength(1);
+
     /*
           expect(service.exposureStatus.get()).toStrictEqual(
         expect.objectContaining({

--- a/src/services/ExposureNotificationService/tests/ExposureNotificationService.spec.ts
+++ b/src/services/ExposureNotificationService/tests/ExposureNotificationService.spec.ts
@@ -1312,11 +1312,19 @@ describe('ExposureNotificationService', () => {
     await outbreakService.addCheckIn(checkIns[1]);
     await outbreakService.checkForOutbreaks();
 
-    const outbreakHistory = outbreakService.outbreakHistory.get();
+    let outbreakHistory = outbreakService.outbreakHistory.get();
     expect(outbreakHistory).toHaveLength(1);
+    /*
+          expect(service.exposureStatus.get()).toStrictEqual(
+        expect.objectContaining({
+          type: ExposureStatusType.Exposed,
+          summary: nextSummary,
+        }),
+      );
+    */
 
     // combine the history as it would be for ExposureHistoryScreen
-    const mergedArray = [
+    let mergedArray = [
       ...toOutbreakExposureHistoryData({history: outbreakHistory, i18n}),
       ...toProximityExposureHistoryData({proximityExposureHistory: displayExposureHistoryItems, i18n}),
     ];
@@ -1324,6 +1332,20 @@ describe('ExposureNotificationService', () => {
     expect(mergedArray).toHaveLength(2);
     expect(mergedArray[0].exposureType).toStrictEqual('outbreak');
     expect(mergedArray[1].exposureType).toStrictEqual('proximity');
+
+    MockDate.set('2021-02-01T12:30Z');
+    outbreakService.ignoreOutbreak(outbreakHistory[0].id);
+    outbreakHistory = outbreakService.outbreakHistory.get();
+    mergedArray = [
+      ...toOutbreakExposureHistoryData({history: outbreakHistory, i18n}),
+      ...toProximityExposureHistoryData({proximityExposureHistory: displayExposureHistoryItems, i18n}),
+    ];
+
+    expect(mergedArray).toHaveLength(2);
+    expect(mergedArray[0].exposureType).toStrictEqual('outbreak');
+    expect(mergedArray[0].historyItem.isIgnored).toStrictEqual(true);
+    expect(mergedArray[1].exposureType).toStrictEqual('proximity');
+    expect(enService.exposureStatus.get()).toStrictEqual(expect.objectContaining({type: ExposureStatusType.Exposed}));
   });
 
   describe('testing metrics component', () => {


### PR DESCRIPTION
# Summary | Résumé

Tests to ensure:

- if we have both a proximity and exposure, we should be able to see both items in our history
- After receiving a negative test from an outbreak exposure (and also having an proximity exposure), your homescreen should return to "All set", the reason being the user has already seen the instruction on how to take precautions and has gotten tested.
- Last test is to check to see that both tests have expired and been removed from the history, status will stay as monitoring.