### PR TITLE
Android: Fixing persistent notifications.

### DIFF
--- a/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
+++ b/android/app/src/main/java/app/covidshield/receiver/worker/ExposureCheckNotificationWorker.kt
@@ -16,14 +16,19 @@ import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import app.covidshield.MainActivity
 import app.covidshield.R
+import app.covidshield.extensions.log
 import app.covidshield.services.metrics.FilteredMetricsService
 import com.facebook.react.ReactApplication
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter
 import com.google.android.gms.nearby.Nearby
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationStatus
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.*
 import kotlinx.coroutines.tasks.await
 import java.lang.Exception
+
+private const val HEADLESS_JS_TASK_NAME = "EXPOSURE_NOTIFICATION_HEADLESS_TASK"
+private const val HEADLESS_JS_TASK_TIMEOUT_MS = 60000L
 
 class ExposureCheckNotificationWorker (private val context: Context, parameters: WorkerParameters) :
         CoroutineWorker(context, parameters) {
@@ -34,69 +39,78 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
         Nearby.getExposureNotificationClient(context)
     }
 
+    private val filteredMetricsService by lazy {
+        FilteredMetricsService.getInstance(context)
+    }
+
     override suspend fun doWork(): Result {
 
         Log.d("background", "ExposureCheckNotificationWorker - doWork")
 
-        val filteredMetricsService = FilteredMetricsService.getInstance(context)
-
         try {
-            val intent = Intent(context, MainActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            withTimeout(HEADLESS_JS_TASK_TIMEOUT_MS) {
+                val intent = Intent(context, MainActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+
+                val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
+                val notification = NotificationCompat.Builder(context, "1")
+                        .setSmallIcon(inputData.getInt("smallIcon", R.drawable.ic_detect_icon))
+                        .setContentTitle(inputData.getString("title"))
+                        .setContentText(inputData.getString("body"))
+                        .setContentIntent(pendingIntent)
+                        .setOngoing(true)
+
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                    notification.setPriority(inputData.getInt("priority", NotificationCompat.PRIORITY_DEFAULT))
+                }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    createNotificationChannel(CHANNEL_ID, inputData.getString("channelName")?: "COVID Alert Exposure Checks", inputData.getBoolean("disableSound", false))
+                    notification.setChannelId(CHANNEL_ID)
+                }
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    val styledText: Spanned = Html.fromHtml(inputData.getString("body"), Html.FROM_HTML_MODE_LEGACY)
+                    notification.setStyle(NotificationCompat.BigTextStyle().bigText(styledText))
+                }
+
+                val foregroundInfo = ForegroundInfo(1, notification.build())
+                setForeground(foregroundInfo)
+
+                val enIsEnabled = exposureNotificationClient.isEnabled.await()
+                val enStatus = exposureNotificationClient.status.await()
+                if (!enIsEnabled || enStatus.contains(ExposureNotificationStatus.INACTIVATED)) {
+                    filteredMetricsService.addDebugMetric(200.2, oncePerUTCDay = true)
+                    Log.d("background", "ExposureCheckNotificationWorker - ExposureNotification: Not enabled or not activated")
+                    filteredMetricsService.addDebugMetric(7.1, "ExposureNotification: enIsEnabled = $enIsEnabled AND enStatus = ${enStatus.map { it.ordinal }}.")
+                }
+
+                val currentReactContext = getCurrentReactContext(context)
+                if (currentReactContext != null) {
+                    currentReactContext.getJSModule(RCTNativeAppEventEmitter::class.java)?.emit("executeExposureCheckEvent", "data")
+                } else {
+                    withContext(Dispatchers.Main) {
+                        filteredMetricsService.addDebugMetric(3.3)
+                        val completer = CompletableDeferred<Unit>()
+                        CustomHeadlessTask(applicationContext, HEADLESS_JS_TASK_NAME) { completer.complete(Unit) }
+                        completer.await()
+                    }
+                }
             }
-
-            val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
-            val notification = NotificationCompat.Builder(context, "1")
-                    .setSmallIcon(inputData.getInt("smallIcon", R.drawable.ic_detect_icon))
-                    .setContentTitle(inputData.getString("title"))
-                    .setContentText(inputData.getString("body"))
-                    .setContentIntent(pendingIntent)
-                    .setOngoing(true)
-
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                notification.setPriority(inputData.getInt("priority", NotificationCompat.PRIORITY_DEFAULT))
-            }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                createNotificationChannel(CHANNEL_ID, inputData.getString("channelName")?: "COVID Alert Exposure Checks", inputData.getBoolean("disableSound", false))
-                notification.setChannelId(CHANNEL_ID)
-            }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                val styledText: Spanned = Html.fromHtml(inputData.getString("body"), Html.FROM_HTML_MODE_LEGACY)
-                notification.setStyle(NotificationCompat.BigTextStyle().bigText(styledText))
-            }
-
-            val foregroundInfo = ForegroundInfo(1, notification.build())
-            setForeground(foregroundInfo)
+        } catch (exception: TimeoutCancellationException) {
+            filteredMetricsService.addDebugMetric(111.0, exception.message ?: "Unknown")
+            log("doWork exception", mapOf("message" to "Timeout"))
+            return Result.success()
         } catch (exception: Exception) {
-            filteredMetricsService.addDebugMetric(107.0, exception.message ?: "Unknown")
+            filteredMetricsService.addDebugMetric(112.0, exception.message ?: "Unknown")
+            log("doWork exception", mapOf("message" to (exception.message ?: "Unknown")))
             return Result.success()
         }
 
