### PR TITLE
Update CI to point to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,9 +6,9 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Renamed the `master` ❌  branch to `main` ✅ 


<img width="400" alt="Screen Shot 2021-06-25 at 8 08 43 AM" src="https://user-images.githubusercontent.com/62242/123423550-ad53fe00-d58d-11eb-95cf-b7e9fb235b09.png">


This PR updates CI to use the main branch 

**Note:**

Use the following to update your local machine:

```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

<img width="600" alt="Screen Shot 2021-06-25 at 8 09 54 AM" src="https://user-images.githubusercontent.com/62242/123423599-c0ff6480-d58d-11eb-9a0d-e814e059ef04.png">



Closes https://github.com/cds-snc/covid-alert-app/issues/1573