### PR TITLE
feat: s3-backup remediation

### DIFF
--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -1,0 +1,30 @@
+name: S3 backup
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+env:
+  BACKUP_BRANCH: main
+
+jobs:
+  s3-backup:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_S3_BACKUP_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_S3_BACKUP_SECRET_ACCESS_KEY }}
+        aws-region: ca-central-1
+
+    - name: Get ZIP bundle
+      run: |
+        mkdir -p ${{ github.repository }}
+        curl -Lo ${{ github.repository }}/`basename ${{ github.repository }}`-`date '+%Y-%m-%d'`.zip \
+          https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}/archive/${{ env.BACKUP_BRANCH }}.zip
+
+    - name: Upload to S3 bucket
+      run: |
+        aws s3 sync . s3://${{ secrets.AWS_S3_BACKUP_BUCKET }} --exclude='*' --include='${{ github.repository }}/*'


### PR DESCRIPTION
# Description

Adding the workflow that will back up this repo to a centralized s3 bucket. 

As part of our disaster recovery work we backup all of our github repos to an s3 bucket in the SRE Tools repo.

This workflows uses organizational centralized credentials to authenticate so there is no need for secret management on your side.

## Important information

This workflow is not mandatory, however if does make it easy to backup your project, and helps us improve our disaster recovery posture. If you do not want to use it will be expected that you achieve this goal another way.

This PR is not-critical and so it can wait.

This PR was generated by an automated tool. 

If you have a question about this PR you can use the PR review process or send a message to the Internal SRE Team.