### PR TITLE
Specify Android core

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 29
         targetSdkVersion = 29
-        androidXCore = "1.5.0"
+        androidXCore = "1.6.0"
         androidXCoreKtxVersion = "1.3.0"
         androidXSwipeRefreshLayoutVersion = "1.0.0"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 29
         targetSdkVersion = 29
-
+        androidXCore = "1.5.0"
         androidXCoreKtxVersion = "1.3.0"
         androidXSwipeRefreshLayoutVersion = "1.0.0"
 


### PR DESCRIPTION
Android builds are throwing the following error

## error

```
The minCompileSdk (30) specified in a
dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
is greater than this module's compileSdkVersion (android-29).
Dependency: androidx.core:core:1.7.0-alpha01.
```

> As some has mentioned, the problem is that the RN build automatically "upgraded" to androidx.core:core:1.7.0-alpha01, which depends on SDK version 30.

https://stackoverflow.com/questions/68207334/getting-error-while-running-react-native-run-android

## androidx

1.6.0 is the latest stable version
https://developer.android.com/jetpack/androidx/releases/core