### PR TITLE
Change `failure` to `success`.

### DIFF
--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
@@ -71,7 +71,7 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
             setForeground(foregroundInfo)
         } catch (exception: Exception) {
             filteredMetricsService.addDebugMetric(107.0, exception.message ?: "Unknown")
-            return Result.failure()
+            return Result.success()
         }
 
         val enIsEnabled = exposureNotificationClient.isEnabled.await()
@@ -95,7 +95,7 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
             return Result.success()
         } catch (exception: Exception) {
             filteredMetricsService.addDebugMetric(106.0, exception.message ?: "Unknown")
-            return Result.failure()
+            return Result.success()
         }
     }
 

--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckSchedulerWorker.kt
@@ -84,17 +84,17 @@ class ExposureCheckSchedulerWorker (val context: Context, parameters: WorkerPara
                 } catch (exception: TimeoutCancellationException) {
                     filteredMetricsService.addDebugMetric(101.0, exception.message ?: "Unknown")
                     log("doWork exception", mapOf("message" to "Timeout"))
-                    return Result.failure()
+                    return Result.success()
                 } catch (exception: Exception) {
                     filteredMetricsService.addDebugMetric(102.0, exception.message ?: "Unknown")
                     log("doWork exception", mapOf("message" to (exception.message ?: "Unknown")))
-                    return Result.failure()
+                    return Result.success()
                 }
             }
         } catch (exception: Exception) {
             filteredMetricsService.addDebugMetric(103.0, exception.message ?: "Unknown")
             Log.d("exception", "exception")
-            return Result.failure()
+            return Result.success()
         }
 
         return Result.success()


### PR DESCRIPTION
# Summary | Résumé

Android only.

There is an issue affecting some users, where the notification that appears when **Checking for Notifications** does not disappear. It has been difficult to troubleshoot and debug since we have been unable to replicate it. One clue we have found is a Crash Report on the Google Play Console that happens when `Result.failure()` is called. Since we do not actively handle the `failure` case (opting to just let exposure checking happen again on the regular schedule), we believe it is safe and reasonable to replace the `failure()` call with a `success()` call.

Trello card:
https://trello.com/c/eJEE7ItN/1306-checking-for-exposures-notification-persists-on-android

# Test instructions | Instructions pour tester la modification

Normal regression testing would apply in this case.