### PR TITLE
Adjust spacing for dismiss text

### DIFF
--- a/src/screens/home/views/ClearExposureView.tsx
+++ b/src/screens/home/views/ClearExposureView.tsx
@@ -51,7 +51,7 @@ export const DismissAlertScreen = () => {
               </Text>
 
               <Text marginBottom="l">
-                {i18n.translate('Home.ExposureDetected.Dismiss.Body')}
+                {i18n.translate('Home.ExposureDetected.Dismiss.Body')}{' '}
                 {qrEnabled && i18n.translate('Home.ExposureDetected.Dismiss.Body1')}
               </Text>
 

--- a/src/screens/home/views/ClearExposureView.tsx
+++ b/src/screens/home/views/ClearExposureView.tsx
@@ -50,10 +50,9 @@ export const DismissAlertScreen = () => {
                 {i18n.translate('Home.ExposureDetected.Dismiss.Title')}
               </Text>
 
-              <Text marginBottom="l">
-                {i18n.translate('Home.ExposureDetected.Dismiss.Body')}{' '}
-                {qrEnabled && i18n.translate('Home.ExposureDetected.Dismiss.Body1')}
-              </Text>
+              <Text marginBottom={qrEnabled ? 'm' : 'l'}>{i18n.translate('Home.ExposureDetected.Dismiss.Body')}</Text>
+
+              {qrEnabled && <Text marginBottom="l">{i18n.translate('Home.ExposureDetected.Dismiss.Body1')}</Text>}
 
               <Button
                 text={i18n.translate('Home.ExposureDetected.Dismiss.CTA')}


### PR DESCRIPTION
[Trello](https://trello.com/c/FadKMmlA/1325-dismiss-alert-box-tells-people-to-continue-following-public-health-guidelines) 

[Slack](https://gcdigital.slack.com/archives/C018MAP09V5/p1624995593173400?thread_ts=1624992905.171500&cid=C018MAP09V5) 

Noting the text / spacing (margin) is different depending on if QR Codes is turned on or off.