-        val enIsEnabled = exposureNotificationClient.isEnabled.await()
-        val enStatus = exposureNotificationClient.status.await()
-        if (!enIsEnabled || enStatus.contains(ExposureNotificationStatus.INACTIVATED)) {
-            filteredMetricsService.addDebugMetric(200.2, oncePerUTCDay = true)
-            Log.d("background", "ExposureCheckNotificationWorker - ExposureNotification: Not enabled or not activated")
-            filteredMetricsService.addDebugMetric(7.1, "ExposureNotification: enIsEnabled = $enIsEnabled AND enStatus = ${enStatus.map { it.ordinal }}.")
-            return Result.success()
-        }
-
-        try {
-            val reactApplication = applicationContext as? ReactApplication ?: return Result.success()
-            filteredMetricsService.addDebugMetric(7.2)
-            val reactInstanceManager = reactApplication.reactNativeHost.reactInstanceManager
-            Log.d("background", "React-native emit")
-            reactInstanceManager.currentReactContext?.getJSModule(RCTNativeAppEventEmitter::class.java)?.emit("executeExposureCheckEvent", "data")
-
-            // Without this delay, the notification will not appear
-            delay(5000)
-            return Result.success()
-        } catch (exception: Exception) {
-            filteredMetricsService.addDebugMetric(106.0, exception.message ?: "Unknown")
-            return Result.success()
-        }
+        // Without this delay, the notification will not appear
+        delay(5000)
+        return Result.success()
     }
 
     /**
@@ -118,11 +132,45 @@ class ExposureCheckNotificationWorker (private val context: Context, parameters:
         }
     }
 
+    private class CustomHeadlessTask(
+            context: Context,
+            taskId: String,
+            private val onComplete: () -> Unit
+    ) : ExposureCheckHeadlessTask(context, taskId) {
+
+        override fun onHeadlessJsTaskStart(taskId: Int) {
+            super.onHeadlessJsTaskStart(taskId)
+            log("onExposureCheckHeadlessJsTaskStart")
+        }
+
+        override fun onHeadlessJsTaskFinish(taskId: Int) {
+            super.onHeadlessJsTaskFinish(taskId)
+            log("onExposureCheckHeadlessJsTaskFinish")
+            onComplete()
+        }
+    }
+
     companion object {
         // A randomly generated constant.
         // If either the channel importance / priority or the sound are changed,
         // then CHANNEL_ID also needs to be changed.
         private const val CHANNEL_ID = "NVYJYRQYOM"
+
+        fun getCurrentReactContext(context: Context): ReactContext? {
+            return try {
+                val reactApplication = context.applicationContext as ReactApplication
+                Log.d("background", "reactApplication - $reactApplication")
+                val reactNativeHost = reactApplication.reactNativeHost
+                Log.d("background", "reactNativeHost - $reactNativeHost")
+                val reactInstanceManager = reactNativeHost.reactInstanceManager
+                Log.d("background", "reactInstanceManager - $reactInstanceManager")
+                val currentReactContext = reactInstanceManager.currentReactContext
+                Log.d("background", "currentReactContext - $currentReactContext")
+                currentReactContext
+            } catch (_: Exception) {
+                null
+            }
+        }
     }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,26 @@ if (Platform.OS === 'android') {
 
     await exposureNotificationService.initiateExposureCheckHeadless();
   });
+
+  BackgroundScheduler.registerAndroidHeadlessExposureNotificationPeriodicTask(async () => {
+    publishDebugMetric(4.7);
+    const backendService = new BackendService(
+      RETRIEVE_URL,
+      SUBMIT_URL,
+      HMAC_KEY,
+      DefaultStorageService.sharedInstance(),
+    );
+    const i18n = await createBackgroundI18n();
+    const exposureNotificationService = new ExposureNotificationService(
+      backendService,
+      i18n,
+      DefaultStorageService.sharedInstance(),
+      ExposureNotification,
+      FilteredMetricsService.sharedInstance(),
+    );
+
+    await exposureNotificationService.executeExposureCheckHeadless();
+  });
 }
 
 if (__DEV__) {

--- a/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
+++ b/src/services/BackgroundSchedulerService/BackgroundSchedulerService.ts
@@ -180,8 +180,35 @@ const registerAndroidHeadlessExposureCheckPeriodicTask = (task: PeriodicTask) =>
   });
 };
 
+const registerAndroidHeadlessExposureNotificationPeriodicTask = (task: PeriodicTask) => {
+  publishDebugMetric(4.5);
+  if (Platform.OS !== 'android') return;
+  AppRegistry.registerHeadlessTask('EXPOSURE_NOTIFICATION_HEADLESS_TASK', () => async () => {
+    log.debug({
+      category: 'background',
+      message: 'EXPOSURE_NOTIFICATION_HEADLESS_TASK',
+    });
+    try {
+      await task();
+    } catch (error) {
+      log.error({
+        category: 'background',
+        message: 'runAndroidHeadlessExposureNotificationPeriodicTask',
+        error,
+      });
+    } finally {
+      BackgroundFetch.finish('EXPOSURE_NOTIFICATION_HEADLESS_TASK');
+    }
+  });
+  log.debug({
+    category: 'background',
+    message: 'registerAndroidHeadlessExposureNotificationPeriodicTask',
+  });
+};
+
 export const BackgroundScheduler = {
   registerPeriodicTask,
   registerAndroidHeadlessPeriodicTask,
   registerAndroidHeadlessExposureCheckPeriodicTask,
+  registerAndroidHeadlessExposureNotificationPeriodicTask,
 };

--- a/src/services/ExposureNotificationService/ExposureNotificationService.ts
+++ b/src/services/ExposureNotificationService/ExposureNotificationService.ts
@@ -173,6 +173,13 @@ export class ExposureNotificationService {
     await this.initiateExposureCheck();
   };
 
+  executeExposureCheckHeadless = async () => {
+    if (Platform.OS !== 'android') return;
+    publishDebugMetric(4.6);
+    log.debug({category: 'background', message: 'executeExposureCheckHeadless'});
+    await this.executeExposureCheck();
+  };
+
   initiateExposureCheck = async () => {
     if (Platform.OS !== 'android') return;
     const payload: NotificationPayload = {

--- a/src/services/OutbreakService/OutbreakService.ts
+++ b/src/services/OutbreakService/OutbreakService.ts
@@ -224,9 +224,13 @@ export class OutbreakService {
 
     const _outbreakHistory = expireHistoryItems(outbreakHistory);
 
-    _outbreakHistory.forEach((historyItem: OutbreakHistoryItem) => {
-      this.expireOutbreak(historyItem.id);
-    });
+    _outbreakHistory
+      .filter(item => {
+        return item.isExpired;
+      })
+      .forEach((historyItem: OutbreakHistoryItem) => {
+        this.expireOutbreak(historyItem.id);
+      });
 
     const updatedHistory = this.outbreakHistory.get();
 


### PR DESCRIPTION
# Summary | Résumé

An attempt to fix the "persistent notification" bug in Android. Adding a `withTimeout` block as suggested by Marcel from Google. Documentation here: https://developers.google.com/android/exposure-notifications/implementation-guide#doWork

Also double checking for the existence of the react-native context, and firing a headless event even though the code returned if it didn't exist. This is more in line with the previous way this was handled in the code.

Trello card: https://trello.com/c/eJEE7ItN/1306-checking-for-exposures-notification-persists-on-android

# Test instructions | Instructions pour tester la modification

Normal regression testing to ensure exposure checks are still happening, and that the visual notification is still appearing as usual. Since we have been unable to replicate this issue, it will be difficult to know if this fixes the issue, but we should be testing to ensure that nothing new is broken.